### PR TITLE
Invalidate specs with identifiers that reference missing rule definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ docker run -it --rm -v $PWD:/cddl -w /cddl ghcr.io/anweiss/cddl-cli:<version> he
 You can validate JSON documents:
 
 ```sh
-cddl validate --cddl <FILE.cddl> [FILE.json]...
+cddl validate --cddl <FILE.cddl> --json [FILE.json]...
 ```
 
 You can validate CBOR files:
 
 ```sh
-cddl validate --cddl <FILE.cddl> [FILE.cbor]...
+cddl validate --cddl <FILE.cddl> --cbor [FILE.cbor]...
 ```
 
 It also supports validating files from STDIN (if it detects the input as valid UTF-8, it will attempt to validate the input as JSON, otherwise it will treat it as CBOR):

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -128,7 +128,7 @@ fn main() -> Result<(), Box<dyn Error>> {
       let file_content = fs::read_to_string(c)?;
       cddl_from_str(&mut lexer_from_str(&file_content), &file_content, true).map(|_| ())?;
 
-      error!("{} is conformant", c);
+      info!("{} is conformant", c);
     }
   }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,8 +9,8 @@ use alloc::string::String;
 #[cfg_attr(target_arch = "wasm32", derive(Serialize))]
 #[derive(Debug, Clone)]
 pub struct ErrorMsg {
-  short: String,
-  extended: Option<String>,
+  pub short: String,
+  pub extended: Option<String>,
 }
 
 impl fmt::Display for ErrorMsg {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,13 +112,13 @@
 //! You can validate JSON documents:
 //!
 //! ```sh
-//! cddl validate --cddl <FILE.cddl> [FILE.json]...
+//! cddl validate --cddl <FILE.cddl> --json [FILE.json]...
 //! ```
 //!
 //! You can validate CBOR files:
 //!
 //! ```sh
-//! cddl validate --cddl <FILE.cddl> [FILE.cbor]...
+//! cddl validate --cddl <FILE.cddl> --cbor [FILE.cbor]...
 //! ```
 //!
 //! It also supports validating files from STDIN (if it detects the input as

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2072,16 +2072,25 @@ where
           comments_after_type_or_group
         };
 
+        #[cfg(feature = "ast-span")]
         if let Some((ident, _, _)) = entry_type.groupname_entry() {
           if ident.socket.is_none()
             && token::lookup_ident(ident.ident)
               .in_standard_prelude()
               .is_none()
           {
-            #[cfg(feature = "ast-span")]
             self.visited_rule_idents.push((ident.ident, ident.span));
-            #[cfg(not(feature = "ast-span"))]
-            self.visited_rule_idents.push(name.ident);
+          }
+        }
+
+        #[cfg(not(feature = "ast-span"))]
+        if let Some((ident, _)) = entry_type.groupname_entry() {
+          if ident.socket.is_none()
+            && token::lookup_ident(ident.ident)
+              .in_standard_prelude()
+              .is_none()
+          {
+            self.visited_rule_idents.push(ident.ident);
           }
         }
 
@@ -2141,16 +2150,25 @@ where
           span.1 = self.lexer_position.range.1;
         }
 
+        #[cfg(feature = "ast-span")]
         if let Some((ident, _, _)) = entry_type.groupname_entry() {
           if ident.socket.is_none()
             && token::lookup_ident(ident.ident)
               .in_standard_prelude()
               .is_none()
           {
-            #[cfg(feature = "ast-span")]
             self.visited_rule_idents.push((ident.ident, ident.span));
-            #[cfg(not(feature = "ast-span"))]
-            self.visited_rule_idents.push(name.ident);
+          }
+        }
+
+        #[cfg(not(feature = "ast-span"))]
+        if let Some((ident, _)) = entry_type.groupname_entry() {
+          if ident.socket.is_none()
+            && token::lookup_ident(ident.ident)
+              .in_standard_prelude()
+              .is_none()
+          {
+            self.visited_rule_idents.push(ident.ident);
           }
         }
 
@@ -2256,16 +2274,25 @@ where
           });
         }
 
+        #[cfg(feature = "ast-span")]
         if let Some((ident, _, _)) = entry_type.groupname_entry() {
           if ident.socket.is_none()
             && token::lookup_ident(ident.ident)
               .in_standard_prelude()
               .is_none()
           {
-            #[cfg(feature = "ast-span")]
             self.visited_rule_idents.push((ident.ident, ident.span));
-            #[cfg(not(feature = "ast-span"))]
-            self.visited_rule_idents.push(name.ident);
+          }
+        }
+
+        #[cfg(not(feature = "ast-span"))]
+        if let Some((ident, _)) = entry_type.groupname_entry() {
+          if ident.socket.is_none()
+            && token::lookup_ident(ident.ident)
+              .in_standard_prelude()
+              .is_none()
+          {
+            self.visited_rule_idents.push(ident.ident);
           }
         }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -58,6 +58,7 @@ where
   visited_rule_idents: Vec<(&'a str, Span)>,
   #[cfg(not(feature = "ast-span"))]
   visited_rule_idents: Vec<&'a str>,
+  current_rule_generic_param_idents: Option<Vec<&'a str>>,
 }
 
 /// Parsing error types
@@ -121,6 +122,7 @@ where
       #[cfg(feature = "ast-span")]
       parser_position: Position::default(),
       visited_rule_idents: Vec::default(),
+      current_rule_generic_param_idents: None,
     };
 
     p.next_token()?;
@@ -468,7 +470,16 @@ where
     let gp = if self.peek_token_is(&Token::LANGLEBRACKET) {
       self.next_token()?;
 
-      Some(self.parse_genericparm()?)
+      let params = self.parse_genericparm()?;
+      let mut param_list = Vec::default();
+
+      for param in params.params.iter() {
+        param_list.push(param.param.ident);
+      }
+
+      self.current_rule_generic_param_idents = Some(param_list);
+
+      Some(params)
     } else {
       None
     };
@@ -567,6 +578,8 @@ where
             begin_rule_line,
           );
 
+          self.current_rule_generic_param_idents = None;
+
           Ok(Rule::Group {
             rule: Box::from(GroupRule {
               name: ident,
@@ -605,6 +618,8 @@ where
 
           #[cfg(not(feature = "ast-comments"))]
           self.advance_newline()?;
+
+          self.current_rule_generic_param_idents = None;
 
           Ok(Rule::Type {
             rule: TypeRule {
@@ -682,6 +697,8 @@ where
                           end_rule_range = self.parser_position.range.1;
                         }
 
+                        self.current_rule_generic_param_idents = None;
+
                         return Ok(Rule::Type {
                           rule: TypeRule {
                             name: ident,
@@ -706,6 +723,8 @@ where
             }
           }
         }
+
+        self.current_rule_generic_param_idents = None;
 
         Ok(Rule::Group {
           rule: Box::from(GroupRule {
@@ -770,6 +789,8 @@ where
           self.parser_position.range.1,
           begin_rule_line,
         );
+
+        self.current_rule_generic_param_idents = None;
 
         Ok(Rule::Type {
           rule: TypeRule {
@@ -2018,7 +2039,13 @@ where
               .in_standard_prelude()
               .is_none()
           {
-            self.visited_rule_idents.push((name.ident, name.span));
+            if let Some(params) = &self.current_rule_generic_param_idents {
+              if !params.iter().any(|&p| p == name.ident) {
+                self.visited_rule_idents.push((name.ident, name.span));
+              }
+            } else {
+              self.visited_rule_idents.push((name.ident, name.span));
+            }
           }
 
           return Ok(GroupEntry::TypeGroupname {
@@ -2042,7 +2069,13 @@ where
               .in_standard_prelude()
               .is_none()
           {
-            self.visited_rule_idents.push(name.ident);
+            if let Some(params) = &self.current_rule_generic_param_idents {
+              if !params.iter().any(|&p| p == name.ident) {
+                self.visited_rule_idents.push((name.ident, name.span));
+              }
+            } else {
+              self.visited_rule_idents.push((name.ident, name.span));
+            }
           }
 
           return Ok(GroupEntry::TypeGroupname {
@@ -2079,7 +2112,13 @@ where
               .in_standard_prelude()
               .is_none()
           {
-            self.visited_rule_idents.push((ident.ident, ident.span));
+            if let Some(params) = &self.current_rule_generic_param_idents {
+              if !params.iter().any(|&p| p == ident.ident) {
+                self.visited_rule_idents.push((ident.ident, ident.span));
+              }
+            } else {
+              self.visited_rule_idents.push((ident.ident, ident.span));
+            }
           }
         }
 
@@ -2090,7 +2129,13 @@ where
               .in_standard_prelude()
               .is_none()
           {
-            self.visited_rule_idents.push(ident.ident);
+            if let Some(params) = &self.current_rule_generic_param_idents {
+              if !params.iter().any(|&p| p == ident.ident) {
+                self.visited_rule_idents.push((ident.ident, ident.span));
+              }
+            } else {
+              self.visited_rule_idents.push((ident.ident, ident.span));
+            }
           }
         }
 
@@ -2157,7 +2202,13 @@ where
               .in_standard_prelude()
               .is_none()
           {
-            self.visited_rule_idents.push((ident.ident, ident.span));
+            if let Some(params) = &self.current_rule_generic_param_idents {
+              if !params.iter().any(|&p| p == ident.ident) {
+                self.visited_rule_idents.push((ident.ident, ident.span));
+              }
+            } else {
+              self.visited_rule_idents.push((ident.ident, ident.span));
+            }
           }
         }
 
@@ -2168,7 +2219,13 @@ where
               .in_standard_prelude()
               .is_none()
           {
-            self.visited_rule_idents.push(ident.ident);
+            if let Some(params) = &self.current_rule_generic_param_idents {
+              if !params.iter().any(|&p| p == ident.ident) {
+                self.visited_rule_idents.push((ident.ident, ident.span));
+              }
+            } else {
+              self.visited_rule_idents.push((ident.ident, ident.span));
+            }
           }
         }
 
@@ -2226,7 +2283,13 @@ where
               .in_standard_prelude()
               .is_none()
           {
-            self.visited_rule_idents.push((name.ident, name.span));
+            if let Some(params) = &self.current_rule_generic_param_idents {
+              if !params.iter().any(|&p| p == name.ident) {
+                self.visited_rule_idents.push((name.ident, name.span));
+              }
+            } else {
+              self.visited_rule_idents.push((name.ident, name.span));
+            }
           }
 
           return Ok(GroupEntry::TypeGroupname {
@@ -2258,7 +2321,13 @@ where
               .in_standard_prelude()
               .is_none()
           {
-            self.visited_rule_idents.push(name.ident);
+            if let Some(params) = &self.current_rule_generic_param_idents {
+              if !params.iter().any(|&p| p == name.ident) {
+                self.visited_rule_idents.push((name.ident, name.span));
+              }
+            } else {
+              self.visited_rule_idents.push((name.ident, name.span));
+            }
           }
 
           return Ok(GroupEntry::TypeGroupname {
@@ -2281,7 +2350,13 @@ where
               .in_standard_prelude()
               .is_none()
           {
-            self.visited_rule_idents.push((ident.ident, ident.span));
+            if let Some(params) = &self.current_rule_generic_param_idents {
+              if !params.iter().any(|&p| p == ident.ident) {
+                self.visited_rule_idents.push((ident.ident, ident.span));
+              }
+            } else {
+              self.visited_rule_idents.push((ident.ident, ident.span));
+            }
           }
         }
 
@@ -2292,7 +2367,13 @@ where
               .in_standard_prelude()
               .is_none()
           {
-            self.visited_rule_idents.push(ident.ident);
+            if let Some(params) = &self.current_rule_generic_param_idents {
+              if !params.iter().any(|&p| p == ident.ident) {
+                self.visited_rule_idents.push((ident.ident, ident.span));
+              }
+            } else {
+              self.visited_rule_idents.push((ident.ident, ident.span));
+            }
           }
         }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2071,10 +2071,10 @@ where
           {
             if let Some(params) = &self.current_rule_generic_param_idents {
               if !params.iter().any(|&p| p == name.ident) {
-                self.visited_rule_idents.push((name.ident, name.span));
+                self.visited_rule_idents.push(name.ident);
               }
             } else {
-              self.visited_rule_idents.push((name.ident, name.span));
+              self.visited_rule_idents.push(name.ident);
             }
           }
 
@@ -2131,10 +2131,10 @@ where
           {
             if let Some(params) = &self.current_rule_generic_param_idents {
               if !params.iter().any(|&p| p == ident.ident) {
-                self.visited_rule_idents.push((ident.ident, ident.span));
+                self.visited_rule_idents.push(ident.ident);
               }
             } else {
-              self.visited_rule_idents.push((ident.ident, ident.span));
+              self.visited_rule_idents.push(ident.ident);
             }
           }
         }
@@ -2221,10 +2221,10 @@ where
           {
             if let Some(params) = &self.current_rule_generic_param_idents {
               if !params.iter().any(|&p| p == ident.ident) {
-                self.visited_rule_idents.push((ident.ident, ident.span));
+                self.visited_rule_idents.push(ident.ident);
               }
             } else {
-              self.visited_rule_idents.push((ident.ident, ident.span));
+              self.visited_rule_idents.push(ident.ident);
             }
           }
         }
@@ -2323,10 +2323,10 @@ where
           {
             if let Some(params) = &self.current_rule_generic_param_idents {
               if !params.iter().any(|&p| p == name.ident) {
-                self.visited_rule_idents.push((name.ident, name.span));
+                self.visited_rule_idents.push(name.ident);
               }
             } else {
-              self.visited_rule_idents.push((name.ident, name.span));
+              self.visited_rule_idents.push(name.ident);
             }
           }
 
@@ -2369,10 +2369,10 @@ where
           {
             if let Some(params) = &self.current_rule_generic_param_idents {
               if !params.iter().any(|&p| p == ident.ident) {
-                self.visited_rule_idents.push((ident.ident, ident.span));
+                self.visited_rule_idents.push(ident.ident);
               }
             } else {
-              self.visited_rule_idents.push((ident.ident, ident.span));
+              self.visited_rule_idents.push(ident.ident);
             }
           }
         }

--- a/src/token.rs
+++ b/src/token.rs
@@ -699,6 +699,7 @@ pub fn lookup_ident(ident: &str) -> Token {
     "number" => Token::NUMBER,
     "biguint" => Token::BIGUINT,
     "bignint" => Token::BIGNINT,
+    "bigint" => Token::BIGINT,
     "integer" => Token::INTEGER,
     "unsigned" => Token::UNSIGNED,
     "decfrac" => Token::DECFRAC,

--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -2477,7 +2477,7 @@ impl<'a> Visitor<'a, Error> for CBORValidator<'a> {
                 })
                 .collect::<Vec<_>>();
 
-              self.values_to_validate = Some(values_to_validate.clone());
+              self.values_to_validate = Some(values_to_validate);
               for e in errors.into_iter() {
                 self.add_error(e);
               }

--- a/src/validator/control.rs
+++ b/src/validator/control.rs
@@ -861,6 +861,7 @@ mod tests {
       )?,
       vec![Type2::TextValue {
         value: "foo\n  bar\n  baz\n".into(),
+        #[cfg(feature = "ast-span")]
         span: Span::default(),
       }],
     );
@@ -891,12 +892,14 @@ mod tests {
         &Type2::Typename {
           ident: "b".into(),
           generic_args: None,
+          #[cfg(feature = "ast-span")]
           span: Span::default(),
         },
         true,
       )?,
       vec![Type2::TextValue {
         value: "foo\nbar\nbaz\n".into(),
+        #[cfg(feature = "ast-span")]
         span: Span::default(),
       }]
     );

--- a/tests/fixtures/cddl/shelley.cddl
+++ b/tests/fixtures/cddl/shelley.cddl
@@ -1,168 +1,308 @@
 ; Shelley Types
 
-block = [
-	header
-	, transaction_bodies: [ * transaction_body ] ; 19
-	, transaction_witness_sets: [ * transaction_witness_set ] ; 20
-	, transaction_metadata_set: { * transaction_index => transaction_metadata }
-]
+block =
+  [ header
+  , transaction_bodies         : [* transaction_body]
+  , transaction_witness_sets   : [* transaction_witness_set]
+  , transaction_metadata_set   :
+      { * transaction_index => transaction_metadata }
+  ]; Valid blocks must also satisfy the following two constraints:
+   ; 1) the length of transaction_bodies and transaction_witness_sets
+   ;    must be the same
+   ; 2) every transaction_index must be strictly smaller than the
+   ;    length of transaction_bodies
 
-transaction = [ transaction_body, transaction_witness_set, [ ? transaction_metadata ] ]
+transaction =
+  [ transaction_body
+  , transaction_witness_set
+  , transaction_metadata / null
+  ]
 
 transaction_index = uint
 
-header = ( header_body, body_signature: $kes_signature )
+header =
+  [ header_body
+  , body_signature : $kes_signature
+  ]
 
-header_body = (
-	prev_hash: $hash
-	, issuer_vkey: $vkey
-	, vrf_vkey: $vrf_vkey
-	, slot: uint
-	, nonce_vrf: $vrf_cert
-	, leader_vrf: $vrf_cert
-	, size: uint
-	, block_number: uint
-	, block_body_hash: $hash ; merkle triple root
-	, operational_cert
-	, protocol_version
-)
+header_body =
+  [ block_number     : uint
+  , slot             : uint
+  , prev_hash        : $hash32 / null
+  , issuer_vkey      : $vkey
+  , vrf_vkey         : $vrf_vkey
+  , nonce_vrf        : $vrf_cert
+  , leader_vrf       : $vrf_cert
+  , block_body_size  : uint
+  , block_body_hash  : $hash32 ; merkle triple root
+  , operational_cert
+  , protocol_version
+  ]
 
-operational_cert = (
-	hot_vkey: $kes_vkey,
-	cold_vkey: $vkey,
-	sequence_number: uint,
-	kes_period: uint,
-	sigma: $signature
-)
+operational_cert =
+  ( hot_vkey        : $kes_vkey
+  , sequence_number : uint
+  , kes_period      : uint
+  , sigma           : $signature
+  )
 
-protocol_version = ( uint, uint )
+protocol_version = (uint, uint)
 
-; Do we want to use a Map here? Is it actually cheaper?
-; Do we want to add extension points here?
-transaction_body = {
-	0: finite_set<transaction_input>
-	, 1: [ * transaction_output ]
-	, 2: coin ; fee
-	, 3: uint ; ttl
-	, 4: [ * delegation_certificate ]
-	, ? 5: withdrawals
-	, ? 6: full_update
-	, ? 7: metadata_hash
-}
+transaction_body =
+  { 0 : set<transaction_input>
+  , 1 : [* transaction_output]
+  , 2 : coin ; fee
+  , 3 : uint ; ttl
+  , ? 4 : [* certificate]
+  , ? 5 : withdrawals
+  , ? 6 : update
+  , ? 7 : metadata_hash
+  }
 
-; Is it okay to have this as a group? Is it valid CBOR?! Does it need to be?
-transaction_input = [ transaction_id: $hash, index: uint ]
+transaction_input = [ transaction_id : $hash32
+                    , index : uint
+                    ]
 
-transaction_output = [ address, amount: uint ]
+transaction_output = [address, amount : coin]
 
-address = (
-	0, keyhash, keyhash ; base address
-	// 1, keyhash, scripthash ; base address
-	// 2, scripthash, keyhash ; base address
-	// 3, scripthash, scripthash ; base address
-	// 4, keyhash, pointer ; pointer address
-	// 5, scripthash, pointer ; pointer address
-	// 6, keyhash ; enterprise address (null staking reference)
-	// 7, scripthash ; enterprise address (null staking reference)
-	// 8, keyhash ; bootstrap address
-)
+; address = bytes
+; reward_account = bytes
 
-delegation_certificate = [
-	0, keyhash ; stake key registration
-	// 1, scripthash ; stake script registration
-	// 2, keyhash ; stake key de-registration
-	// 3, scripthash ; stake script de-registration
-	// 4 ; stake key delegation
-		, keyhash ; delegating key
-		, keyhash ; key delegated to
-	// 5 ; stake script delegation
-		, scripthash ; delegating script
-		, keyhash ; key delegated to
-	// 6, pool_params ; stake pool registration
-	// 7, keyhash, epoch ; stake pool retirement
-	// 8 ; genesis key delegation
-		, genesishash ; delegating key
-		, keyhash ; key delegated to
-	// 9, move_instantaneous_reward ; move instantaneous rewards
-]
+; address format:
+; [ 8 bit header | payload ];
+;
+; shelley payment addresses:
+; bit 7: 0
+; bit 6: base/other
+; bit 5: pointer/enterprise [for base: stake cred is keyhash/scripthash]
+; bit 4: payment cred is keyhash/scripthash
+; bits 3-0: network id
+;
+; reward addresses:
+; bits 7-5: 111
+; bit 4: credential is keyhash/scripthash
+; bits 3-0: network id
+;
+; byron addresses:
+; bits 7-4: 1000
 
-move_instantaneous_reward = { * [ credential ] => coin }
+; 0000: base address: keyhash28,keyhash28
+; 0001: base address: scripthash28,keyhash28
+; 0010: base address: keyhash28,scripthash28
+; 0011: base address: scripthash28,scripthash28
+; 0100: pointer address: keyhash28, 3 variable length uint
+; 0101: pointer address: scripthash28, 3 variable length uint
+; 0110: enterprise address: keyhash28
+; 0111: enterprise address: scripthash28
+; 1000: byron address
+; 1110: reward account: keyhash28
+; 1111: reward account: scripthash28
+; 1001 - 1101: future formats
 
-pointer = ( uint, uint, uint )
+certificate =
+  [ stake_registration
+  // stake_deregistration
+  // stake_delegation
+  // pool_registration
+  // pool_retirement
+  // genesis_key_delegation
+  // move_instantaneous_rewards_cert
+  ]
 
-credential = ( 0, keyhash // 1, scripthash )
+stake_registration = (0, stake_credential)
+stake_deregistration = (1, stake_credential)
+stake_delegation = (2, stake_credential, pool_keyhash)
+pool_registration = (3, pool_params)
+pool_retirement = (4, pool_keyhash, epoch)
+genesis_key_delegation = (5, genesishash, genesis_delegate_hash, vrf_keyhash)
+move_instantaneous_rewards_cert = (6, move_instantaneous_reward)
 
-pool_params = (
-	keyhash ; operator
-	, $vrf_keyhash ; vrf keyhash
-	, coin ; pledge
-	, coin ; cost
-	, unit_interval ; margin
-	, [ credential ]
-	, finite_set<keyhash> ; pool owners
-)
+move_instantaneous_reward = [ 0 / 1, { * stake_credential => coin } ]
+; The first field determines where the funds are drawn from.
+; 0 denotes the reserves, 1 denotes the treasury.
 
-withdrawals = { * [ credential ] => coin }
+stake_credential =
+  [  0, addr_keyhash
+  // 1, scripthash
+  ]
 
-full_update = [ protocol_param_update_votes, application_version_update_votes, [ ? epoch ] ]
+pool_params = ( operator:       pool_keyhash
+              , vrf_keyhash:    vrf_keyhash
+              , pledge:         coin
+              , cost:           coin
+              , margin:         unit_interval
+              , reward_account: reward_account
+              , pool_owners:    set<addr_keyhash>
+              , relays:         [* relay]
+              , pool_metadata:  pool_metadata / null
+              )
 
-protocol_param_update_votes = { * genesishash => protocol_param_update }
+port = uint .le 65535
+ipv4 = bytes .size 4
+ipv6 = bytes .size 16
+dns_name = tstr .size (0..64)
 
-protocol_param_update = {
-	? 0: uint ; minfee A
-	, ? 1: uint ; minfee B
-	, ? 2: uint ; max block body size
-	, ? 3: uint ; max transaction size
-	, ? 4: uint ; max block header size
-	, ? 5: coin ; key deposit
-	, ? 6: unit_interval ; key deposit min refund
-	, ? 7: rational ; key deposit decay rate
-	, ? 8: coin ; pool deposit
-	, ? 9: unit_interval ; pool deposit min refund
-	, ? 10: rational ; pool deposit decay rate
-	, ? 11: epoch ; maximum epoch
-	, ? 12: uint ; n_optimal. desired number of stake pools
-	, ? 13: rational ; pool pledge influence
-	, ? 14: unit_interval ; expansion rate
-	, ? 15: unit_interval ; treasury growth rate
-	, ? 16: unit_interval ; active slot coefficient
-	, ? 17: unit_interval ; d. decentralization constant
-	, ? 18: $nonce ; extra entropy
-	, ? 19: [ protocol_version ] ; protocol version
-}
+single_host_addr = ( 0
+                   , port / null
+                   , ipv4 / null
+                   , ipv6 / null
+                   )
+single_host_name = ( 1
+                   , port / null
+                   , dns_name ; An A or AAAA DNS record
+                   )
+multi_host_name = ( 2
+                   , dns_name ; A SRV DNS record
+                   )
+relay =
+  [  single_host_addr
+  // single_host_name
+  // multi_host_name
+  ]
 
-application_version_update_votes = { * genesishash => application_version_update }
+pool_metadata = [url, metadata_hash]
+url = tstr .size (0..64)
 
-application_version_update = { * application_name => [ uint, application_metadata ] }
+withdrawals = { * reward_account => coin }
 
-application_metadata = { * system_tag => installerhash }
+update = [ proposed_protocol_parameter_updates
+         , epoch
+         ]
 
-application_name = tstr .size 64
-system_tag = tstr .size 64
+proposed_protocol_parameter_updates =
+  { * genesishash => protocol_param_update }
 
-transaction_witness_set = { ? 0: [ * pubkey_witness ], ? 1: [ * script ] }
+protocol_param_update =
+  { ? 0:  uint               ; minfee A
+  , ? 1:  uint               ; minfee B
+  , ? 2:  uint               ; max block body size
+  , ? 3:  uint               ; max transaction size
+  , ? 4:  uint               ; max block header size
+  , ? 5:  coin               ; key deposit
+  , ? 6:  coin               ; pool deposit
+  , ? 7: epoch               ; maximum epoch
+  , ? 8: uint                ; n_opt: desired number of stake pools
+  , ? 9: rational            ; pool pledge influence
+  , ? 10: unit_interval      ; expansion rate
+  , ? 11: unit_interval      ; treasury growth rate
+  , ? 12: unit_interval      ; d. decentralization constant
+  , ? 13: $nonce             ; extra entropy
+  , ? 14: [protocol_version] ; protocol version
+  , ? 15: coin               ; min utxo value
+  }
 
-transaction_metadatum = { * transaction_metadatum => transaction_metadatum }
-	/ [ * transaction_metadatum ]
-	/ int
-	/ bytes .size 64
-	/ text .size 64
+transaction_witness_set =
+  { ?0 => [* vkeywitness ]
+  , ?1 => [* multisig_script ]
+  , ?2 => [* bootstrap_witness ]
+  ; In the future, new kinds of witnesses can be added like this:
+  ; , ?3 => [* monetary_policy_script ]
+  ; , ?4 => [* plutus_script ]
+  }
 
-transaction_metadadum_label = uint
+transaction_metadatum =
+    { * transaction_metadatum => transaction_metadatum }
+  / [ * transaction_metadatum ]
+  / int
+  / bytes .size (0..64)
+  / text .size (0..64)
 
-transaction_metadata = { * transaction_metadadum_label => transaction_metadatum }
+transaction_metadatum_label = uint
+
+transaction_metadata =
+  { * transaction_metadatum_label => transaction_metadatum }
 
 vkeywitness = [ $vkey, $signature ]
 
-unit_interval = rational
+bootstrap_witness =
+  [ public_key : $vkey
+  , signature  : $signature
+  , chain_code : bytes .size 32
+  , attributes : bytes
+  ]
 
-; rational =  #6.30( TODO use the cbor tag
-rational = [ numerator: uint, denominator: uint ] ;)
+multisig_script =
+  [ multisig_pubkey
+  // multisig_all
+  // multisig_any
+  // multisig_n_of_k
+  ]
+
+multisig_pubkey = (0, addr_keyhash)
+multisig_all = (1, [ * multisig_script ])
+multisig_any = (2, [ * multisig_script ])
+multisig_n_of_k = (3, n: uint, [ * multisig_script ])
 
 coin = uint
 epoch = uint
-keyhash = $hash
-scripthash = $hash
-genesishash = $hash
-installerhash = $hash
-metadata_hash = $hash
+
+addr_keyhash          = $hash28
+scripthash            = $hash28
+genesis_delegate_hash = $hash28
+pool_keyhash          = $hash28
+genesishash           = $hash28
+
+vrf_keyhash           = $hash32
+metadata_hash         = $hash32
+
+$nonce /= [ 0 // 1, bytes .size 32 ]
+
+finite_set<a> = [* a ]
+
+$hash28 /= bytes .size 28
+$hash32 /= bytes .size 32
+
+$vkey /= bytes .size 32
+
+$vrf_vkey /= bytes .size 32
+$vrf_cert /= [bytes, bytes .size 80]
+
+$kes_vkey /= bytes .size 32
+$kes_signature /= bytes .size 448
+signkeyKES = bytes .size 64
+
+$signature /= bytes .size 64
+
+$hash28 /= bytes .size 8
+$hash32 /= bytes .size 10
+
+$vkey /= bytes .size 8
+
+$vrf_vkey /= bytes .size 8
+$vrf_cert /= [bytes, bytes .size 10]
+
+$kes_vkey /= bytes .size 8
+$kes_signature /= bytes .size 32
+
+$signature /= bytes .size 16
+
+set<a> = [a]
+  ; real set is [* a]
+
+unit_interval = #6.30([1, 2])
+  ; real unit_interval is: #6.30([uint, uint])
+  ; but this produces numbers outside the unit interval
+  ; and can also produce a zero in the denominator
+
+rational =  #6.30(
+   [ numerator   : 1
+   , denominator : 2
+   ])
+  ; real rational is: #6.30([uint, uint])
+  ; but this produces numbers outside the unit interval
+  ; and can also produce a zero in the denominator
+
+
+address =
+  h'001000000000000000000000000000000000000000000000000000000011000000000000000000000000000000000000000000000000000000' /
+  h'102000000000000000000000000000000000000000000000000000000022000000000000000000000000000000000000000000000000000000' /
+  h'203000000000000000000000000000000000000000000000000000000033000000000000000000000000000000000000000000000000000000' /
+  h'304000000000000000000000000000000000000000000000000000000044000000000000000000000000000000000000000000000000000000' /
+  h'405000000000000000000000000000000000000000000000000000000087680203' /
+  h'506000000000000000000000000000000000000000000000000000000087680203' /
+  h'6070000000000000000000000000000000000000000000000000000000' /
+  h'7080000000000000000000000000000000000000000000000000000000'
+
+reward_account =
+  h'E090000000000000000000000000000000000000000000000000000000' /
+  h'F0A0000000000000000000000000000000000000000000000000000000'

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -24,7 +24,7 @@ fn verify_cddl() -> Result<()> {
         message<t, v> = {type: 2, value: v}
         color = &colors
         colors = ( red: "red" )
-        thing = ( int / float )
+        test = ( int / float )
       "#
   );
 
@@ -546,9 +546,9 @@ fn verify_cddl() -> Result<()> {
             Rule::Type {
               rule: TypeRule {
                 name: Identifier {
-                  ident: "thing".into(),
+                  ident: "test".into(),
                   socket: None,
-                  span: (187, 192, 9),
+                  span: (187, 191, 9),
                 },
                 generic_params: None,
                 is_type_choice_alternate: false,
@@ -564,14 +564,14 @@ fn verify_cddl() -> Result<()> {
                                   ident: Identifier {
                                     ident: "int".into(),
                                     socket: None,
-                                    span: (197, 200, 9),
+                                    span: (196, 199, 9),
                                   },
                                   generic_args: None,
-                                  span: (197, 200, 9),
+                                  span: (196, 199, 9),
                                 },
                                 operator: None,
                                 comments_after_type: None,
-                                span: (197, 200, 9),
+                                span: (196, 199, 9),
                               },
                               comments_before_type: None,
                               comments_after_type: None,
@@ -582,40 +582,40 @@ fn verify_cddl() -> Result<()> {
                                   ident: Identifier {
                                     ident: "float".into(),
                                     socket: None,
-                                    span: (203, 208, 9),
+                                    span: (202, 207, 9),
                                   },
                                   generic_args: None,
-                                  span: (203, 208, 9),
+                                  span: (202, 207, 9),
                                 },
                                 operator: None,
                                 comments_after_type: None,
-                                span: (203, 208, 9),
+                                span: (202, 207, 9),
                               },
                               comments_before_type: None,
                               comments_after_type: None,
                             },
                           ],
-                          span: (197, 208, 9),
+                          span: (196, 207, 9),
                         },
                         comments_before_type: None,
                         comments_after_type: None,
-                        span: (195, 210, 9),
+                        span: (194, 209, 9),
                       },
                       operator: None,
                       comments_after_type: None,
-                      span: (195, 211, 9),
+                      span: (194, 210, 9),
                     },
                     comments_before_type: None,
                     comments_after_type: None,
                   }],
 
-                  span: (195, 211, 9),
+                  span: (194, 210, 9),
                 },
                 comments_before_assignt: None,
                 comments_after_assignt: None,
               },
               comments_after_rule: None,
-              span: (187, 211, 9),
+              span: (187, 210, 9),
             },
           ],
           comments: None,

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -20,7 +20,7 @@
         "style-loader": "^3.2.1",
         "webpack": "^5.50.0",
         "webpack-cli": "^4.7.0",
-        "webpack-dev-server": "git://github.com/webpack/webpack-dev-server.git#2e1151eef3e4ae8a3369787d61b2e5763572ede9"
+        "webpack-dev-server": "^4.2.0"
       }
     },
     "../pkg": {
@@ -404,10 +404,10 @@
         "ajv": "^6.9.1"
       }
     },
-    "node_modules/ansi-html": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+    "node_modules/ansi-html-community": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
       "dev": true,
       "engines": [
         "node >= 0.8.0"
@@ -1895,15 +1895,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/is-absolute-url": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
-      "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -2160,12 +2151,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/killable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
-      "integrity": "sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==",
-      "dev": true
-    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -2252,18 +2237,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "dev": true,
-      "dependencies": {
-        "p-defer": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -2273,35 +2246,10 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mem": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
-      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
-      "dev": true,
-      "dependencies": {
-        "map-age-cleaner": "^0.1.3",
-        "mimic-fn": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/mem?sponsor=1"
-      }
-    },
-    "node_modules/mem/node_modules/mimic-fn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/memfs": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.2.2.tgz",
-      "integrity": "sha512-RE0CwmIM3CEvpcdK3rZ19BC4E6hv9kADkMN5rPduRak58cNArWLi/9jFLsa4rhsjfVxMP3v0jO7FHXq7SvFY5Q==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.2.4.tgz",
+      "integrity": "sha512-2mDCPhuduRPOxlfgsXF9V+uqC6Jgz8zt/bNe4d4W7d5f6pCzHrWkxLNr17jKGXd4+j2kQNsAG2HARPnt74sqVQ==",
       "dev": true,
       "dependencies": {
         "fs-monkey": "1.0.3"
@@ -2677,15 +2625,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/p-event": {
@@ -4069,17 +4008,16 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.0.0.tgz",
-      "integrity": "sha512-9zng2Z60pm6A98YoRcA0wSxw1EYn7B7y5owX/Tckyt9KGyULTkLtiavjaXlWqOMkM0YtqGgL3PvMOFgyFLq8vw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.1.0.tgz",
+      "integrity": "sha512-oT660AR1gOnU/NTdUQi3EiGR0iXG7CFxmKsj3ylWCBA2khJ8LFHK+sKv3BZEsC11gl1eChsltRhzUq7nWj7XIQ==",
       "dev": true,
       "dependencies": {
         "colorette": "^1.2.2",
-        "mem": "^8.1.1",
         "memfs": "^3.2.2",
         "mime-types": "^2.1.31",
         "range-parser": "^1.2.1",
-        "schema-utils": "^3.0.0"
+        "schema-utils": "^3.1.0"
       },
       "engines": {
         "node": ">= 12.13.0"
@@ -4093,15 +4031,16 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "4.0.0-rc.0",
-      "resolved": "git+ssh://git@github.com/webpack/webpack-dev-server.git#2e1151eef3e4ae8a3369787d61b2e5763572ede9",
-      "integrity": "sha512-9S+MywBN/ecr8AbXNVUnmbFji8UTtzLR6M5Dgy6sB5Ti/73UgHn8TMhLaSBZBkY/cmSmWHDSwUXFs8lOeARpOw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.2.1.tgz",
+      "integrity": "sha512-SQrIyQDZsTaF84p/WMAXNRKxjTeIaewhDIiHYZ423ENhNAsQWyubvqPTn0IoLMGkbhWyWv8/GYnCjItt0ZNC5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-html": "^0.0.7",
+        "ansi-html-community": "^0.0.8",
         "bonjour": "^3.5.0",
         "chokidar": "^3.5.1",
+        "colorette": "^1.2.2",
         "compression": "^1.7.4",
         "connect-history-api-fallback": "^1.6.0",
         "del": "^6.0.0",
@@ -4111,8 +4050,6 @@
         "http-proxy-middleware": "^2.0.0",
         "internal-ip": "^6.2.0",
         "ipaddr.js": "^2.0.1",
-        "is-absolute-url": "^3.0.3",
-        "killable": "^1.0.1",
         "open": "^8.0.9",
         "p-retry": "^4.5.0",
         "portfinder": "^1.0.28",
@@ -4123,8 +4060,8 @@
         "spdy": "^4.0.2",
         "strip-ansi": "^7.0.0",
         "url": "^0.11.0",
-        "webpack-dev-middleware": "^5.0.0",
-        "ws": "^7.5.3"
+        "webpack-dev-middleware": "^5.1.0",
+        "ws": "^8.1.0"
       },
       "bin": {
         "webpack-dev-server": "bin/webpack-dev-server.js"
@@ -4133,7 +4070,7 @@
         "node": ">= 12.13.0"
       },
       "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
+        "webpack": "^4.37.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
         "webpack-cli": {
@@ -4224,12 +4161,12 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.2.tgz",
+      "integrity": "sha512-Q6B6H2oc8QY3llc3cB8kVmQ6pnJWVQbP7Q5algTcIxx7YEpc0oU4NBVHlztA7Ekzfhw2r0rPducMUiCGWKQRzw==",
       "dev": true,
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
@@ -4592,10 +4529,10 @@
       "dev": true,
       "requires": {}
     },
-    "ansi-html": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+    "ansi-html-community": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
       "dev": true
     },
     "ansi-regex": {
@@ -5763,12 +5700,6 @@
       "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
       "dev": true
     },
-    "is-absolute-url": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
-      "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
-      "dev": true
-    },
     "is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -5944,12 +5875,6 @@
         "minimist": "^1.2.5"
       }
     },
-    "killable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
-      "integrity": "sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==",
-      "dev": true
-    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -6014,43 +5939,16 @@
         }
       }
     },
-    "map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "dev": true,
-      "requires": {
-        "p-defer": "^1.0.0"
-      }
-    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
-    "mem": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
-      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
-      "dev": true,
-      "requires": {
-        "map-age-cleaner": "^0.1.3",
-        "mimic-fn": "^3.1.0"
-      },
-      "dependencies": {
-        "mimic-fn": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-          "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
-          "dev": true
-        }
-      }
-    },
     "memfs": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.2.2.tgz",
-      "integrity": "sha512-RE0CwmIM3CEvpcdK3rZ19BC4E6hv9kADkMN5rPduRak58cNArWLi/9jFLsa4rhsjfVxMP3v0jO7FHXq7SvFY5Q==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.2.4.tgz",
+      "integrity": "sha512-2mDCPhuduRPOxlfgsXF9V+uqC6Jgz8zt/bNe4d4W7d5f6pCzHrWkxLNr17jKGXd4+j2kQNsAG2HARPnt74sqVQ==",
       "dev": true,
       "requires": {
         "fs-monkey": "1.0.3"
@@ -6328,12 +6226,6 @@
         "is-docker": "^2.1.1",
         "is-wsl": "^2.2.0"
       }
-    },
-    "p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-      "dev": true
     },
     "p-event": {
       "version": "4.2.0",
@@ -7359,28 +7251,28 @@
       }
     },
     "webpack-dev-middleware": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.0.0.tgz",
-      "integrity": "sha512-9zng2Z60pm6A98YoRcA0wSxw1EYn7B7y5owX/Tckyt9KGyULTkLtiavjaXlWqOMkM0YtqGgL3PvMOFgyFLq8vw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.1.0.tgz",
+      "integrity": "sha512-oT660AR1gOnU/NTdUQi3EiGR0iXG7CFxmKsj3ylWCBA2khJ8LFHK+sKv3BZEsC11gl1eChsltRhzUq7nWj7XIQ==",
       "dev": true,
       "requires": {
         "colorette": "^1.2.2",
-        "mem": "^8.1.1",
         "memfs": "^3.2.2",
         "mime-types": "^2.1.31",
         "range-parser": "^1.2.1",
-        "schema-utils": "^3.0.0"
+        "schema-utils": "^3.1.0"
       }
     },
     "webpack-dev-server": {
-      "version": "git+ssh://git@github.com/webpack/webpack-dev-server.git#2e1151eef3e4ae8a3369787d61b2e5763572ede9",
-      "integrity": "sha512-9S+MywBN/ecr8AbXNVUnmbFji8UTtzLR6M5Dgy6sB5Ti/73UgHn8TMhLaSBZBkY/cmSmWHDSwUXFs8lOeARpOw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.2.1.tgz",
+      "integrity": "sha512-SQrIyQDZsTaF84p/WMAXNRKxjTeIaewhDIiHYZ423ENhNAsQWyubvqPTn0IoLMGkbhWyWv8/GYnCjItt0ZNC5w==",
       "dev": true,
-      "from": "webpack-dev-server@git://github.com/webpack/webpack-dev-server.git#2e1151eef3e4ae8a3369787d61b2e5763572ede9",
       "requires": {
-        "ansi-html": "^0.0.7",
+        "ansi-html-community": "^0.0.8",
         "bonjour": "^3.5.0",
         "chokidar": "^3.5.1",
+        "colorette": "^1.2.2",
         "compression": "^1.7.4",
         "connect-history-api-fallback": "^1.6.0",
         "del": "^6.0.0",
@@ -7390,8 +7282,6 @@
         "http-proxy-middleware": "^2.0.0",
         "internal-ip": "^6.2.0",
         "ipaddr.js": "^2.0.1",
-        "is-absolute-url": "^3.0.3",
-        "killable": "^1.0.1",
         "open": "^8.0.9",
         "p-retry": "^4.5.0",
         "portfinder": "^1.0.28",
@@ -7402,8 +7292,8 @@
         "spdy": "^4.0.2",
         "strip-ansi": "^7.0.0",
         "url": "^0.11.0",
-        "webpack-dev-middleware": "^5.0.0",
-        "ws": "^7.5.3"
+        "webpack-dev-middleware": "^5.1.0",
+        "ws": "^8.1.0"
       }
     },
     "webpack-merge": {
@@ -7465,9 +7355,9 @@
       "dev": true
     },
     "ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.2.tgz",
+      "integrity": "sha512-Q6B6H2oc8QY3llc3cB8kVmQ6pnJWVQbP7Q5algTcIxx7YEpc0oU4NBVHlztA7Ekzfhw2r0rPducMUiCGWKQRzw==",
       "dev": true,
       "requires": {}
     },

--- a/www/package.json
+++ b/www/package.json
@@ -35,6 +35,6 @@
     "style-loader": "^3.2.1",
     "webpack": "^5.50.0",
     "webpack-cli": "^4.7.0",
-    "webpack-dev-server": "git://github.com/webpack/webpack-dev-server.git#2e1151eef3e4ae8a3369787d61b2e5763572ede9"
+    "webpack-dev-server": "^4.2.0"
   }
 }


### PR DESCRIPTION
Fixes #87 by keeping track of visited identifiers that aren't sockets and are missing rule definitions