### PR TITLE
Fix AST parsing for comments

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -296,7 +296,7 @@ impl<'a> Parser<'a> {
     let mut comments: Option<Comments> = None;
 
     while let Token::COMMENT(_comment) = self.cur_token {
-      #[cfg(feature = "lsp")]
+      #[cfg(not(feature = "lsp"))]
       comments.get_or_insert(Comments::default()).0.push(_comment);
 
       self.next_token()?;

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -1865,4 +1865,64 @@ mod tests {
 
     Ok(())
   }
+
+  #[test]
+  fn verify_comment() -> Result<()> {
+    let input = indoc!(
+      r#"
+        ; test
+        myrule = 1234
+      "#
+    );
+
+    let expected_output = CDDL {
+      rules: vec![
+        Rule::Type {
+          rule: TypeRule {
+            name: Identifier {
+              ident: "myrule".into(),
+              socket: None,
+              span: (7, 13, 2),
+            },
+            generic_params: None,
+            is_type_choice_alternate: false,
+            value: Type {
+              type_choices: vec![TypeChoice {
+                type1: Type1 {
+                  type2: Type2::UintValue {
+                    value: 1234,
+                    span: (16, 20, 2),
+                  },
+                  operator: None,
+                  comments_after_type: None,
+                  span: (16, 20, 2),
+                },
+                comments_before_type: None,
+                comments_after_type: None,
+              }],
+
+              span: (16, 20, 2),
+            },
+            comments_before_assignt: None,
+            comments_after_assignt: None,
+          },
+          comments_after_rule: None,
+          span: (7, 20, 2),
+        },
+      ],
+      comments: Some(
+        Comments(
+          vec![
+            " test"
+          ]
+        )
+      ),
+    };
+
+    let parser = Parser::new(input, Box::new(Lexer::new(input).iter()))?.parse_cddl()?;
+    assert_eq!(parser, expected_output);
+    assert_eq!(parser.to_string(), expected_output.to_string());
+
+    Ok(())
+  }
 }


### PR DESCRIPTION
Presumably due to a copy-paste mistake, the condition on this flag was the opposite of what it should be.

You can see this function has 3 cases where it looks at compiler flags. The 3rd flag correctly uses `not(feature = "lsp")`, but the first flag doesn't.