### PR TITLE
Add new API for extracting the underling CBOR value from a CBORValidator for reuse

### DIFF
--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -371,6 +371,11 @@ impl<'a> CBORValidator<'a> {
     }
   }
 
+  /// Extract the underlying CBOR Value.
+  pub fn extract_cbor(self) -> Value {
+      self.cbor
+  }
+
   fn validate_array_items<T: std::fmt::Debug + 'static>(
     &mut self,
     token: &ArrayItemToken,
@@ -3902,5 +3907,15 @@ mod tests {
     cv.validate()?;
 
     Ok(())
+  }
+
+  #[test]
+  fn extract_cbor() {
+      use ciborium::value::Value;
+
+      let cbor = Value::Float(1.23);
+      let cddl = cddl_from_str("start = any", true).unwrap();
+      let cv = CBORValidator::new(&cddl, cbor, None);
+      assert_eq!(cv.extract_cbor(), Value::Float(1.23));
   }
 }

--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -373,7 +373,7 @@ impl<'a> CBORValidator<'a> {
 
   /// Extract the underlying CBOR Value.
   pub fn extract_cbor(self) -> Value {
-      self.cbor
+    self.cbor
   }
 
   fn validate_array_items<T: std::fmt::Debug + 'static>(
@@ -3911,11 +3911,11 @@ mod tests {
 
   #[test]
   fn extract_cbor() {
-      use ciborium::value::Value;
+    use ciborium::value::Value;
 
-      let cbor = Value::Float(1.23);
-      let cddl = cddl_from_str("start = any", true).unwrap();
-      let cv = CBORValidator::new(&cddl, cbor, None);
-      assert_eq!(cv.extract_cbor(), Value::Float(1.23));
+    let cbor = Value::Float(1.23);
+    let cddl = cddl_from_str("start = any", true).unwrap();
+    let cv = CBORValidator::new(&cddl, cbor, None);
+    assert_eq!(cv.extract_cbor(), Value::Float(1.23));
   }
 }


### PR DESCRIPTION
Fixes #216 

This reduces the time for `pycddl` to do validation+deserialization combo for a small document from 2.5µs to 1.8µs, by allowing only a single CBOR parse.

Happy to do a different API variation if you prefer.