### PR TITLE
Fix rustfmt violations in tests/cddl.rs

### DIFF
--- a/tests/cddl.rs
+++ b/tests/cddl.rs
@@ -41,12 +41,12 @@ fn verify_json_validation() -> json::Result {
 
 #[cfg(test)]
 mod test_rfc9165_controls {
-    use cddl::cddl_from_str;
+  use cddl::cddl_from_str;
 
-    #[test]
-    fn test_standard_control_operators_parse() {
-        // Test that all standard control operators from RFC 8610 can be parsed
-        let cddl_text = r#"
+  #[test]
+  fn test_standard_control_operators_parse() {
+    // Test that all standard control operators from RFC 8610 can be parsed
+    let cddl_text = r#"
 size_test = uint .size 4
 bits_test = uint .bits 8
 regexp_test = tstr .regexp "[a-z]+"
@@ -61,31 +61,47 @@ ne_test = int .ne 0
 default_test = int .default 0
         "#;
 
-        let result = cddl_from_str(cddl_text, true);
-        assert!(result.is_ok(), "Failed to parse CDDL with standard control operators: {:?}", result.err());
-        
-        let cddl = result.unwrap();
-        // Note: The parser includes the CDDL prelude rules, so the count will be higher
-        assert!(cddl.rules.len() >= 11, "Expected at least 11 rules, got {}", cddl.rules.len());
-    }
+    let result = cddl_from_str(cddl_text, true);
+    assert!(
+      result.is_ok(),
+      "Failed to parse CDDL with standard control operators: {:?}",
+      result.err()
+    );
 
-    #[test]
-    #[cfg(feature = "additional-controls")]
-    fn test_rfc9165_additional_operators() {
-        // Test RFC 9165 and RFC 9741 additional control operators
-        let cddl_text = r#"
+    let cddl = result.unwrap();
+    // Note: The parser includes the CDDL prelude rules, so the count will be higher
+    assert!(
+      cddl.rules.len() >= 11,
+      "Expected at least 11 rules, got {}",
+      cddl.rules.len()
+    );
+  }
+
+  #[test]
+  #[cfg(feature = "additional-controls")]
+  fn test_rfc9165_additional_operators() {
+    // Test RFC 9165 and RFC 9741 additional control operators
+    let cddl_text = r#"
 cat_test = tstr .cat "suffix"
 det_test = tstr .det "test"
 plus_test = int .plus 10
 b64u_test = bstr .b64u "test"
 hex_test = bstr .hex "test"
         "#;
-        
-        let result = cddl_from_str(cddl_text, true);
-        assert!(result.is_ok(), "Failed to parse RFC 9165 additional operators: {:?}", result.err());
-        
-        let cddl = result.unwrap();
-        // Note: The parser includes the CDDL prelude rules, so the count will be higher
-        assert!(cddl.rules.len() >= 5, "Expected at least 5 rules, got {}", cddl.rules.len());
-    }
+
+    let result = cddl_from_str(cddl_text, true);
+    assert!(
+      result.is_ok(),
+      "Failed to parse RFC 9165 additional operators: {:?}",
+      result.err()
+    );
+
+    let cddl = result.unwrap();
+    // Note: The parser includes the CDDL prelude rules, so the count will be higher
+    assert!(
+      cddl.rules.len() >= 5,
+      "Expected at least 5 rules, got {}",
+      cddl.rules.len()
+    );
+  }
 }


### PR DESCRIPTION
Applies cargo fmt to fix formatting issues introduced in recent merges.