### PR TITLE
Potential fix for code scanning alert no. 73: Code injection

### DIFF
--- a/.github/workflows/compilation-check.yml
+++ b/.github/workflows/compilation-check.yml
@@ -16,14 +16,20 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Rust
+        env:
+          RUST_TOOLCHAIN: ${{ matrix.rust_toolchain }}
         run: |
           rustup update
-          rustup install ${{ matrix.rust_toolchain }}
+          rustup install $RUST_TOOLCHAIN
 
       - name: Check compilation with default features
+        env:
+          RUST_TOOLCHAIN: ${{ matrix.rust_toolchain }}
         run: |
-          cargo +${{ matrix.rust_toolchain }} check --all --bins --examples --tests
+          cargo +$RUST_TOOLCHAIN check --all --bins --examples --tests
 
       - name: Check compilation with no features
+        env:
+          RUST_TOOLCHAIN: ${{ matrix.rust_toolchain }}
         run: |
-          cargo +${{ matrix.rust_toolchain }} check --all --bins --examples --tests --no-default-features
+          cargo +$RUST_TOOLCHAIN check --all --bins --examples --tests --no-default-features


### PR DESCRIPTION
Potential fix for [https://github.com/anweiss/cddl/security/code-scanning/73](https://github.com/anweiss/cddl/security/code-scanning/73)

To fix the code injection risk, we should avoid using `${{ matrix.rust_toolchain }}` directly in the shell command. Instead, set it as an environment variable in the step, and reference it using shell syntax (`$RUST_TOOLCHAIN`). This change should be applied to all steps where `${{ matrix.rust_toolchain }}` is used in a shell command, specifically lines 21, 25, and 29. No additional imports or definitions are needed, as this is a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
