### PR TITLE
fix: update anchore scan-action to v7.3.2

### DIFF
--- a/.github/workflows/anchore.yml
+++ b/.github/workflows/anchore.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag localbuild/testimage:latest
     - name: Run the Anchore Grype scan action
-      uses: anchore/scan-action@d5aa5b6cb9414b0c7771438046ff5bcfa2854ed7
+      uses: anchore/scan-action@7037fa011853d5a11690026fb85feee79f4c946c # v7.3.2
       id: scan
       with:
         image: "localbuild/testimage:latest"
@@ -41,5 +41,6 @@ jobs:
         severity-cutoff: critical
     - name: Upload vulnerability report
       uses: github/codeql-action/upload-sarif@v3
+      if: always()
       with:
         sarif_file: ${{ steps.scan.outputs.sarif }}


### PR DESCRIPTION
## Summary

Fixes the failing [Anchore Grype vulnerability scan](https://github.com/anweiss/cddl/actions/runs/21959604915) workflow.

## Changes

- **Updated `anchore/scan-action`** from an ancient pinned SHA (which used the deprecated `set-output` command) to **v7.3.2** (`7037fa0`), which includes:
  - Modern Grype scanner (v0.107.1) with improved vulnerability detection and fewer false positives
  - No more deprecated `set-output` warnings
  - Bug fixes and dependency updates

- **Added `if: always()` to the SARIF upload step** so vulnerability reports are uploaded to GitHub Security tab even when the scan finds critical issues (previously the upload was skipped on scan failure)