### PR TITLE
Implement basic deferred parsing

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -329,6 +329,13 @@ pub enum Rule<'a> {
     #[doc(hidden)]
     comments_after_rule: Option<Comments<'a>>,
   },
+  /// Unknown expression
+  Unknown {
+    #[doc(hidden)]
+    rule: Box<Rule<'a>>,
+    #[doc(hidden)]
+    range: (usize, usize),
+  },
 }
 
 impl<'a> Rule<'a> {
@@ -338,6 +345,7 @@ impl<'a> Rule<'a> {
     match self {
       Rule::Type { span, .. } => *span,
       Rule::Group { span, .. } => *span,
+      Rule::Unknown { rule, .. } => rule.span(),
     }
   }
 
@@ -433,6 +441,7 @@ impl<'a> fmt::Display for Rule<'a> {
 
         write!(f, "{}", rule_str)
       }
+      Rule::Unknown { rule, .. } => rule.fmt(f),
     }
   }
 }
@@ -443,6 +452,7 @@ impl<'a> Rule<'a> {
     match self {
       Rule::Type { rule, .. } => rule.name.to_string(),
       Rule::Group { rule, .. } => rule.name.to_string(),
+      Rule::Unknown { rule, .. } => rule.name(),
     }
   }
 
@@ -452,6 +462,7 @@ impl<'a> Rule<'a> {
     match self {
       Rule::Type { rule, .. } => rule.is_type_choice_alternate,
       Rule::Group { rule, .. } => rule.is_group_choice_alternate,
+      Rule::Unknown { rule, .. } => rule.is_choice_alternate(),
     }
   }
 }

--- a/src/ast/parent.rs
+++ b/src/ast/parent.rs
@@ -235,6 +235,9 @@ impl<'a, 'b: 'a> Visitor<'a, 'b, Error> for ParentVisitor<'a, 'b> {
 
         self.visit_type_rule(rule)?;
       }
+      Rule::Unknown { rule, .. } => {
+        self.visit_rule(rule)?;
+      }
     }
 
     Ok(())
@@ -910,6 +913,7 @@ mod tests {
   fn generic_args_parent_is_type2() -> Result<()> {
     let cddl = cddl_from_str(
       r#"
+        message<name, value> = {}
         messages = message<"reboot", "now"> / message<"sleep", 1..100>
       "#,
       true,
@@ -936,6 +940,7 @@ mod tests {
   fn generic_arg_parent_is_generic_args() -> Result<()> {
     let cddl = cddl_from_str(
       r#"
+        message<name, value> = {}
         messages = message<"reboot", "now"> / message<"sleep", 1..100>
       "#,
       true,

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -462,6 +462,7 @@ pub fn generic_params_from_rule<'a>(rule: &Rule<'a>) -> Option<Vec<&'a str>> {
       .generic_params
       .as_ref()
       .map(|gp| gp.params.iter().map(|gp| gp.param.ident).collect()),
+    Rule::Unknown { rule, .. } => generic_params_from_rule(rule),
   }
 }
 
@@ -519,6 +520,7 @@ pub fn type_choices_from_group_choice<'a>(
               cddl,
               &GroupChoice::new(vec![rule.entry.clone()]),
             )),
+            _ => {}
           }
         }
       }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -188,6 +188,7 @@ where
   match rule {
     Rule::Type { rule, .. } => visitor.visit_type_rule(rule),
     Rule::Group { rule, .. } => visitor.visit_group_rule(rule),
+    Rule::Unknown { rule, .. } => walk_rule(visitor, rule),
   }
 }
 

--- a/tests/fixtures/cddl/tricky.cddl
+++ b/tests/fixtures/cddl/tricky.cddl
@@ -1,0 +1,11 @@
+; These all become type rules.
+a = ( b )
+b = ( c )
+c = d
+d = tstr
+
+; These all become group rules.
+e = ( f )
+f = ( g )
+g = h
+h = ()


### PR DESCRIPTION
This PR implements rudimentary deferred parsing. It continues to not support generic parameters, however typenames/groupnames are fully disambiguated and thus `cddl` is now correct.