### PR TITLE
Make some fixes needed to make commands work

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ docker run -it --rm -v $PWD:/cddl -w /cddl ghcr.io/anweiss/cddl-cli:<version> he
 You can validate JSON documents:
 
 ```sh
-cddl validate --cddl <FILE.cddl> --json [FILE.json]...
+cddl validate --cddl <FILE.cddl> [FILE.json]...
 ```
 
 You can validate CBOR files:
 
 ```sh
-cddl validate --cddl <FILE.cddl> --cbor [FILE.cbor]...
+cddl validate --cddl <FILE.cddl> [FILE.cbor]...
 ```
 
 It also supports validating files from STDIN (if it detects the input as valid UTF-8, it will attempt to validate the input as JSON, otherwise it will treat it as CBOR):
@@ -95,7 +95,7 @@ cat reputon.cbor | cddl validate --cddl reputon.cddl --stdin
 or using Docker:
 
 ```sh
-docker run -i --rm -v $PWD:/cddl -w /cddl ghcr.io/anweiss/cddl-cli:latest validate --cddl reputon.cddl --stdin < reputon.json
+docker run -i --rm -v $PWD:/data -w /data ghcr.io/anweiss/cddl-cli:latest validate --cddl reputon.cddl --stdin < reputon.json
 ```
 
 ## Website


### PR DESCRIPTION
1. --json and --cbor no longer seem to exist (at least when trying with Docker image, perhaps that's out of date).
2. Mounting to `/cddl` doesn't work, I suspect that's where the binary gets stored by the Dockerfile? So switched to `/data`.