### PR TITLE
CBOR validation fixes

### DIFF
--- a/src/validation/cbor.rs
+++ b/src/validation/cbor.rs
@@ -433,7 +433,7 @@ impl Validator<Value> for CDDL {
   ) -> Result {
     let mut errors: Vec<Error> = Vec::new();
 
-    for ge in gc.group_entries.iter() {
+    for (ge_index, ge) in gc.group_entries.iter().enumerate() {
       match value {
         Value::Array(values) => {
           if let GroupEntry::TypeGroupname { ge: tge, .. } = &ge.0 {
@@ -473,24 +473,9 @@ impl Validator<Value> for CDDL {
             }
           }
 
-          // If an array element is not validated by any of the group entries,
-          // return scoped errors
-          let mut errors: Vec<Error> = Vec::new();
-
-          if values.iter().any(
-            |v| match self.validate_group_entry(&ge.0, false, None, occur, v) {
-              Ok(()) => true,
-              Err(e) => {
-                errors.push(e);
-
-                false
-              }
-            },
-          ) {
-            continue;
-          }
-
-          if !errors.is_empty() {
+          // Match array element 1-on-1
+          // first verify that the array lengths match.
+          if values.len() != gc.group_entries.len() {
             return Err(
               CBORError {
                 expected_memberkey: None,
@@ -501,6 +486,8 @@ impl Validator<Value> for CDDL {
               .into(),
             );
           }
+          let value_at_index = values.get(ge_index).unwrap();
+          self.validate_group_entry(&ge.0, false, None, occur, value_at_index)?;
         }
         Value::Map(_) => {
           // Validate the object key/value pairs against each group entry,

--- a/src/validation/cbor.rs
+++ b/src/validation/cbor.rs
@@ -744,7 +744,17 @@ impl Validator<Value> for CDDL {
 
   fn validate_array_occurrence(&self, occur: &Occur, group: &str, values: &[Value]) -> Result {
     match occur {
-      Occur::ZeroOrMore(_) | Occur::Optional(_) => Ok(()),
+      Occur::ZeroOrMore(_) => Ok(()),
+      Occur::Optional(_) => {
+        if values.len() > 1 {
+          Err(Error::Occurrence(format!(
+            "Expecting zero or one values of group {}",
+            group
+          )))
+        } else {
+          Ok(())
+        }
+      }
       Occur::OneOrMore(_) => {
         if values.is_empty() {
           Err(Error::Occurrence(format!(

--- a/src/validation/cbor.rs
+++ b/src/validation/cbor.rs
@@ -862,7 +862,7 @@ impl Validator<Value> for CDDL {
         ),
       },
       Value::Float(_n) => match ident {
-        "number" | "float16" | "float32" => Ok(()),
+        "number" | "float" | "float16" | "float32" | "float64" => Ok(()),
         // TODO: Finish rest of numerical data types
         _ => Err(
           CBORError {

--- a/tests/cbor_tests.rs
+++ b/tests/cbor_tests.rs
@@ -158,9 +158,15 @@ fn validate_cbor_group() {
 }
 
 #[test]
-#[ignore] // FIXME: broken
 fn validate_cbor_homogenous_array() {
   let cddl_input = r#"thing = [* int]"#;
+  validate_cbor_from_slice(cddl_input, cbor::ARRAY_EMPTY).unwrap();
+  validate_cbor_from_slice(cddl_input, cbor::ARRAY_123).unwrap();
+  let cddl_input = r#"thing = [* tstr]"#;
+  validate_cbor_from_slice(cddl_input, cbor::ARRAY_123).unwrap_err();
+
+  // Alias type.  Note the rule we want to validate must come first.
+  let cddl_input = r#"thing = [* zipcode]  zipcode = int"#;
   validate_cbor_from_slice(cddl_input, cbor::ARRAY_EMPTY).unwrap();
   validate_cbor_from_slice(cddl_input, cbor::ARRAY_123).unwrap();
 }

--- a/tests/cbor_tests.rs
+++ b/tests/cbor_tests.rs
@@ -172,7 +172,6 @@ fn validate_cbor_array_groups() {
 }
 
 #[test]
-#[ignore] // FIXME: https://github.com/anweiss/cddl/issues/25
 fn validate_cbor_array_record() {
   let cddl_input = r#"thing = [a: int, b: int, c: int]"#;
   validate_cbor_from_slice(cddl_input, cbor::ARRAY_123).unwrap();

--- a/tests/cbor_tests.rs
+++ b/tests/cbor_tests.rs
@@ -159,9 +159,18 @@ fn validate_cbor_group() {
 
 #[test]
 fn validate_cbor_homogenous_array() {
-  let cddl_input = r#"thing = [* int]"#;
+  let cddl_input = r#"thing = [* int]"#; // zero or more
   validate_cbor_from_slice(cddl_input, cbor::ARRAY_EMPTY).unwrap();
   validate_cbor_from_slice(cddl_input, cbor::ARRAY_123).unwrap();
+  let cddl_input = r#"thing = [+ int]"#; // one or more
+  validate_cbor_from_slice(cddl_input, cbor::ARRAY_123).unwrap();
+  validate_cbor_from_slice(cddl_input, cbor::ARRAY_EMPTY).unwrap_err();
+  let cddl_input = r#"thing = [? int]"#; // zero or one
+  validate_cbor_from_slice(cddl_input, cbor::ARRAY_EMPTY).unwrap();
+  let cbor_bytes = serde_cbor::to_vec(&[42]).unwrap();
+  validate_cbor_from_slice(cddl_input, &cbor_bytes).unwrap();
+  validate_cbor_from_slice(cddl_input, cbor::ARRAY_123).unwrap_err();
+
   let cddl_input = r#"thing = [* tstr]"#;
   validate_cbor_from_slice(cddl_input, cbor::ARRAY_123).unwrap_err();
 

--- a/tests/cbor_tests.rs
+++ b/tests/cbor_tests.rs
@@ -49,13 +49,10 @@ fn validate_cbor_float() {
   validate_cbor_from_slice(cddl_input, cbor::FLOAT_0_0).unwrap();
   validate_cbor_from_slice(cddl_input, cbor::FLOAT_1_0).unwrap_err();
 
-  // FIXME: broken, "float" is not handled correctly.
-  if false {
-    let cddl_input = r#"thing = float"#;
-    validate_cbor_from_slice(cddl_input, cbor::FLOAT_1_0).unwrap();
-    validate_cbor_from_slice(cddl_input, cbor::FLOAT_1E5).unwrap();
-    validate_cbor_from_slice(cddl_input, cbor::FLOAT_1E300).unwrap();
-  }
+  let cddl_input = r#"thing = float"#;
+  validate_cbor_from_slice(cddl_input, cbor::FLOAT_1_0).unwrap();
+  validate_cbor_from_slice(cddl_input, cbor::FLOAT_1E5).unwrap();
+  validate_cbor_from_slice(cddl_input, cbor::FLOAT_1E300).unwrap();
 
   let cddl_input = r#"thing = float16"#;
   validate_cbor_from_slice(cddl_input, cbor::FLOAT_1_0).unwrap();
@@ -68,12 +65,9 @@ fn validate_cbor_float() {
   validate_cbor_from_slice(cddl_input, cbor::FLOAT_1_0).unwrap();
   validate_cbor_from_slice(cddl_input, cbor::FLOAT_1E5).unwrap();
 
-  // FIXME: broken, "float64" is not handled correctly.
-  if false {
-    let cddl_input = r#"thing = float64"#;
-    validate_cbor_from_slice(cddl_input, cbor::FLOAT_1_0).unwrap();
-    validate_cbor_from_slice(cddl_input, cbor::FLOAT_1E300).unwrap();
-  }
+  let cddl_input = r#"thing = float64"#;
+  validate_cbor_from_slice(cddl_input, cbor::FLOAT_1_0).unwrap();
+  validate_cbor_from_slice(cddl_input, cbor::FLOAT_1E300).unwrap();
 
   // TODO: check that large floats don't validate against a smaller size.
   // E.g. CBOR #7.27 (64-bit) shouldn't validate against "float16" or "float32".

--- a/tests/cbor_tests.rs
+++ b/tests/cbor_tests.rs
@@ -116,11 +116,16 @@ fn validate_cbor_array() {
   let cddl_input = r#"thing = []"#;
   validate_cbor_from_slice(cddl_input, cbor::ARRAY_EMPTY).unwrap();
   validate_cbor_from_slice(cddl_input, cbor::NULL).unwrap_err();
-  //validate_cbor_from_slice(cddl_input, cbor::ARRAY_123).unwrap_err(); // FIXME: broken
+  // FIXME: broken
+  if false {
+    validate_cbor_from_slice(cddl_input, cbor::ARRAY_123).unwrap_err();
+  }
 
   // FIXME: unimplemented!() in validation
-  //let cddl_input = r#"thing = [1, 2, 3]"#;
-  //validate_cbor_from_slice(cddl_input, cbor::ARRAY_123).unwrap();
+  if false {
+    let cddl_input = r#"thing = [1, 2, 3]"#;
+    validate_cbor_from_slice(cddl_input, cbor::ARRAY_123).unwrap();
+  }
 }
 
 // These data structures exist so that we can serialize some more complex

--- a/tests/cbor_tests.rs
+++ b/tests/cbor_tests.rs
@@ -222,12 +222,14 @@ fn validate_cbor_map() {
   let cddl_input = r#"thing = {name: tstr, ? age: int}"#;
   validate_cbor_from_slice(cddl_input, &cbor_bytes).unwrap();
 
-  // FIXME: broken
-  if false {
-    // TODO: try * and + as well (should be functionally equivalent)
-    let cddl_input = r#"thing = {name: tstr, age: int, ? minor: bool}"#;
-    validate_cbor_from_slice(cddl_input, &cbor_bytes).unwrap();
-  }
+  // Ensure that keys are optional if the occurrence is "?" or "*"
+  // and required if the occurrence is "+"
+  let cddl_input = r#"thing = {name: tstr, age: int, ? minor: bool}"#;
+  validate_cbor_from_slice(cddl_input, &cbor_bytes).unwrap();
+  let cddl_input = r#"thing = {name: tstr, age: int, * minor: bool}"#;
+  validate_cbor_from_slice(cddl_input, &cbor_bytes).unwrap();
+  let cddl_input = r#"thing = {name: tstr, age: int, + minor: bool}"#;
+  validate_cbor_from_slice(cddl_input, &cbor_bytes).unwrap_err();
 
   let cddl_input = r#"thing = {name: tstr, age: tstr}"#;
   validate_cbor_from_slice(cddl_input, &cbor_bytes).unwrap_err();


### PR DESCRIPTION
A collection of CBOR validation fixes.

The map fix has an open question (see the comment with "REVIEW NEEDED"); I don't really understand the control flow so I'm not sure whether the fix needs to be implemented in more than one place.

Homogeneous arrays (e.g. `[ * int]`) still don't validate (though they didn't before my record-array change, so I don't think I made anything worse than it was before).  I'll keep looking at it.