### PR TITLE
AST parent pointer

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -75,6 +75,10 @@ pub struct CDDL<'a> {
   #[cfg_attr(target_arch = "wasm32", serde(skip))]
   #[doc(hidden)]
   pub comments: Option<Comments<'a>>,
+
+  #[cfg(feature = "ast-parent")]
+  #[serde(skip)]
+  pub parent: Option<()>, // always None
 }
 
 impl<'a> fmt::Display for CDDL<'a> {
@@ -214,6 +218,11 @@ impl<'a> From<Token<'a>> for Identifier<'a> {
   }
 }
 
+#[cfg(feature = "ast-parent")]
+pub enum RuleParent<'a> {
+  CDDL(&'a CDDL<'a>),
+}
+
 /// Type or group expression
 ///
 /// ```abnf
@@ -236,6 +245,10 @@ pub enum Rule<'a> {
     #[cfg_attr(target_arch = "wasm32", serde(skip))]
     #[doc(hidden)]
     comments_after_rule: Option<Comments<'a>>,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<RuleParent>,
   },
   /// Group expression
   Group {
@@ -249,6 +262,10 @@ pub enum Rule<'a> {
     #[cfg_attr(target_arch = "wasm32", serde(skip))]
     #[doc(hidden)]
     comments_after_rule: Option<Comments<'a>>,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<RuleParent>,
   },
 }
 
@@ -377,6 +394,11 @@ impl<'a> Rule<'a> {
   }
 }
 
+#[cfg(feature = "ast-parent")]
+pub enum TypeRuleParent<'a> {
+  Rule(&'a Rule<'a>)
+}
+
 /// Type expression
 ///
 /// ```abnf
@@ -403,6 +425,10 @@ pub struct TypeRule<'a> {
   #[cfg_attr(target_arch = "wasm32", serde(skip))]
   #[doc(hidden)]
   pub comments_after_assignt: Option<Comments<'a>>,
+
+  #[cfg(feature = "ast-parent")]
+  #[serde(skip)]
+  pub parent: Option<TypeRuleParent<'a>>,
 }
 
 impl<'a> fmt::Display for TypeRule<'a> {
@@ -435,6 +461,11 @@ impl<'a> fmt::Display for TypeRule<'a> {
   }
 }
 
+#[cfg(feature = "ast-parent")]
+pub enum GroupRuleParent<'a> {
+  Rule(&'a Rule<'a>)
+}
+
 /// Group expression
 ///
 /// ```abnf
@@ -461,6 +492,10 @@ pub struct GroupRule<'a> {
   #[cfg_attr(target_arch = "wasm32", serde(skip))]
   #[doc(hidden)]
   pub comments_after_assigng: Option<Comments<'a>>,
+
+  #[cfg(feature = "ast-parent")]
+  #[serde(skip)]
+  pub parent: Option<GroupRuleParent<'a>>,
 }
 
 impl<'a> fmt::Display for GroupRule<'a> {
@@ -493,6 +528,12 @@ impl<'a> fmt::Display for GroupRule<'a> {
   }
 }
 
+#[cfg(feature = "ast-parent")]
+pub enum GenericParamsParent<'a> {
+  TypeRule(&'a TypeRule<'a>),
+  GroupRule(&'a GroupRule<'a>),
+}
+
 /// Generic parameters
 ///
 /// ```abnf
@@ -506,6 +547,15 @@ pub struct GenericParams<'a> {
   /// Span
   #[cfg(feature = "ast-span")]
   pub span: Span,
+
+  #[cfg(feature = "ast-parent")]
+  #[serde(skip)]
+  pub parent: Option<GenericParamsParent<'a>>,
+}
+
+#[cfg(feature = "ast-parent")]
+pub enum GenericParamParent<'a> {
+  GenericParams(&'a GenericParams<'a>),
 }
 
 /// Generic parameter
@@ -523,6 +573,10 @@ pub struct GenericParam<'a> {
   #[cfg_attr(target_arch = "wasm32", serde(skip))]
   #[doc(hidden)]
   pub comments_after_ident: Option<Comments<'a>>,
+
+  #[cfg(feature = "ast-parent")]
+  #[serde(skip)]
+  pub parent: Option<GenericParamParent<'a>>,
 }
 
 impl<'a> fmt::Display for GenericParams<'a> {
@@ -552,6 +606,12 @@ impl<'a> fmt::Display for GenericParams<'a> {
   }
 }
 
+#[cfg(feature = "ast-parent")]
+pub enum GenericArgsParent<'a> {
+  Type2(&'a Type2<'a>),
+  TypeGroupnameEntry(&'a TypeGroupnameEntry<'a>)
+}
+
 /// Generic arguments
 ///
 /// ```abnf
@@ -565,6 +625,10 @@ pub struct GenericArgs<'a> {
   /// Span
   #[cfg(feature = "ast-span")]
   pub span: Span,
+
+  #[cfg(feature = "ast-parent")]
+  #[serde(skip)]
+  pub parent: Option<GenericArgsParent<'a>>,
 }
 
 impl<'a> GenericArgs<'a> {
@@ -576,6 +640,11 @@ impl<'a> GenericArgs<'a> {
       span: (0, 0, 0),
     }
   }
+}
+
+#[cfg(feature = "ast-parent")]
+pub enum GenericArgParent<'a> {
+  GenericArgs(&'a GenericArgs<'a>),
 }
 
 /// Generic argument
@@ -593,6 +662,10 @@ pub struct GenericArg<'a> {
   #[cfg_attr(target_arch = "wasm32", serde(skip))]
   #[doc(hidden)]
   pub comments_after_type: Option<Comments<'a>>,
+
+  #[cfg(feature = "ast-parent")]
+  #[serde(skip)]
+  pub parent: Option<GenericArgParent<'a>>,
 }
 
 impl<'a> fmt::Display for GenericArgs<'a> {
@@ -622,6 +695,13 @@ impl<'a> fmt::Display for GenericArgs<'a> {
   }
 }
 
+#[cfg(feature = "ast-parent")]
+pub enum TypeParent<'a> {
+  TypeRule(&'a TypeRule<'a>),
+  Type2(&'a Type2<'a>),
+  ValueMemberKeyEntry(&'a ValueMemberKeyEntry<'a>)
+}
+
 /// Type choices
 ///
 /// ```abnf
@@ -635,6 +715,10 @@ pub struct Type<'a> {
   /// Span
   #[cfg(feature = "ast-span")]
   pub span: Span,
+
+  #[cfg(feature = "ast-parent")]
+  #[serde(skip)]
+  pub parent: Option<TypeParent<'a>>,
 }
 
 impl<'a> Type<'a> {
@@ -660,6 +744,11 @@ impl<'a> Type<'a> {
   }
 }
 
+#[cfg(feature = "ast-parent")]
+pub enum TypeChoiceParent<'a> {
+  Type(&'a Type<'a>),
+}
+
 /// Type choice
 #[cfg_attr(target_arch = "wasm32", derive(Serialize))]
 #[derive(Debug, Clone, PartialEq)]
@@ -675,6 +764,10 @@ pub struct TypeChoice<'a> {
   #[cfg_attr(target_arch = "wasm32", serde(skip))]
   #[doc(hidden)]
   pub comments_after_type: Option<Comments<'a>>,
+
+  #[cfg(feature = "ast-parent")]
+  #[serde(skip)]
+  pub parent: Option<TypeChoiceParent<'a>>,
 }
 
 impl<'a> fmt::Display for Type<'a> {
@@ -761,6 +854,13 @@ impl<'a> Type<'a> {
   }
 }
 
+#[cfg(feature = "ast-parent")]
+pub enum Type1Parent<'a> {
+  Type(&'a Type<'a>),
+  GenericArg(&'a GenericArg<'a>),
+  MemberKey(&'a MemberKey<'a>),
+}
+
 /// Type with optional range or control operator
 ///
 /// ```abnf
@@ -781,6 +881,10 @@ pub struct Type1<'a> {
   #[cfg_attr(target_arch = "wasm32", serde(skip))]
   #[doc(hidden)]
   pub comments_after_type: Option<Comments<'a>>,
+
+  #[cfg(feature = "ast-parent")]
+  #[serde(skip)]
+  pub parent: Option<Type1Parent<'a>>,
 }
 
 impl<'a> From<Value<'a>> for Type1<'a> {
@@ -836,6 +940,11 @@ impl<'a> From<Value<'a>> for Type1<'a> {
   }
 }
 
+#[cfg(feature = "ast-parent")]
+pub enum OperatorParent<'a> {
+  Type1(&'a Type1<'a>),
+}
+
 #[cfg_attr(target_arch = "wasm32", derive(Serialize))]
 #[derive(Debug, Clone, PartialEq)]
 /// Range or control operator
@@ -853,6 +962,10 @@ pub struct Operator<'a> {
   #[cfg_attr(target_arch = "wasm32", serde(skip))]
   #[doc(hidden)]
   pub comments_after_operator: Option<Comments<'a>>,
+
+  #[cfg(feature = "ast-parent")]
+  #[serde(skip)]
+  pub parent: Option<OperatorParent<'a>>,
 }
 
 impl<'a> fmt::Display for Type1<'a> {
@@ -905,6 +1018,11 @@ impl<'a> fmt::Display for Type1<'a> {
   }
 }
 
+#[cfg(feature = "ast-parent")]
+pub enum RangeCtlOpParent<'a> {
+  Operator(&'a Operator<'a>),
+}
+
 /// Range or control operator
 ///
 /// ```abnf
@@ -921,6 +1039,10 @@ pub enum RangeCtlOp<'a> {
     /// Span
     #[cfg(feature = "ast-span")]
     span: Span,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<RangeCtlOpParent<'a>>,
   },
   /// Control operator
   CtlOp {
@@ -929,6 +1051,10 @@ pub enum RangeCtlOp<'a> {
     /// Span
     #[cfg(feature = "ast-span")]
     span: Span,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<RangeCtlOpParent<'a>>,
   },
 }
 
@@ -945,6 +1071,12 @@ impl<'a> fmt::Display for RangeCtlOp<'a> {
       RangeCtlOp::CtlOp { ctrl, .. } => write!(f, "{}", ctrl),
     }
   }
+}
+
+#[cfg(feature = "ast-parent")]
+pub enum Type2Parent<'a> {
+  Type1(&'a Type1<'a>),
+  Operator(&'a Operator<'a>),
 }
 
 /// Type
@@ -972,6 +1104,10 @@ pub enum Type2<'a> {
     /// Span
     #[cfg(feature = "ast-span")]
     span: Span,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<Type2Parent<'a>>,
   },
 
   /// Unsigned integer value
@@ -981,6 +1117,10 @@ pub enum Type2<'a> {
     /// Span
     #[cfg(feature = "ast-span")]
     span: Span,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<Type2Parent<'a>>,
   },
 
   /// Float value
@@ -990,6 +1130,10 @@ pub enum Type2<'a> {
     /// Span
     #[cfg(feature = "ast-span")]
     span: Span,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<Type2Parent<'a>>,
   },
 
   /// Text string value (enclosed by '"')
@@ -999,6 +1143,10 @@ pub enum Type2<'a> {
     /// Span
     #[cfg(feature = "ast-span")]
     span: Span,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<Type2Parent<'a>>,
   },
 
   /// UTF-8 encoded byte string (enclosed by '')
@@ -1008,6 +1156,10 @@ pub enum Type2<'a> {
     /// Span
     #[cfg(feature = "ast-span")]
     span: Span,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<Type2Parent<'a>>,
   },
 
   /// Base 16 encoded prefixed byte string
@@ -1017,6 +1169,10 @@ pub enum Type2<'a> {
     /// Span
     #[cfg(feature = "ast-span")]
     span: Span,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<Type2Parent<'a>>,
   },
 
   /// Base 64 encoded (URL safe) prefixed byte string
@@ -1026,6 +1182,10 @@ pub enum Type2<'a> {
     /// Span
     #[cfg(feature = "ast-span")]
     span: Span,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<Type2Parent<'a>>,
   },
 
   /// Type name identifier with optional generic arguments
@@ -1037,6 +1197,10 @@ pub enum Type2<'a> {
     /// Span
     #[cfg(feature = "ast-span")]
     span: Span,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<Type2Parent<'a>>,
   },
 
   /// Parenthesized type expression (for operator precedence)
@@ -1055,6 +1219,10 @@ pub enum Type2<'a> {
     #[cfg_attr(target_arch = "wasm32", serde(skip))]
     #[doc(hidden)]
     comments_after_type: Option<Comments<'a>>,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<Type2Parent<'a>>,
   },
 
   /// Map expression
@@ -1073,6 +1241,10 @@ pub enum Type2<'a> {
     #[cfg_attr(target_arch = "wasm32", serde(skip))]
     #[doc(hidden)]
     comments_after_group: Option<Comments<'a>>,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<Type2Parent<'a>>,
   },
 
   /// Array expression
@@ -1091,6 +1263,10 @@ pub enum Type2<'a> {
     #[cfg_attr(target_arch = "wasm32", serde(skip))]
     #[doc(hidden)]
     comments_after_group: Option<Comments<'a>>,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<Type2Parent<'a>>,
   },
 
   /// Unwrapped group
@@ -1107,6 +1283,10 @@ pub enum Type2<'a> {
     #[cfg_attr(target_arch = "wasm32", serde(skip))]
     #[doc(hidden)]
     comments: Option<Comments<'a>>,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<Type2Parent<'a>>,
   },
 
   /// Enumeration expression over an inline group
@@ -1129,6 +1309,10 @@ pub enum Type2<'a> {
     #[cfg_attr(target_arch = "wasm32", serde(skip))]
     #[doc(hidden)]
     comments_after_group: Option<Comments<'a>>,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<Type2Parent<'a>>,
   },
 
   /// Enumeration expression over previously defined group
@@ -1145,6 +1329,10 @@ pub enum Type2<'a> {
     #[cfg_attr(target_arch = "wasm32", serde(skip))]
     #[doc(hidden)]
     comments: Option<Comments<'a>>,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<Type2Parent<'a>>,
   },
 
   /// Tagged data item where the first element is an optional tag and the second
@@ -1166,6 +1354,10 @@ pub enum Type2<'a> {
     #[cfg_attr(target_arch = "wasm32", serde(skip))]
     #[doc(hidden)]
     comments_after_type: Option<Comments<'a>>,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<Type2Parent<'a>>,
   },
 
   /// Data item of a major type with optional data constraint
@@ -1177,15 +1369,22 @@ pub enum Type2<'a> {
     /// Span
     #[cfg(feature = "ast-span")]
     span: Span,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<Type2Parent<'a>>,
   },
 
   /// Any data item
-  #[cfg(feature = "ast-span")]
-  Any(Span),
-
-  /// Any data item
-  #[cfg(not(feature = "ast-span"))]
-  Any,
+  Any {
+    /// Span
+    #[cfg(feature = "ast-span")]
+    span: Span,
+    
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<Type2Parent<'a>>, 
+  },
 }
 
 #[allow(clippy::cognitive_complexity)]
@@ -1500,10 +1699,7 @@ impl<'a> fmt::Display for Type2<'a> {
 
         write!(f, "{}", mt)
       }
-      #[cfg(feature = "ast-span")]
-      Type2::Any(_) => write!(f, "#"),
-      #[cfg(not(feature = "ast-span"))]
-      Type2::Any => write!(f, "#"),
+      Type2::Any { .. } => write!(f, "#"),
     }
   }
 }
@@ -1817,6 +2013,12 @@ pub fn type_from_token(token: Token) -> Type {
   }
 }
 
+#[cfg(feature = "ast-parent")]
+pub enum GroupParent<'a> {
+  Type2(&'a Type2<'a>),
+  GroupEntry(&'a GroupEntry<'a>),
+}
+
 /// Group choices
 ///
 /// ```abnf
@@ -1831,6 +2033,10 @@ pub struct Group<'a> {
   /// Span
   #[cfg(feature = "ast-span")]
   pub span: Span,
+
+  #[cfg(feature = "ast-parent")]
+  #[serde(skip)]
+  pub parent: Option<GroupParent<'a>>,
 }
 
 impl<'a> From<GroupEntry<'a>> for Group<'a> {
@@ -1919,6 +2125,11 @@ impl<'a> fmt::Display for Group<'a> {
   }
 }
 
+#[cfg(feature = "ast-parent")]
+pub enum GroupChoiceParent<'a> {
+  Group(&'a Group<'a>),
+}
+
 /// Group entries
 ///
 /// ```abnf
@@ -1943,6 +2154,10 @@ pub struct GroupChoice<'a> {
   #[cfg_attr(target_arch = "wasm32", serde(skip))]
   #[doc(hidden)]
   pub comments_before_grpchoice: Option<Comments<'a>>,
+
+  #[cfg(feature = "ast-parent")]
+  #[serde(skip)]
+  pub parent: Option<GroupChoiceParent<'a>>,
 }
 
 impl<'a> GroupChoice<'a> {
@@ -2159,6 +2374,13 @@ impl<'a> fmt::Display for GroupChoice<'a> {
   }
 }
 
+#[cfg(feature = "ast-parent")]
+pub enum GroupEntryParent<'a> {
+  GroupChoice(&'a GroupChoice<'a>),
+  GroupRule(&'a GroupRule<'a>),
+}
+
+
 /// Group entry
 ///
 /// ```abnf
@@ -2186,6 +2408,10 @@ pub enum GroupEntry<'a> {
     #[cfg_attr(target_arch = "wasm32", serde(skip))]
     #[doc(hidden)]
     trailing_comments: Option<Comments<'a>>,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<GroupEntryParent<'a>>,
   },
 
   /// Group entry from a named group or type
@@ -2205,6 +2431,10 @@ pub enum GroupEntry<'a> {
     #[cfg_attr(target_arch = "wasm32", serde(skip))]
     #[doc(hidden)]
     trailing_comments: Option<Comments<'a>>,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<GroupEntryParent<'a>>,
   },
 
   /// Parenthesized group with optional occurrence indicator
@@ -2225,6 +2455,10 @@ pub enum GroupEntry<'a> {
     #[cfg_attr(target_arch = "wasm32", serde(skip))]
     #[doc(hidden)]
     comments_after_group: Option<Comments<'a>>,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<GroupEntryParent<'a>>,
   },
 }
 
@@ -2242,6 +2476,11 @@ impl<'a> GroupEntry<'a> {
       } if comments.any_non_newline()
     )
   }
+}
+
+#[cfg(feature = "ast-parent")]
+pub enum OptionalCommaParent<'a> {
+  GroupChoice(&'a GroupChoice<'a>),
 }
 
 /// Optional comma
@@ -2438,6 +2677,13 @@ impl<'a> fmt::Display for GroupEntry<'a> {
   }
 }
 
+#[cfg(feature = "ast-parent")]
+pub enum OccurrenceParent<'a> {
+  ValueMemberKeyEntry(&'a ValueMemberKeyEntry<'a>),
+  TypeGroupnameEntry(&'a TypeGroupnameEntry<'a>),
+  GroupEntry(&'a GroupEntry<'a>),
+}
+
 /// Occurrence indicator
 #[cfg_attr(target_arch = "wasm32", derive(Serialize))]
 #[derive(Debug, Clone, PartialEq)]
@@ -2452,6 +2698,10 @@ pub struct Occurrence<'a> {
 
   #[doc(hidden)]
   pub _a: PhantomData<&'a ()>,
+
+  #[cfg(feature = "ast-parent")]
+  #[serde(skip)]
+  pub parent: Option<OccurrenceParent<'a>>,
 }
 
 impl<'a> fmt::Display for Occurrence<'a> {
@@ -2470,6 +2720,11 @@ impl<'a> fmt::Display for Occurrence<'a> {
   }
 }
 
+#[cfg(feature = "ast-parent")]
+pub enum ValueMemberKeyEntryParent<'a> {
+  GroupEntry(&'a GroupEntry<'a>),
+}
+
 /// Value group entry type with optional occurrence indicator and optional
 /// member key
 ///
@@ -2486,6 +2741,10 @@ pub struct ValueMemberKeyEntry<'a> {
   /// Entry type
   #[cfg_attr(target_arch = "wasm32", serde(borrow))]
   pub entry_type: Type<'a>,
+
+  #[cfg(feature = "ast-parent")]
+  #[serde(skip)]
+  pub parent: Option<ValueMemberKeyEntryParent<'a>>,
 }
 
 impl<'a> fmt::Display for ValueMemberKeyEntry<'a> {
@@ -2506,6 +2765,11 @@ impl<'a> fmt::Display for ValueMemberKeyEntry<'a> {
   }
 }
 
+#[cfg(feature = "ast-parent")]
+pub enum TypeGroupnameEntryParent<'a> {
+  GroupEntry(&'a GroupEntry<'a>),
+}
+
 /// Group entry from a named type or group
 #[cfg_attr(target_arch = "wasm32", derive(Serialize))]
 #[derive(Debug, Clone, PartialEq)]
@@ -2517,6 +2781,10 @@ pub struct TypeGroupnameEntry<'a> {
   pub name: Identifier<'a>,
   /// Optional generic arguments
   pub generic_args: Option<GenericArgs<'a>>,
+
+  #[cfg(feature = "ast-parent")]
+  #[serde(skip)]
+  pub parent: Option<TypeGroupnameEntryParent<'a>>,
 }
 
 impl<'a> fmt::Display for TypeGroupnameEntry<'a> {
@@ -2535,6 +2803,11 @@ impl<'a> fmt::Display for TypeGroupnameEntry<'a> {
 
     write!(f, "{}", tge_str)
   }
+}
+
+#[cfg(feature = "ast-parent")]
+pub enum MemberKeyParent<'a> {
+  ValueMemberKeyEntry(&'a ValueMemberKeyEntry<'a>),
 }
 
 /// Member key
@@ -2569,6 +2842,10 @@ pub enum MemberKey<'a> {
     #[cfg_attr(target_arch = "wasm32", serde(skip))]
     #[doc(hidden)]
     comments_after_arrowmap: Option<Comments<'a>>,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<MemberKeyParent<'a>>,
   },
 
   /// Bareword string type
@@ -2588,6 +2865,10 @@ pub enum MemberKey<'a> {
     #[cfg_attr(target_arch = "wasm32", serde(skip))]
     #[doc(hidden)]
     comments_after_colon: Option<Comments<'a>>,
+    
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<MemberKeyParent<'a>>,
   },
 
   /// Value type
@@ -2607,6 +2888,10 @@ pub enum MemberKey<'a> {
     #[cfg_attr(target_arch = "wasm32", serde(skip))]
     #[doc(hidden)]
     comments_after_colon: Option<Comments<'a>>,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<MemberKeyParent<'a>>,
   },
 
   #[cfg_attr(target_arch = "wasm32", serde(skip))]
@@ -2617,6 +2902,10 @@ pub enum MemberKey<'a> {
     comments_before_type_or_group: Option<Comments<'a>>,
     #[cfg(feature = "ast-comments")]
     comments_after_type_or_group: Option<Comments<'a>>,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<MemberKeyParent<'a>>,
   },
 }
 
@@ -2778,6 +3067,11 @@ impl<'a> fmt::Display for MemberKey<'a> {
   }
 }
 
+#[cfg(feature = "ast-parent")]
+pub enum OccurParent<'a> {
+  Occurrence(&'a Occurrence<'a>),
+}
+
 /// Occurrence indicator
 /// ```abnf
 /// occur = [uint] "*" [uint]
@@ -2797,40 +3091,50 @@ pub enum Occur {
     /// Span
     #[cfg(feature = "ast-span")]
     span: Span,
+
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<OccurParent<'a>>,
   },
 
   /// Occurrence indicator in the form *, allowing zero or more occurrences
-  #[cfg(feature = "ast-span")]
-  ZeroOrMore(Span),
+  ZeroOrMore {
+    /// Span
+    #[cfg(feature = "ast-span")]
+    span: Span,
 
-  /// Occurrence indicator in the form *, allowing zero or more occurrences
-  #[cfg(not(feature = "ast-span"))]
-  ZeroOrMore,
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<OccurParent<'a>>,
+  },
 
   /// Occurrence indicator in the form +, allowing one or more occurrences
-  #[cfg(feature = "ast-span")]
-  OneOrMore(Span),
+  OneOrMore {
+    /// Span
+    #[cfg(feature = "ast-span")]
+    span: Span,
 
-  #[cfg(not(feature = "ast-span"))]
-  /// Occurrence indicator in the form +, allowing one or more occurrences
-  OneOrMore,
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<OccurParent<'a>>,
+  },
 
   /// Occurrence indicator in the form ?, allowing an optional occurrence
-  #[cfg(feature = "ast-span")]
-  Optional(Span),
+  Optional {
+    /// Span
+    #[cfg(feature = "ast-span")]
+    span: Span,
 
-  /// Occurrence indicator in the form ?, allowing an optional occurrence
-  #[cfg(not(feature = "ast-span"))]
-  Optional,
+    #[cfg(feature = "ast-parent")]
+    #[serde(skip)]
+    pub parent: Option<OccurParent<'a>>,
+  },
 }
 
 impl fmt::Display for Occur {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
-      #[cfg(feature = "ast-span")]
-      Occur::ZeroOrMore(_) => write!(f, "*"),
-      #[cfg(not(feature = "ast-span"))]
-      Occur::ZeroOrMore => write!(f, "*"),
+      Occur::ZeroOrMore { .. } => write!(f, "*"),
       Occur::Exact { lower, upper, .. } => {
         if let Some(li) = lower {
           if let Some(ui) = upper {
@@ -2846,14 +3150,8 @@ impl fmt::Display for Occur {
 
         write!(f, "*")
       }
-      #[cfg(feature = "ast-span")]
-      Occur::OneOrMore(_) => write!(f, "+"),
-      #[cfg(not(feature = "ast-span"))]
-      Occur::OneOrMore => write!(f, "+"),
-      #[cfg(feature = "ast-span")]
-      Occur::Optional(_) => write!(f, "?"),
-      #[cfg(not(feature = "ast-span"))]
-      Occur::Optional => write!(f, "?"),
+      Occur::OneOrMore { .. } => write!(f, "+"),
+      Occur::Optional { .. } => write!(f, "?"),
     }
   }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1716,11 +1716,11 @@ impl<'a> Parser<'a> {
             ),
           }),
           #[cfg(feature = "ast-span")]
-          _ => Ok(Type2::Any((
+          _ => Ok(Type2::Any { span: (
             begin_type2_range,
             self.lexer_position.range.1,
             begin_type2_line,
-          ))),
+          )}),
           #[cfg(not(feature = "ast-span"))]
           _ => Ok(Type2::Any),
         }
@@ -3160,11 +3160,11 @@ impl<'a> Parser<'a> {
 
         Ok(Some(Occurrence {
           #[cfg(feature = "ast-span")]
-          occur: Occur::Optional((
+          occur: Occur::Optional { span: (
             self.parser_position.range.0,
             self.parser_position.range.1,
             self.parser_position.line,
-          )),
+          )},
           #[cfg(not(feature = "ast-span"))]
           occur: Occur::Optional,
           #[cfg(feature = "ast-comments")]
@@ -3187,11 +3187,11 @@ impl<'a> Parser<'a> {
 
         Ok(Some(Occurrence {
           #[cfg(feature = "ast-span")]
-          occur: Occur::OneOrMore((
+          occur: Occur::OneOrMore { span: (
             self.parser_position.range.0,
             self.parser_position.range.1,
             self.parser_position.line,
-          )),
+          )},
           #[cfg(not(feature = "ast-span"))]
           occur: Occur::OneOrMore,
           #[cfg(feature = "ast-comments")]
@@ -3221,11 +3221,11 @@ impl<'a> Parser<'a> {
           #[cfg(feature = "ast-span")]
           {
             self.parser_position.range = self.lexer_position.range;
-            Occur::ZeroOrMore((
+            Occur::ZeroOrMore { span: (
               self.parser_position.range.0,
               self.parser_position.range.1,
               self.parser_position.line,
-            ))
+            )}
           }
 
           #[cfg(not(feature = "ast-span"))]

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -671,7 +671,7 @@ mod tests {
         value: 9.9,
         span: (0, 3, 1),
       },
-      Type2::Any((0, 1, 1)),
+      Type2::Any { span: (0, 1, 1) },
       Type2::Array {
         group: Group {
           group_choices: vec![GroupChoice {
@@ -720,7 +720,7 @@ mod tests {
               GroupEntry::TypeGroupname {
                 ge: TypeGroupnameEntry {
                   occur: Some(Occurrence {
-                    occur: Occur::OneOrMore((1, 2, 1)),
+                    occur: Occur::OneOrMore { span: (1, 2, 1) },
                     comments: None,
                     _a: PhantomData::default(),
                   }),
@@ -801,7 +801,7 @@ mod tests {
               GroupEntry::ValueMemberKey {
                 ge: Box::from(ValueMemberKeyEntry {
                   occur: Some(Occurrence {
-                    occur: Occur::Optional((2, 3, 1)),
+                    occur: Occur::Optional { span: (2, 3, 1) },
                     comments: None,
                     _a: PhantomData::default(),
                   }),
@@ -1029,7 +1029,7 @@ mod tests {
                                   GroupEntry::TypeGroupname {
                                     ge: TypeGroupnameEntry {
                                       occur: Some(Occurrence {
-                                        occur: Occur::ZeroOrMore((3, 4, 1)),
+                                        occur: Occur::ZeroOrMore { span: (3, 4, 1) },
                                         comments: None,
                                         _a: PhantomData::default(),
                                       }),
@@ -1094,7 +1094,7 @@ mod tests {
                                   GroupEntry::TypeGroupname {
                                     ge: TypeGroupnameEntry {
                                       occur: Some(Occurrence {
-                                        occur: Occur::ZeroOrMore((19, 20, 1)),
+                                        occur: Occur::ZeroOrMore { span: (19, 20, 1) },
                                         comments: None,
                                         _a: PhantomData::default(),
                                       }),
@@ -1386,7 +1386,7 @@ mod tests {
       GroupEntry::ValueMemberKey {
         ge: Box::from(ValueMemberKeyEntry {
           occur: Some(Occurrence {
-            occur: Occur::ZeroOrMore((0, 1, 1)),
+            occur: Occur::ZeroOrMore { span: (0, 1, 1) },
             comments: None,
             _a: PhantomData::default(),
           }),
@@ -1488,7 +1488,7 @@ mod tests {
       GroupEntry::ValueMemberKey {
         ge: Box::from(ValueMemberKeyEntry {
           occur: Some(Occurrence {
-            occur: Occur::Optional((0, 1, 1)),
+            occur: Occur::Optional { span: (0, 1, 1) },
             comments: None,
             _a: PhantomData::default(),
           }),
@@ -1583,7 +1583,7 @@ mod tests {
       GroupEntry::ValueMemberKey {
         ge: Box::from(ValueMemberKeyEntry {
           occur: Some(Occurrence {
-            occur: Occur::ZeroOrMore((0, 1, 1)),
+            occur: Occur::ZeroOrMore { span: (0, 1, 1) },
             comments: None,
             _a: PhantomData::default(),
           }),
@@ -1819,12 +1819,12 @@ mod tests {
         _a: PhantomData::default(),
       },
       Occurrence {
-        occur: Occur::ZeroOrMore((0, 1, 1)),
+        occur: Occur::ZeroOrMore { span: (0, 1, 1) },
         comments: None,
         _a: PhantomData::default(),
       },
       Occurrence {
-        occur: Occur::OneOrMore((0, 1, 1)),
+        occur: Occur::OneOrMore { span: (0, 1, 1) },
         comments: None,
         _a: PhantomData::default(),
       },
@@ -1847,7 +1847,7 @@ mod tests {
         _a: PhantomData::default(),
       },
       Occurrence {
-        occur: Occur::Optional((0, 1, 1)),
+        occur: Occur::Optional { span: (0, 1, 1) },
         comments: None,
         _a: PhantomData::default(),
       },

--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -51,7 +51,7 @@ impl<T: std::fmt::Debug> fmt::Display for Error<T> {
       Error::CBORParsing(error) => write!(f, "error parsing cbor: {}", error),
       Error::JSONParsing(error) => write!(f, "error parsing json string: {}", error),
       Error::CDDLParsing(error) => write!(f, "error parsing CDDL: {}", error),
-      Error::UTF8Parsing(error) => write!(f, "error pasing utf8: {}", error),
+      Error::UTF8Parsing(error) => write!(f, "error parsing utf8: {}", error),
     }
   }
 }
@@ -1178,7 +1178,7 @@ where
         self.visit_type2(target)?;
         if self.errors.len() != error_count {
           #[cfg(feature = "ast-span")]
-          if let Some(Occur::Optional(_)) = self.occurrence.take() {
+          if let Some(Occur::Optional { .. }) = self.occurrence.take() {
             self.add_error(format!(
               "expected default value {}, got {:?}",
               controller, self.cbor
@@ -2164,7 +2164,7 @@ where
         }
       },
       #[cfg(feature = "ast-span")]
-      Type2::Any(_) => Ok(()),
+      Type2::Any { .. } => Ok(()),
       #[cfg(not(feature = "ast-span"))]
       Type2::Any => Ok(()),
       _ => {
@@ -2294,8 +2294,8 @@ where
       Value::Map(m) => {
         if let Some(occur) = &self.occurrence {
           #[cfg(feature = "ast-span")]
-          if let Occur::ZeroOrMore(_) | Occur::OneOrMore(_) = occur {
-            if let Occur::OneOrMore(_) = occur {
+          if let Occur::ZeroOrMore { .. } | Occur::OneOrMore { .. } = occur {
+            if let Occur::OneOrMore { .. } = occur {
               if m.is_empty() {
                 self.add_error(format!(
                   "map cannot be empty, one or more entries with key type {} required",
@@ -3326,7 +3326,7 @@ where
           self.cbor_location.push_str(&format!("/{}", value));
 
           None
-        } else if let Some(Occur::Optional(_)) | Some(Occur::ZeroOrMore(_)) =
+        } else if let Some(Occur::Optional { .. }) | Some(Occur::ZeroOrMore { .. }) =
           &self.occurrence.take()
         {
           self.advance_to_next_entry = true;

--- a/src/validator/control.rs
+++ b/src/validator/control.rs
@@ -599,7 +599,7 @@ fn dedent_bytes(source: &[u8], is_utf8_byte_string: bool) -> Result<Vec<u8>, Str
 }
 
 /// Numeric addition of target and controller. The Vec return type is to
-/// accomodate more than one type choice in the controller
+/// accommodate more than one type choice in the controller
 pub fn plus_operation<'a>(
   cddl: &CDDL,
   target: &Type2,

--- a/src/validator/json.rs
+++ b/src/validator/json.rs
@@ -499,7 +499,7 @@ impl<'a> JSONValidator<'a> {
           self.json_location.push_str(&format!("/{}", t));
 
           return Ok(());
-        } else if let Some(Occur::Optional(_)) | Some(Occur::ZeroOrMore(_)) =
+        } else if let Some(Occur::Optional { .. }) | Some(Occur::ZeroOrMore { .. }) =
           &self.occurrence.take()
         {
           self.advance_to_next_entry = true;
@@ -1266,7 +1266,7 @@ impl<'a> Visitor<'a, Error> for JSONValidator<'a> {
         self.visit_type2(target)?;
         if self.errors.len() != error_count {
           #[cfg(feature = "ast-span")]
-          if let Some(Occur::Optional(_)) = self.occurrence.take() {
+          if let Some(Occur::Optional { .. }) = self.occurrence.take() {
             self.add_error(format!(
               "expected default value {}, got {}",
               controller, self.json
@@ -1775,7 +1775,7 @@ impl<'a> Visitor<'a, Error> for JSONValidator<'a> {
         Ok(())
       }
       #[cfg(feature = "ast-span")]
-      Type2::Any(_) => Ok(()),
+      Type2::Any { .. } => Ok(()),
       #[cfg(not(feature = "ast-span"))]
       Type2::Any => Ok(()),
       _ => {
@@ -1897,8 +1897,8 @@ impl<'a> Visitor<'a, Error> for JSONValidator<'a> {
       Value::Object(o) => {
         if let Some(occur) = &self.occurrence {
           #[cfg(feature = "ast-span")]
-          if let Occur::ZeroOrMore(_) | Occur::OneOrMore(_) = occur {
-            if let Occur::OneOrMore(_) = occur {
+          if let Occur::ZeroOrMore { .. } | Occur::OneOrMore { .. } = occur {
+            if let Occur::OneOrMore { .. } = occur {
               if o.is_empty() {
                 self.add_error(format!(
                   "object cannot be empty, one or more entries with key type {} required",

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -5,6 +5,9 @@ pub mod cbor;
 /// JSON validation implementation
 pub mod json;
 
+/// parent visitor implementation
+mod parent_visitor;
+
 mod control;
 
 use crate::{
@@ -831,7 +834,7 @@ pub fn validate_array_occurrence<'de, T: Deserialize<'de>>(
 ) -> std::result::Result<(bool, bool), Vec<String>> {
   let mut iter_items = false;
   #[cfg(feature = "ast-span")]
-  let allow_empty_array = matches!(occurrence, Some(Occur::Optional(_)));
+  let allow_empty_array = matches!(occurrence, Some(Occur::Optional { .. }));
   #[cfg(not(feature = "ast-span"))]
   let allow_empty_array = matches!(occurrence, Some(Occur::Optional));
 
@@ -839,11 +842,11 @@ pub fn validate_array_occurrence<'de, T: Deserialize<'de>>(
 
   match occurrence {
     #[cfg(feature = "ast-span")]
-    Some(Occur::ZeroOrMore(_)) => iter_items = true,
+    Some(Occur::ZeroOrMore { .. }) => iter_items = true,
     #[cfg(not(feature = "ast-span"))]
     Some(Occur::ZeroOrMore) => iter_items = true,
     #[cfg(feature = "ast-span")]
-    Some(Occur::OneOrMore(_)) => {
+    Some(Occur::OneOrMore { .. }) => {
       if values.is_empty() {
         errors.push("array must have at least one item".to_string());
       } else {
@@ -882,7 +885,7 @@ pub fn validate_array_occurrence<'de, T: Deserialize<'de>>(
       iter_items = true;
     }
     #[cfg(feature = "ast-span")]
-    Some(Occur::Optional(_)) => {
+    Some(Occur::Optional { .. }) => {
       if values.len() > 1 {
         errors.push("array must have 0 or 1 items".to_string());
       }
@@ -1014,11 +1017,11 @@ pub fn validate_entry_count(valid_entry_counts: &[EntryCount], num_entries: usiz
     num_entries == ec.count as usize
       || match ec.entry_occurrence {
         #[cfg(feature = "ast-span")]
-        Some(Occur::ZeroOrMore(_)) | Some(Occur::Optional(_)) => true,
+        Some(Occur::ZeroOrMore { .. }) | Some(Occur::Optional { .. }) => true,
         #[cfg(not(feature = "ast-span"))]
         Some(Occur::ZeroOrMore) | Some(Occur::Optional) => true,
         #[cfg(feature = "ast-span")]
-        Some(Occur::OneOrMore(_)) if num_entries > 0 => true,
+        Some(Occur::OneOrMore { .. } ) if num_entries > 0 => true,
         #[cfg(not(feature = "ast-span"))]
         Some(Occur::OneOrMore) if num_entries > 0 => true,
         Some(Occur::Exact { lower, upper, .. }) => {

--- a/src/validator/parent_visitor.rs
+++ b/src/validator/parent_visitor.rs
@@ -1,0 +1,213 @@
+use crate::{
+    ast::*,
+    token::{self, Token},
+    visitor::{self, *}, validator::group_choice_alternates_from_ident,
+  };
+  
+  use std::{borrow::Cow, collections::HashMap, convert::TryFrom, fmt};
+  
+  /// validation Result
+  pub type Result = std::result::Result<(), Error>;
+  
+  /// validation error
+  #[derive(Debug)]
+  pub enum Error {
+    /// Zero or more validation errors
+    Validation(Vec<ValidationError>),
+    /// CDDL parsing error
+    CDDLParsing(String),
+    /// UTF8 parsing error,
+    UTF8Parsing(std::str::Utf8Error),
+    /// Disabled feature
+    DisabledFeature(String),
+  }
+  
+  impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+      match self {
+        Error::Validation(errors) => {
+          let mut error_str = String::new();
+          for e in errors.iter() {
+            error_str.push_str(&format!("{}\n", e));
+          }
+          write!(f, "{}", error_str)
+        }
+        Error::CDDLParsing(error) => write!(f, "error parsing CDDL: {}", error),
+        Error::UTF8Parsing(error) => write!(f, "error pasing utf8: {}", error),
+        Error::DisabledFeature(feature) => write!(f, "feature {} is not enabled", feature),
+      }
+    }
+  }
+  
+  impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+      match self {
+        _ => None,
+      }
+    }
+  }
+  
+  impl Error {
+    fn from_validator(pv: &ParentValidator, reason: String) -> Self {
+      Error::Validation(vec![ValidationError {
+        cddl_location: pv.cddl_location.clone(),
+        reason,
+      }])
+    }
+  }
+  
+  /// JSON validation error
+  #[derive(Clone, Debug)]
+  pub struct ValidationError {
+    /// Error message
+    pub reason: String,
+    /// Location in CDDL where error occurred
+    pub cddl_location: String,
+  }
+  
+  impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+      let mut error_str = String::from("error validating");
+      write!(
+        f,
+        "{} at location {}: {}",
+        error_str, self.cddl_location, self.reason
+      )
+    }
+  }
+  
+  impl std::error::Error for ValidationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+      None
+    }
+  }
+  
+  impl ValidationError {
+    fn from_validator(pv: &ParentValidator, reason: String) -> Self {
+      ValidationError {
+        cddl_location: pv.cddl_location.clone(),
+        reason,
+      }
+    }
+  }
+  
+  type Rule = u16; // TODO
+  
+  /// validator type
+  #[derive(Clone)]
+  pub struct ParentValidator<'a> {
+    cddl: &'a CDDL<'a>,
+    stack: Vec<Rule>,
+    errors: Vec<ValidationError>,
+    cddl_location: String,
+  }
+  
+  impl<'a> ParentValidator<'a> {
+    pub fn new(cddl: &'a CDDL<'a>) -> Self {
+      ParentValidator {
+        cddl,
+        stack: Vec::default(),
+        errors: Vec::default(),
+        cddl_location: String::new(),
+      }
+    }
+  }
+  
+  impl<'a> Visitor<'a, Error> for ParentValidator<'a> {
+    fn visit_type_rule(&mut self, tr: &TypeRule<'a>) -> visitor::Result<Error> {
+      self.visit_gener
+      Ok(())
+    }
+  
+    fn visit_group_rule(&mut self, gr: &GroupRule<'a>) -> visitor::Result<Error> {
+  
+  
+      Ok(())
+    }
+  
+    fn visit_type(&mut self, t: &Type<'a>) -> visitor::Result<Error> {
+      Ok(())
+    }
+  
+    fn visit_group(&mut self, g: &Group<'a>) -> visitor::Result<Error> {
+  
+      Ok(())
+    }
+  
+    fn visit_group_choice(&mut self, gc: &GroupChoice<'a>) -> visitor::Result<Error> {
+      
+  
+      Ok(())
+    }
+  
+    fn visit_range(
+      &mut self,
+      lower: &Type2,
+      upper: &Type2,
+      is_inclusive: bool,
+    ) -> visitor::Result<Error> {
+      // note: this is a case of type1
+      Ok(())
+    }
+  
+    fn visit_control_operator(
+      &mut self,
+      target: &Type2<'a>,
+      ctrl: &str,
+      controller: &Type2<'a>,
+    ) -> visitor::Result<Error> {
+      // note: this is a case of type1
+  
+      Ok(())
+    }
+  
+    fn visit_type2(&mut self, t2: &Type2<'a>) -> visitor::Result<Error> {
+      Ok(())
+    }
+  
+    fn visit_identifier(&mut self, ident: &Identifier<'a>) -> visitor::Result<Error> {
+      Ok(())
+    }
+  
+    fn visit_value_member_key_entry(
+      &mut self,
+      entry: &ValueMemberKeyEntry<'a>,
+    ) -> visitor::Result<Error> {
+      // note: this is a case of grpent
+      Ok(())
+    }
+  
+    fn visit_type_groupname_entry(
+      &mut self,
+      entry: &TypeGroupnameEntry<'a>,
+    ) -> visitor::Result<Error> {
+      // note: this is a case of grpent
+      Ok(())
+    }
+  
+    fn visit_memberkey(&mut self, mk: &MemberKey<'a>) -> visitor::Result<Error> {
+  
+      Ok(())
+    }
+  
+    fn visit_value(&mut self, value: &token::Value<'a>) -> visitor::Result<Error> {
+  
+      Ok(())
+    }
+  
+    fn visit_occurrence(&mut self, o: &Occurrence) -> visitor::Result<Error> {
+  
+      Ok(())
+    }
+  }
+  
+  #[cfg(test)]
+  #[cfg(not(target_arch = "wasm32"))]
+  mod tests {
+    #![allow(unused_imports)]
+  
+    use super::*;
+  
+    
+  }
+  


### PR DESCRIPTION
# Problem

Right now, there is no good way to go up the tree given a node in the AST. This kind of operation can be done outside the library, but it's hacky so I'd prefer to just add it as an optional feature here.

# Proposed solution

Add a `ast-parent` flag that when set, building the AST will do an additional pass after the AST is completed to fill in the parent pointers.

# Related work

Note that unfortunately this change will have a very large conflict with #96. Unfortunately that PR is still a draft so there was no good way to build my work on top of that PR.

# Issues 

Note that the visitor pattern is for some reason missing a few cases:

```
visit_cddl
visit_generic_args
visit_generic_params
visit_group_entry
visit_operator
visit_rule
```

TODO:
- [ ] add missing visitor calls
- [ ] Finish coding parent visitor
- [ ] Run parent visitor to fill the AST if the compiler flag is set
- [ ] Write tests
- [ ] Check for build errors on different compiler flags (ex: if ast-span is off)