### PR TITLE
change error message on mismatched socket and assignment types

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -169,11 +169,11 @@ impl From<MsgType> for ErrorMsg {
         extended: None,
       },
       MsgType::TypeSocketNamesMustBeTypeAugmentations => ErrorMsg {
-        short: "all plugs for type socket names must be augmentations using '/='".into(),
+        short: "all plugs for type socket names must be augmentations using '/=' (alternatively change the definition to be a group socket)".into(),
         extended: None,
       },
       MsgType::GroupSocketNamesMustBeGroupAugmentations => ErrorMsg {
-        short: "all plugs for group socket names must be augmentations using '//='".into(),
+        short: "all plugs for group socket names must be augmentations using '//=' (alternatively change the definition to be a type socket)".into(),
         extended: None,
       },
       MsgType::InvalidHexFloat => ErrorMsg {


### PR DESCRIPTION
Old error assumed socket type was right. New error adds reminder that socket type may be what needs to change.