### PR TITLE
String refactor for enabling better support for IDEs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = { version = "1.0", optional = true, default-features = false }
 serde_cbor = { version = "0.10", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 half = "1.3"
-lexical-core = "^0.4"
+lexical = "^4.0"
 clap = "2.33"
 base16 = "0.2"
 base64 = "0.10"
@@ -35,7 +35,7 @@ wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 console_error_panic_hook = { version = "0.1", optional = true }
 wee_alloc = { version = "0.4", optional = true }
 
-[target.'cfg(target_arch = "wasm32"'.dev-dependencies]
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.2"
 
 [features]

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -170,10 +170,13 @@ pub trait Validator<T> {
   /// Validate data against a given group
   fn validate_group(&self, g: &Group, occur: Option<&Occur>, value: &T) -> Result;
 
+  /// Validate data against a given group-to-choice enumeration
   fn validate_group_to_choice_enum(&self, g: &Group, occur: Option<&Occur>, value: &T) -> Result;
 
+  /// Validate data against a given group choice
   fn validate_group_choice(&self, gc: &GroupChoice, occur: Option<&Occur>, value: &T) -> Result;
 
+  /// Validate data against a given group entry
   fn validate_group_entry(
     &self,
     ge: &GroupEntry,
@@ -183,10 +186,13 @@ pub trait Validator<T> {
     value: &T,
   ) -> Result;
 
+  /// Validate data against a given array and occurrence indicator
   fn validate_array_occurrence(&self, occur: &Occur, group: &str, values: &[T]) -> Result;
 
+  /// Expect data to be a boolean
   fn expect_bool(&self, ident: &str, value: &T) -> Result;
 
+  /// Validate data against a given numeric data type
   fn validate_numeric_data_type(
     &self,
     expected_memberkey: Option<String>,
@@ -196,7 +202,7 @@ pub trait Validator<T> {
   ) -> Result;
 }
 
-impl<'a> CDDL<'a> {
+impl CDDL {
   fn numerical_value_type_from_ident(&self, ident: &Identifier) -> Option<Vec<&Type2>> {
     let mut type_choices = Vec::new();
 
@@ -257,9 +263,9 @@ impl<'a> CDDL<'a> {
   }
 
   // Returns the text value(s) from a given type
-  fn text_values_from_type(&'a self, ident: &'a Type2) -> result::Result<Vec<&'a str>, Error> {
+  fn text_values_from_type(&self, ident: &Type2) -> result::Result<Vec<String>, Error> {
     match ident {
-      Type2::TextValue(t) => Ok(vec![t]),
+      Type2::TextValue(t) => Ok(vec![t.into()]),
       Type2::Typename((ident, _)) => {
         let mut text_values = Vec::new();
 
@@ -307,7 +313,7 @@ impl<'a> CDDL<'a> {
         Err(Error::Syntax("Target data type must be a 'uint' or 'number' in order to validate against an unsigned integer value".into()))
       }
       Type2::FloatValue(f) => {
-        if target_idents.into_iter().any(|ti| match ti {
+        if target_idents.into_iter().any(|ti| match ti.as_ref() {
           "float" | "float16" | "float32" | "float64" | "float16-32" | "float32-64" | "number" => true,
           _ => false,
         }) {
@@ -338,12 +344,12 @@ impl<'a> CDDL<'a> {
     }
   }
 
-  fn numerical_ident_from_type(&'a self, t2: &'a Type2) -> result::Result<Vec<&'a str>, Error> {
+  fn numerical_ident_from_type(&self, t2: &Type2) -> result::Result<Vec<String>, Error> {
     let mut numeric_type_idents = Vec::new();
 
     match t2 {
       Type2::Typename((Identifier((ident, _)), _)) if is_numeric_data_type(ident) => {
-        numeric_type_idents.push(*ident);
+        numeric_type_idents.push(ident.clone());
         Ok(numeric_type_idents)
       }
       Type2::Typename((ident, _)) => {


### PR DESCRIPTION
Removes `&str`'s in favor of `String`'s for enabling better support for IDEs.