### PR TITLE
Add a CI general argument to trigger failure when files are not found

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -189,7 +189,12 @@ fn main() -> Result<(), Box<dyn Error>> {
               info!("Validation of {:?} is successful", p);
             }
             Err(e) => {
-              error!(cli.ci, "Validation of {:?} failed: {}", p, e.to_string().trim_end());
+              error!(
+                cli.ci,
+                "Validation of {:?} failed: {}",
+                p,
+                e.to_string().trim_end()
+              );
             }
           }
         }
@@ -217,7 +222,12 @@ fn main() -> Result<(), Box<dyn Error>> {
               info!("Validation of {:?} is successful", p);
             }
             Err(e) => {
-              error!(cli.ci, "Validation of {:?} failed: {}", p, e.to_string().trim_end());
+              error!(
+                cli.ci,
+                "Validation of {:?} failed: {}",
+                p,
+                e.to_string().trim_end()
+              );
             }
           }
         }
@@ -240,7 +250,11 @@ fn main() -> Result<(), Box<dyn Error>> {
               info!("Validation from stdin is successful");
             }
             Err(e) => {
-              error!(cli.ci, "Validation from stdin failed: {}", e.to_string().trim_end());
+              error!(
+                cli.ci,
+                "Validation from stdin failed: {}",
+                e.to_string().trim_end()
+              );
             }
           }
         } else {
@@ -254,7 +268,11 @@ fn main() -> Result<(), Box<dyn Error>> {
               info!("Validation from stdin is successful");
             }
             Err(e) => {
-              error!(cli.ci, "Validation from stdin failed: {}", e.to_string().trim_end());
+              error!(
+                cli.ci,
+                "Validation from stdin failed: {}",
+                e.to_string().trim_end()
+              );
             }
           }
         }

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -23,6 +23,10 @@ use std::{
 #[derive(Parser)]
 #[clap(author, version, about = "Tool for verifying conformance of CDDL definitions against RFC 8610 and for validating JSON documents and CBOR binary files", long_about = None)]
 struct Cli {
+  /// Enable CI mode, failing if files cannot be found or other edge cases.
+  #[clap(long)]
+  ci: bool,
+
   #[clap(subcommand)]
   command: Commands,
 }
@@ -78,6 +82,15 @@ struct Validate {
   stdin: bool,
 }
 
+macro_rules! error {
+    ($ci: expr, $($args: tt)+ ) => {
+      log::error!($($args)+);
+      if $ci {
+        return Err(format!($($args)+).into());
+      }
+    };
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
   TermLogger::init(
     LevelFilter::Info,
@@ -94,8 +107,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     Commands::CompileCddl { file } => {
       let p = Path::new(file);
       if !p.exists() {
-        error!("CDDL document {:?} does not exist", p);
-
+        error!(cli.ci, "CDDL document {:?} does not exist", p);
         return Ok(());
       }
 
@@ -107,7 +119,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     Commands::CompileJson { file } => {
       let p = Path::new(file);
       if !p.exists() {
-        error!("JSON document {:?} does not exist", p);
+        error!(cli.ci, "JSON document {:?} does not exist", p);
 
         return Ok(());
       }
@@ -142,7 +154,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
       let p = Path::new(&validate.cddl);
       if !p.exists() {
-        error!("CDDL document {:?} does not exist", p);
+        error!(cli.ci, "CDDL document {:?} does not exist", p);
 
         return Ok(());
       }
@@ -158,7 +170,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         for file in files {
           let p = Path::new(file);
           if !p.exists() {
-            error!("File {:?} does not exist", p);
+            error!(cli.ci, "File {:?} does not exist", p);
 
             continue;
           }
@@ -177,7 +189,7 @@ fn main() -> Result<(), Box<dyn Error>> {
               info!("Validation of {:?} is successful", p);
             }
             Err(e) => {
-              error!("Validation of {:?} failed: {}", p, e.to_string().trim_end());
+              error!(cli.ci, "Validation of {:?} failed: {}", p, e.to_string().trim_end());
             }
           }
         }
@@ -187,7 +199,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         for file in files {
           let p = Path::new(file);
           if !p.exists() {
-            error!("CBOR binary file {:?} does not exist", p);
+            error!(cli.ci, "CBOR binary file {:?} does not exist", p);
 
             continue;
           }
@@ -205,7 +217,7 @@ fn main() -> Result<(), Box<dyn Error>> {
               info!("Validation of {:?} is successful", p);
             }
             Err(e) => {
-              error!("Validation of {:?} failed: {}", p, e.to_string().trim_end());
+              error!(cli.ci, "Validation of {:?} failed: {}", p, e.to_string().trim_end());
             }
           }
         }
@@ -228,7 +240,7 @@ fn main() -> Result<(), Box<dyn Error>> {
               info!("Validation from stdin is successful");
             }
             Err(e) => {
-              error!("Validation from stdin failed: {}", e.to_string().trim_end());
+              error!(cli.ci, "Validation from stdin failed: {}", e.to_string().trim_end());
             }
           }
         } else {
@@ -242,7 +254,7 @@ fn main() -> Result<(), Box<dyn Error>> {
               info!("Validation from stdin is successful");
             }
             Err(e) => {
-              error!("Validation from stdin failed: {}", e.to_string().trim_end());
+              error!(cli.ci, "Validation from stdin failed: {}", e.to_string().trim_end());
             }
           }
         }


### PR DESCRIPTION
In CI, we had some refactor that moved the files, and CI never failed as the CDDL CLI still returns status 0 when a file is not found.

This addresses it in a backward compatible way by adding a flag that will fail the process (status code 1) if an error happens that would normally not fail (report error in the logs).