### PR TITLE
Fix type1 member key parsing issues

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -783,6 +783,8 @@ pub enum MemberKey {
     t1: Box<Type1>,
     is_cut: bool,
     span: Span,
+    /// Set to false if no trailing "=>"
+    is_mk: bool,
   },
   /// Bareword string type
   Bareword { ident: Identifier, span: Span },

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,7 +1,6 @@
 use super::token::{self, ByteValue, RangeValue, Token, Value};
 use annotate_snippets::{
-  display_list::DisplayList,
-  formatter::DisplayListFormatter,
+  display_list::{DisplayList, FormatOptions},
   snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
 };
 use std::{
@@ -88,13 +87,16 @@ impl Error for LexerError {
 
 impl fmt::Display for LexerError {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    let dlf = DisplayListFormatter::new(false, false);
+    let opt = FormatOptions {
+      color: true,
+      ..Default::default()
+    };
 
     match &self.error_type {
       LexerErrorType::LEXER(le) => write!(
         f,
         "{}",
-        dlf.format(&DisplayList::from(Snippet {
+        DisplayList::from(Snippet {
           title: Some(Annotation {
             label: Some((*le).to_string()),
             id: None,
@@ -114,12 +116,13 @@ impl fmt::Display for LexerError {
               annotation_type: AnnotationType::Error,
             }],
           }],
-        }))
+          opt,
+        })
       ),
       LexerErrorType::UTF8(utf8e) => write!(
         f,
         "{}",
-        dlf.format(&DisplayList::from(Snippet {
+        DisplayList::from(Snippet {
           title: Some(Annotation {
             label: Some(utf8e.to_string()),
             id: None,
@@ -139,12 +142,13 @@ impl fmt::Display for LexerError {
               annotation_type: AnnotationType::Error,
             }],
           }],
-        }))
+          opt,
+        })
       ),
       LexerErrorType::BASE16(b16e) => write!(
         f,
         "{}",
-        dlf.format(&DisplayList::from(Snippet {
+        DisplayList::from(Snippet {
           title: Some(Annotation {
             label: Some(b16e.to_string()),
             id: None,
@@ -164,12 +168,13 @@ impl fmt::Display for LexerError {
               annotation_type: AnnotationType::Error,
             }],
           }],
-        }))
+          opt,
+        })
       ),
       LexerErrorType::BASE64(b64e) => write!(
         f,
         "{}",
-        dlf.format(&DisplayList::from(Snippet {
+        DisplayList::from(Snippet {
           title: Some(Annotation {
             label: Some(b64e.to_string()),
             id: None,
@@ -189,12 +194,13 @@ impl fmt::Display for LexerError {
               annotation_type: AnnotationType::Error,
             }],
           }],
-        }))
+          opt,
+        })
       ),
       LexerErrorType::PARSEINT(pie) => write!(
         f,
         "{}",
-        dlf.format(&DisplayList::from(Snippet {
+        DisplayList::from(Snippet {
           title: Some(Annotation {
             label: Some(pie.to_string()),
             id: None,
@@ -214,12 +220,13 @@ impl fmt::Display for LexerError {
               annotation_type: AnnotationType::Error,
             }],
           }],
-        }))
+          opt,
+        })
       ),
       LexerErrorType::PARSEFLOAT(pfe) => write!(
         f,
         "{}",
-        dlf.format(&DisplayList::from(Snippet {
+        DisplayList::from(Snippet {
           title: Some(Annotation {
             label: Some(format!("Error code: {:?}", pfe.code)),
             id: None,
@@ -239,7 +246,8 @@ impl fmt::Display for LexerError {
               annotation_type: AnnotationType::Error,
             }],
           }],
-        }))
+          opt,
+        })
       ),
     }
   }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -76,14 +76,6 @@ impl std::error::Error for Error {
   }
 }
 
-// Unix-style newlines are counted as two chars (see
-// https://github.com/rust-lang/annotate-snippets-rs/issues/24).
-fn unix_newline_fix(input: &str, idx: usize) -> usize {
-  let nbr_newlines = input[..idx].chars().filter(|c| *c == '\n').count();
-  let nbr_carriage_returns = input[..idx].chars().filter(|c| *c == '\r').count();
-  idx + nbr_newlines - nbr_carriage_returns
-}
-
 impl<'a> Parser<'a> {
   /// Create a new `Parser` from a given `Lexer`
   pub fn new(l: Lexer<'a>) -> Result<Parser> {
@@ -130,10 +122,7 @@ impl<'a> Parser<'a> {
               origin: Some("input".to_string()),
               fold: false,
               annotations: vec![SourceAnnotation {
-                range: (
-                  unix_newline_fix(&input.clone(), error.position.range.0),
-                  unix_newline_fix(&input.clone(), error.position.range.1),
-                ),
+                range: (error.position.range.0, error.position.range.1,),
                 label: error.message.to_string(),
                 annotation_type: AnnotationType::Error,
               }],

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,8 +4,7 @@ use super::{
   token::{self, ByteValue, Token, Value},
 };
 use annotate_snippets::{
-  display_list::DisplayList,
-  formatter::DisplayListFormatter,
+  display_list::{DisplayList, FormatOptions},
   snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
 };
 use std::{fmt, mem, result};
@@ -110,17 +109,15 @@ impl<'a> Parser<'a> {
       return None;
     }
 
-    let dlf = DisplayListFormatter::new(false, false);
-
     let input = String::from_utf8(self.l.str_input.clone()).ok()?;
 
     let mut errors = String::new();
 
     for error in self.errors.iter() {
-      errors.push_str(&format!(
-        "{}\n\n",
-        dlf
-          .format(&DisplayList::from(Snippet {
+      errors.push_str(
+        &format!(
+          "{}\n\n",
+          DisplayList::from(Snippet {
             title: Some(Annotation {
               label: Some("Parser error".into()),
               id: None,
@@ -141,9 +138,14 @@ impl<'a> Parser<'a> {
                 annotation_type: AnnotationType::Error,
               }],
             }],
-          }))
-          .to_string()
-      ));
+            opt: FormatOptions {
+              color: true,
+              ..Default::default()
+            }
+          })
+        )
+        .to_string(),
+      );
     }
 
     Some(errors)

--- a/src/validation/cbor.rs
+++ b/src/validation/cbor.rs
@@ -704,7 +704,7 @@ impl Validator<Value> for CDDL {
             &Type2::Typename {
               ident: tge.name.clone(),
               generic_arg: tge.generic_arg.clone(),
-              span: span.clone(),
+              span: *span,
             },
             None,
             None,


### PR DESCRIPTION
Group entries whose member keys are of table tables (`Type1` from ABNF grammar) were not being properly parsed. This addresses #37.