### PR TITLE
Better support for nested inline groups and group entries

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -783,13 +783,26 @@ pub enum MemberKey {
     t1: Box<Type1>,
     is_cut: bool,
     span: Span,
-    /// Set to false if no trailing "=>"
-    is_mk: bool,
   },
   /// Bareword string type
-  Bareword { ident: Identifier, span: Span },
+  Bareword {
+    ident: Identifier,
+    span: Span,
+  },
   /// Value type
-  Value { value: Value, span: Span },
+  Value {
+    value: Value,
+    span: Span,
+  },
+  NonMemberKey(NonMemberKey),
+}
+
+#[cfg_attr(target_arch = "wasm32", derive(Serialize))]
+#[derive(Debug, Clone, PartialEq)]
+#[allow(missing_docs)]
+pub enum NonMemberKey {
+  Group(Group),
+  Type(Type),
 }
 
 impl fmt::Display for MemberKey {
@@ -804,6 +817,8 @@ impl fmt::Display for MemberKey {
       }
       MemberKey::Bareword { ident, .. } => write!(f, "{}:", ident),
       MemberKey::Value { value, .. } => write!(f, "{}:", value),
+      MemberKey::NonMemberKey(NonMemberKey::Group(g)) => write!(f, "{}", g),
+      MemberKey::NonMemberKey(NonMemberKey::Type(t)) => write!(f, "{}", t),
     }
   }
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -244,7 +244,7 @@ impl fmt::Display for LexerError {
   }
 }
 
-impl<'a> From<(&str, Position, &'static str)> for LexerError {
+impl From<(&str, Position, &'static str)> for LexerError {
   fn from(e: (&str, Position, &'static str)) -> Self {
     LexerError {
       error_type: LexerErrorType::LEXER(e.2),
@@ -254,7 +254,7 @@ impl<'a> From<(&str, Position, &'static str)> for LexerError {
   }
 }
 
-impl<'a> From<(&str, Position, string::FromUtf8Error)> for LexerError {
+impl From<(&str, Position, string::FromUtf8Error)> for LexerError {
   fn from(e: (&str, Position, string::FromUtf8Error)) -> Self {
     LexerError {
       error_type: LexerErrorType::UTF8(e.2),
@@ -264,7 +264,7 @@ impl<'a> From<(&str, Position, string::FromUtf8Error)> for LexerError {
   }
 }
 
-impl<'a> From<(&str, Position, base16::DecodeError)> for LexerError {
+impl From<(&str, Position, base16::DecodeError)> for LexerError {
   fn from(e: (&str, Position, base16::DecodeError)) -> Self {
     LexerError {
       error_type: LexerErrorType::BASE16(e.2),
@@ -274,7 +274,7 @@ impl<'a> From<(&str, Position, base16::DecodeError)> for LexerError {
   }
 }
 
-impl<'a> From<(&str, Position, base64::DecodeError)> for LexerError {
+impl From<(&str, Position, base64::DecodeError)> for LexerError {
   fn from(e: (&str, Position, base64::DecodeError)) -> Self {
     LexerError {
       error_type: LexerErrorType::BASE64(e.2),
@@ -284,7 +284,7 @@ impl<'a> From<(&str, Position, base64::DecodeError)> for LexerError {
   }
 }
 
-impl<'a> From<(&str, Position, num::ParseIntError)> for LexerError {
+impl From<(&str, Position, num::ParseIntError)> for LexerError {
   fn from(e: (&str, Position, num::ParseIntError)) -> Self {
     LexerError {
       error_type: LexerErrorType::PARSEINT(e.2),
@@ -294,7 +294,7 @@ impl<'a> From<(&str, Position, num::ParseIntError)> for LexerError {
   }
 }
 
-impl<'a> From<(&str, Position, lexical::Error)> for LexerError {
+impl From<(&str, Position, lexical::Error)> for LexerError {
   fn from(e: (&str, Position, lexical::Error)) -> Self {
     LexerError {
       error_type: LexerErrorType::PARSEFLOAT(e.2),
@@ -305,7 +305,7 @@ impl<'a> From<(&str, Position, lexical::Error)> for LexerError {
 }
 
 /// Lexer which holds a byte slice and iterator over the byte slice
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Lexer<'a> {
   /// CDDL input string
   pub str_input: &'a str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,31 +56,6 @@
 //! around small code and message sizes and constrained nodes, scenarios that
 //! Rust has also been designed for.
 //!
-//! ## CLI
-//!
-//! A CLI has been made available for various platforms and as a Docker image.
-//! It can downloaded from the
-//! [Releases](https://github.com/anweiss/cddl/releases) tab. The tool supports
-//! parsing of `.cddl` files for verifying conformance against RFC 8610. It also
-//! supports validation of `.cddl` documents against `.json` files. Detailed
-//! information about the JSON validation functions can be found in the
-//! [validating JSON](#validating-json) section below. Instructions for using
-//! the tool can be viewed by executing the `help` subcommand:
-//!
-//!     $ cddl help
-//!
-//! If using Docker:
-//!
-//! > Ensure your Docker client has been
-//! > [authenticated](https://help.github.com/en/articles/configuring-docker-for-use-with-github-package-registry#authenticating-to-github-package-registry)
-//! > into GitHub Package Registry. Replace `<version>` with an appropriate
-//! > [release](https://github.com/anweiss/cddl/releases) tag. Requires use of
-//! > the `--volume` argument for mounting `.cddl` and `.json` documents into
-//! > the container when executing the command. The command below assumes these
-//! > documents are in your current working directory.
-//!
-//!     $ docker run -it --rm -v $PWD:/cddl -w /cddl docker.pkg.github.com/anweiss/cddl/cddl:<version> help
-//!
 //! ## Website
 //!
 //! You can also find a simple RFC 8610 conformance tool at

--- a/src/token.rs
+++ b/src/token.rs
@@ -10,7 +10,7 @@ use alloc::{
 };
 
 /// Token which represents a valids CDDL character or sequence
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum Token {
   /// Illegal sequence of characters
   ILLEGAL(String),


### PR DESCRIPTION
This PR provides better support for nested inline groups and group entries. For example:

```
concise-swid-tag = {
  ? (( payload => payload-entry ) // ( evidence => evidence-entry )),
}
```

The group entry in the map above should be parsed as an optional group choice between two inline groups. Prior to this PR, this example wasn't being parsed correctly.

Furthermore, these fixes also include a rudimentary `Iterator` implementation of `Lexer`, which lays the groundwork for refactoring the validation code.