### PR TITLE
fix: upgrade time to 0.3.47 to resolve CVE-2026-25727, bump MSRV to 1.88.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   minimum-version-check:
     strategy:
       matrix:
-        rust_toolchain: [1.81.0]
+        rust_toolchain: [1.88.0]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     name: msrv check
     runs-on: ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,9 +354,9 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
 ]
@@ -579,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-traits"
@@ -872,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -882,22 +882,22 @@ dependencies = [
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.10.2"
 authors = ["Andrew Weiss <andrew.weiss@outlook.com>"]
 readme = "README.md"
 edition = "2018"
+rust-version = "1.88.0"
 exclude = [
     "cddl-lsp/**/*",
     "www/**/*",


### PR DESCRIPTION
## Summary

Fixes a security vulnerability (CVE-2026-25727 / GHSA-r6v5-fh4h-64xc) in the `time` crate — stack exhaustion Denial of Service attack affecting versions `>= 0.3.6, < 0.3.47`.

This was introduced when `time` was pinned to 0.3.41 in #404 to work around an MSRV incompatibility with `time-core 0.1.8`.

## Changes

- **`Cargo.lock`**: Upgrade `time` from 0.3.41 to 0.3.47 (patched version)
- **`Cargo.toml`**: Add `rust-version = \"1.88.0\"` — the new MSRV required by `time-macros 0.2.27`
- **`.github/workflows/ci.yml`**: Bump MSRV check from 1.81.0 to 1.88.0

## Why the MSRV bump?

`time 0.3.47` depends on `time-core 0.1.8` (edition 2024, needs Rust 1.85+) and `time-macros 0.2.27` (needs Rust 1.88.0). There is no way to use the patched `time` without bumping the MSRV.