### PR TITLE
feat: add CSV validation support (draft-bormann-cbor-cddl-csv-07)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,7 @@ dependencies = [
  "clap",
  "codespan-reporting",
  "console_error_panic_hook",
+ "csv",
  "data-encoding",
  "displaydoc",
  "hex",
@@ -346,6 +347,27 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ serde = { version = "1.0.228", optional = true, features = ["derive"] }
 ciborium = { version = "0.2.0", optional = true }
 ciborium-ll = { version = "0.2.0", optional = true }
 ciborium-io = { version = "0.2.0", optional = true }
+csv = { version = "1.3", optional = true }
 serde_json = { version = "1.0.145", optional = true, default-features = false, features = [
     "std",
 ] }
@@ -79,6 +80,7 @@ default = [
     "ast-comments",
     "json",
     "cbor",
+    "csv-validate",
     "additional-controls",
     "ast-parent",
     "wasm-bindgen",
@@ -108,10 +110,11 @@ ast-comments = []
 ast-parent = []
 json = ["std"]
 cbor = ["std"]
+csv-validate = ["std", "json", "csv"]
 
 [[bin]]
 name = "cddl"
-required-features = ["std", "json", "cbor"]
+required-features = ["std", "json", "cbor", "csv-validate"]
 path = "src/bin/cli.rs"
 
 [profile.release]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -544,3 +544,10 @@ pub use self::validator::validate_cbor_from_slice;
 #[cfg(not(feature = "lsp"))]
 #[cfg(not(target_arch = "wasm32"))]
 pub use self::validator::validate_json_from_str;
+
+#[doc(inline)]
+#[cfg(feature = "std")]
+#[cfg(feature = "csv-validate")]
+#[cfg(not(feature = "lsp"))]
+#[cfg(not(target_arch = "wasm32"))]
+pub use self::validator::validate_csv_from_str;

--- a/src/validator/csv_validator.rs
+++ b/src/validator/csv_validator.rs
@@ -1,0 +1,356 @@
+#![cfg(feature = "std")]
+#![cfg(feature = "csv-validate")]
+#![cfg(not(feature = "lsp"))]
+
+//! CSV validation implementation based on draft-bormann-cbor-cddl-csv-07.
+//!
+//! This module validates CSV data against CDDL definitions. The generic data
+//! model for CSV is:
+//!
+//! ```cddl
+//! csv = [?header, *record]
+//! header = [+header-field]
+//! record = [+field]
+//! header-field = text
+//! field = text
+//! ```
+//!
+//! CSV fields are text strings, but the CDDL model may specify application-level
+//! types such as `uint`, `int`, or `float`. When such types are specified, the
+//! validator coerces text fields to their JSON representation as described in
+//! the spec: "As a preferred choice, the JSON representation of the data model
+//! item, if it exists, MAY be chosen by that instruction."
+
+use std::fmt::{self, Write};
+
+use super::json;
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::cddl_from_str;
+
+#[cfg(target_arch = "wasm32")]
+use crate::{error::ErrorMsg, lexer::Position, parser, pest_bridge};
+#[cfg(target_arch = "wasm32")]
+use serde::Serialize;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Serialize)]
+struct ParserError {
+  #[cfg(feature = "ast-span")]
+  position: Position,
+  msg: ErrorMsg,
+}
+
+/// CSV validation Result
+pub type Result = std::result::Result<(), Error>;
+
+/// CSV validation error
+#[derive(Debug)]
+pub enum Error {
+  /// Zero or more validation errors (from JSON validator)
+  Validation(Vec<json::ValidationError>),
+  /// CSV parsing error
+  CSVParsing(csv::Error),
+  /// JSON serialization error (internal conversion)
+  JSONSerialization(serde_json::Error),
+  /// CDDL parsing error
+  CDDLParsing(String),
+  /// JSON validation error (delegated)
+  JSONValidation(json::Error),
+}
+
+impl fmt::Display for Error {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    match self {
+      Error::Validation(errors) => {
+        let mut error_str = String::new();
+        for e in errors.iter() {
+          let _ = writeln!(error_str, "{}", e);
+        }
+        write!(f, "{}", error_str)
+      }
+      Error::CSVParsing(error) => write!(f, "error parsing CSV: {}", error),
+      Error::JSONSerialization(error) => {
+        write!(f, "error converting CSV to JSON representation: {}", error)
+      }
+      Error::CDDLParsing(error) => write!(f, "error parsing CDDL: {}", error),
+      Error::JSONValidation(error) => write!(f, "{}", error),
+    }
+  }
+}
+
+impl std::error::Error for Error {
+  fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+    match self {
+      Error::CSVParsing(error) => Some(error),
+      Error::JSONSerialization(error) => Some(error),
+      _ => None,
+    }
+  }
+}
+
+/// Parse CSV data into the generic CDDL data model.
+///
+/// Returns a `serde_json::Value::Array` where each element is a
+/// `serde_json::Value::Array` representing a record (row). The header row, if
+/// present, is included as the first element. Each field is represented as
+/// a JSON value: integers become `Number`, floats become `Number`, empty
+/// strings become `String("")`, and everything else stays as `String`.
+///
+/// The `has_header` parameter controls whether the first row should be treated
+/// as a header. If `true`, the first row remains as text strings (no numeric
+/// coercion). If `false` or `None`, all rows are coerced.
+pub fn parse_csv_to_json(
+  csv_data: &str,
+  has_header: Option<bool>,
+) -> std::result::Result<serde_json::Value, csv::Error> {
+  let has_header = has_header.unwrap_or(false);
+  let mut reader = csv::ReaderBuilder::new()
+    .has_headers(false)
+    .flexible(true)
+    .from_reader(csv_data.as_bytes());
+
+  let mut rows: Vec<serde_json::Value> = Vec::new();
+
+  for (row_idx, result) in reader.records().enumerate() {
+    let record = result?;
+    let fields: Vec<serde_json::Value> = record
+      .iter()
+      .map(|field| {
+        // Header row: keep as text
+        if has_header && row_idx == 0 {
+          return serde_json::Value::String(field.to_string());
+        }
+        coerce_field(field)
+      })
+      .collect();
+
+    rows.push(serde_json::Value::Array(fields));
+  }
+
+  Ok(serde_json::Value::Array(rows))
+}
+
+/// Coerce a CSV field text value to an appropriate JSON value.
+///
+/// Per draft-bormann-cbor-cddl-csv-07: "As a preferred choice, the JSON
+/// representation of the data model item, if it exists, MAY be chosen."
+///
+/// - Empty string `""` stays as `String("")`
+/// - Unsigned integers (all digits) become `Number` (u64)
+/// - Negative integers (`-` followed by digits) become `Number` (i64)
+/// - Floating-point numbers become `Number` (f64)
+/// - Everything else stays as `String`
+fn coerce_field(field: &str) -> serde_json::Value {
+  if field.is_empty() {
+    return serde_json::Value::String(String::new());
+  }
+
+  // Try unsigned integer first
+  if let Ok(n) = field.parse::<u64>() {
+    return serde_json::json!(n);
+  }
+
+  // Try signed integer
+  if let Ok(n) = field.parse::<i64>() {
+    return serde_json::json!(n);
+  }
+
+  // Try float
+  if let Ok(n) = field.parse::<f64>() {
+    if n.is_finite() {
+      return serde_json::json!(n);
+    }
+  }
+
+  serde_json::Value::String(field.to_string())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "additional-controls")]
+/// Validate CSV string against a given CDDL document string.
+///
+/// The CSV data is parsed according to RFC 4180 and mapped to the CDDL generic
+/// data model as described in draft-bormann-cbor-cddl-csv-07. The first rule in
+/// the CDDL document is used as the root validation type.
+///
+/// `has_header` indicates whether the first row of the CSV is a header row.
+/// If `None`, defaults to `false`.
+pub fn validate_csv_from_str(
+  cddl: &str,
+  csv_data: &str,
+  has_header: Option<bool>,
+  enabled_features: Option<&[&str]>,
+) -> Result {
+  let cddl_ast = cddl_from_str(cddl, true).map_err(Error::CDDLParsing)?;
+  let json_value = parse_csv_to_json(csv_data, has_header).map_err(Error::CSVParsing)?;
+
+  let mut jv = json::JSONValidator::new(&cddl_ast, json_value, enabled_features);
+
+  use super::Validator;
+  jv.validate().map_err(Error::JSONValidation)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(feature = "additional-controls"))]
+/// Validate CSV string against a given CDDL document string.
+///
+/// The CSV data is parsed according to RFC 4180 and mapped to the CDDL generic
+/// data model as described in draft-bormann-cbor-cddl-csv-07. The first rule in
+/// the CDDL document is used as the root validation type.
+///
+/// `has_header` indicates whether the first row of the CSV is a header row.
+/// If `None`, defaults to `false`.
+pub fn validate_csv_from_str(cddl: &str, csv_data: &str, has_header: Option<bool>) -> Result {
+  let cddl_ast = cddl_from_str(cddl, true).map_err(Error::CDDLParsing)?;
+  let json_value = parse_csv_to_json(csv_data, has_header).map_err(Error::CSVParsing)?;
+
+  let mut jv = json::JSONValidator::new(&cddl_ast, json_value);
+
+  use super::Validator;
+  jv.validate().map_err(Error::JSONValidation)
+}
+
+#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "additional-controls")]
+#[wasm_bindgen]
+/// Validate CSV string from a given CDDL document string
+pub fn validate_csv_from_str(
+  cddl: &str,
+  csv_data: &str,
+  has_header: Option<bool>,
+  enabled_features: Option<Box<[JsValue]>>,
+) -> std::result::Result<JsValue, JsValue> {
+  let c = pest_bridge::cddl_from_pest_str(cddl).map_err(|e| {
+    if let parser::Error::PARSER {
+      #[cfg(feature = "ast-span")]
+      position,
+      msg,
+    } = &e
+    {
+      let errors = vec![ParserError {
+        #[cfg(feature = "ast-span")]
+        position: *position,
+        msg: msg.clone(),
+      }];
+      serde_wasm_bindgen::to_value(&errors).unwrap_or_else(|e| JsValue::from(e.to_string()))
+    } else {
+      JsValue::from(e.to_string())
+    }
+  })?;
+
+  let json_value =
+    parse_csv_to_json(csv_data, has_header).map_err(|e| JsValue::from(e.to_string()))?;
+
+  let mut jv = json::JSONValidator::new(&c, json_value, enabled_features);
+
+  use super::Validator;
+  jv.validate()
+    .map_err(|e| JsValue::from(e.to_string()))
+    .map(|_| JsValue::default())
+}
+
+#[cfg(target_arch = "wasm32")]
+#[cfg(not(feature = "additional-controls"))]
+#[wasm_bindgen]
+/// Validate CSV string from a given CDDL document string
+pub fn validate_csv_from_str(
+  cddl: &str,
+  csv_data: &str,
+  has_header: Option<bool>,
+) -> std::result::Result<JsValue, JsValue> {
+  let c = pest_bridge::cddl_from_pest_str(cddl).map_err(|e| {
+    if let parser::Error::PARSER {
+      #[cfg(feature = "ast-span")]
+      position,
+      msg,
+    } = &e
+    {
+      let errors = vec![ParserError {
+        #[cfg(feature = "ast-span")]
+        position: *position,
+        msg: msg.clone(),
+      }];
+      serde_wasm_bindgen::to_value(&errors).unwrap_or_else(|e| JsValue::from(e.to_string()))
+    } else {
+      JsValue::from(e.to_string())
+    }
+  })?;
+
+  let json_value =
+    parse_csv_to_json(csv_data, has_header).map_err(|e| JsValue::from(e.to_string()))?;
+
+  let mut jv = json::JSONValidator::new(&c, json_value);
+
+  use super::Validator;
+  jv.validate()
+    .map_err(|e| JsValue::from(e.to_string()))
+    .map(|_| JsValue::default())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_coerce_field_empty() {
+    assert_eq!(coerce_field(""), serde_json::Value::String(String::new()));
+  }
+
+  #[test]
+  fn test_coerce_field_uint() {
+    assert_eq!(coerce_field("42"), serde_json::json!(42));
+    assert_eq!(coerce_field("0"), serde_json::json!(0));
+    assert_eq!(coerce_field("1700"), serde_json::json!(1700));
+  }
+
+  #[test]
+  fn test_coerce_field_negative_int() {
+    assert_eq!(coerce_field("-1"), serde_json::json!(-1));
+    assert_eq!(coerce_field("-100"), serde_json::json!(-100));
+  }
+
+  #[test]
+  fn test_coerce_field_float() {
+    assert_eq!(coerce_field("3.14"), serde_json::json!(3.14));
+    assert_eq!(coerce_field("-2.5"), serde_json::json!(-2.5));
+  }
+
+  #[test]
+  fn test_coerce_field_text() {
+    assert_eq!(
+      coerce_field("hello"),
+      serde_json::Value::String("hello".to_string())
+    );
+    assert_eq!(
+      coerce_field("ietf-system"),
+      serde_json::Value::String("ietf-system".to_string())
+    );
+  }
+
+  #[test]
+  fn test_parse_csv_no_header() {
+    let csv = "a,b,c\n1,2,3\n";
+    let result = parse_csv_to_json(csv, None).unwrap();
+    let expected = serde_json::json!([["a", "b", "c"], [1, 2, 3]]);
+    assert_eq!(result, expected);
+  }
+
+  #[test]
+  fn test_parse_csv_with_header() {
+    let csv = "name,value\nhello,42\n";
+    let result = parse_csv_to_json(csv, Some(true)).unwrap();
+    let expected = serde_json::json!([["name", "value"], ["hello", 42]]);
+    assert_eq!(result, expected);
+  }
+
+  #[test]
+  fn test_parse_csv_empty_fields() {
+    let csv = "a,,c\n";
+    let result = parse_csv_to_json(csv, None).unwrap();
+    let expected = serde_json::json!([["a", "", "c"]]);
+    assert_eq!(result, expected);
+  }
+}

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -4,6 +4,8 @@
 pub mod cbor;
 /// Custom CBOR value type with simple value support
 pub mod cbor_value;
+/// CSV validation implementation (draft-bormann-cbor-cddl-csv-07)
+pub mod csv_validator;
 /// JSON validation implementation
 pub mod json;
 
@@ -280,6 +282,40 @@ pub fn validate_cbor_from_slice(
   cv.validate()
     .map_err(|e| JsValue::from(e.to_string()))
     .map(|_| JsValue::default())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "csv-validate")]
+#[cfg(feature = "additional-controls")]
+/// Validate CSV string from a given CDDL document string.
+///
+/// Implements draft-bormann-cbor-cddl-csv-07. CSV data is parsed according to
+/// RFC 4180 and mapped to the CDDL generic data model. Fields are coerced to
+/// their JSON representation for validation.
+///
+/// `has_header` indicates whether the first row is a header. Defaults to `false`.
+pub fn validate_csv_from_str(
+  cddl: &str,
+  csv_data: &str,
+  has_header: Option<bool>,
+  enabled_features: Option<&[&str]>,
+) -> csv_validator::Result {
+  csv_validator::validate_csv_from_str(cddl, csv_data, has_header, enabled_features)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "csv-validate")]
+#[cfg(not(feature = "additional-controls"))]
+/// Validate CSV string from a given CDDL document string.
+///
+/// Implements draft-bormann-cbor-cddl-csv-07. CSV data is parsed according to
+/// RFC 4180 and mapped to the CDDL generic data model.
+pub fn validate_csv_from_str(
+  cddl: &str,
+  csv_data: &str,
+  has_header: Option<bool>,
+) -> csv_validator::Result {
+  csv_validator::validate_csv_from_str(cddl, csv_data, has_header)
 }
 
 /// Find non-choice alternate rule from a given identifier

--- a/tests/csv.rs
+++ b/tests/csv.rs
@@ -1,0 +1,132 @@
+#![cfg(feature = "std")]
+#![cfg(feature = "csv-validate")]
+#![cfg(feature = "additional-controls")]
+#![cfg(not(target_arch = "wasm32"))]
+
+//! Integration tests for CSV validation (draft-bormann-cbor-cddl-csv-07)
+
+use cddl::validate_csv_from_str;
+use std::fs;
+
+#[test]
+fn validate_simple_csv() {
+  let cddl = fs::read_to_string("tests/fixtures/cddl/csv-simple.cddl").unwrap();
+  let csv = fs::read_to_string("tests/fixtures/csv/simple.csv").unwrap();
+  let result = validate_csv_from_str(&cddl, &csv, None, None);
+  assert!(result.is_ok(), "Validation failed: {:?}", result.err());
+}
+
+#[test]
+fn validate_csv_with_header() {
+  let cddl = fs::read_to_string("tests/fixtures/cddl/csv-with-header.cddl").unwrap();
+  let csv = fs::read_to_string("tests/fixtures/csv/with-header.csv").unwrap();
+  let result = validate_csv_from_str(&cddl, &csv, Some(true), None);
+  assert!(result.is_ok(), "Validation failed: {:?}", result.err());
+}
+
+#[test]
+fn validate_sid_file_csv() {
+  let cddl = fs::read_to_string("tests/fixtures/cddl/csv-sid-file.cddl").unwrap();
+  let csv = fs::read_to_string("tests/fixtures/csv/sid-file.csv").unwrap();
+  let result = validate_csv_from_str(&cddl, &csv, None, None);
+  assert!(result.is_ok(), "Validation failed: {:?}", result.err());
+}
+
+#[test]
+fn validate_csv_type_mismatch() {
+  // CDDL expects uint for age, but CSV has text "abc"
+  let cddl = r#"
+    records = [*record]
+    record = [name: text, age: uint]
+  "#;
+  let csv = "Alice,abc\n";
+  let result = validate_csv_from_str(cddl, csv, None, None);
+  assert!(
+    result.is_err(),
+    "Expected validation error for type mismatch"
+  );
+}
+
+#[test]
+fn validate_csv_empty() {
+  let cddl = r#"
+    records = [*record]
+    record = [text, uint]
+  "#;
+  let csv = "";
+  let result = validate_csv_from_str(cddl, csv, None, None);
+  assert!(result.is_ok(), "Empty CSV should validate against *record");
+}
+
+#[test]
+fn validate_csv_with_empty_fields() {
+  let cddl = r#"
+    records = [*record]
+    record = [key: text, value: text]
+  "#;
+  let csv = "hello,\nworld,foo\n";
+  let result = validate_csv_from_str(cddl, csv, None, None);
+  assert!(
+    result.is_ok(),
+    "CSV with empty fields should validate: {:?}",
+    result.err()
+  );
+}
+
+#[test]
+fn validate_csv_wrong_field_count() {
+  let cddl = r#"
+    records = [*record]
+    record = [text, text, text]
+  "#;
+  let csv = "a,b\n";
+  let result = validate_csv_from_str(cddl, csv, None, None);
+  assert!(
+    result.is_err(),
+    "Expected validation error for wrong number of fields"
+  );
+}
+
+#[test]
+fn validate_csv_inline_cddl() {
+  let cddl = r#"
+    data = [*[text, uint, text]]
+  "#;
+  let csv = "foo,42,bar\nbaz,10,qux\n";
+  let result = validate_csv_from_str(cddl, csv, None, None);
+  assert!(result.is_ok(), "Validation failed: {:?}", result.err());
+}
+
+#[test]
+fn validate_csv_mixed_record_types() {
+  // Test with choice types (different record formats)
+  let cddl = r#"
+    file = [*record]
+    record = meta-record / data-record
+    meta-record = ["meta", text]
+    data-record = [uint, text]
+  "#;
+  let csv = "meta,info\n42,hello\n";
+  let result = validate_csv_from_str(cddl, csv, None, None);
+  assert!(result.is_ok(), "Validation failed: {:?}", result.err());
+}
+
+#[test]
+fn validate_csv_negative_numbers() {
+  let cddl = r#"
+    data = [*[text, int]]
+  "#;
+  let csv = "temp,-5\npressure,-10\n";
+  let result = validate_csv_from_str(cddl, csv, None, None);
+  assert!(result.is_ok(), "Validation failed: {:?}", result.err());
+}
+
+#[test]
+fn validate_csv_float_values() {
+  let cddl = r#"
+    data = [*[text, float]]
+  "#;
+  let csv = "pi,3.14\ne,2.718\n";
+  let result = validate_csv_from_str(cddl, csv, None, None);
+  assert!(result.is_ok(), "Validation failed: {:?}", result.err());
+}

--- a/tests/fixtures/cddl/csv-sid-file.cddl
+++ b/tests/fixtures/cddl/csv-sid-file.cddl
@@ -1,0 +1,28 @@
+; CSV data model for a simplified SID file (draft-bormann-cbor-cddl-csv-07)
+; header = absent
+
+SID-File = [*record]
+record = meta-record / description-record / dependency-record / range-record / item-record
+
+empty = ""
+
+meta-record = ["ietf-sid-file",
+               module-name: text,
+               module-revision: empty / text,
+               sid-file-revision: empty / text]
+
+description-record = ["description",
+                       description: empty / text]
+
+dependency-record = ["dependency",
+                      module-name: text,
+                      module-revision: text]
+
+range-record = ["range",
+                entry-point: uint,
+                size: uint]
+
+item-record = [sid: uint,
+               namespace: text,
+               identifier: text,
+               status: empty / text]

--- a/tests/fixtures/cddl/csv-simple.cddl
+++ b/tests/fixtures/cddl/csv-simple.cddl
@@ -1,0 +1,4 @@
+; A simple CSV schema: records with name and age
+; header = absent
+person-file = [*person-record]
+person-record = [name: text, age: uint]

--- a/tests/fixtures/cddl/csv-with-header.cddl
+++ b/tests/fixtures/cddl/csv-with-header.cddl
@@ -1,0 +1,5 @@
+; CSV with header row
+; header = present
+with-header = [header-row, *data-row]
+header-row = ["name", "score"]
+data-row = [name: text, score: uint]

--- a/tests/fixtures/csv/sid-file.csv
+++ b/tests/fixtures/csv/sid-file.csv
@@ -1,0 +1,11 @@
+ietf-sid-file,ietf-system,2014-08-06,
+description,Example sid file
+dependency,ietf-yang-types,2013-07-15
+dependency,ietf-inet-types,2013-07-15
+dependency,ietf-netconf-acm,2018-02-14
+dependency,iana-crypt-hash,2014-08-06
+range,1700,100
+1700,module,ietf-system,
+1701,identity,authentication-method,
+1702,identity,local-users,
+1703,identity,radius,

--- a/tests/fixtures/csv/simple.csv
+++ b/tests/fixtures/csv/simple.csv
@@ -1,0 +1,3 @@
+Alice,30
+Bob,25
+Charlie,35

--- a/tests/fixtures/csv/with-header.csv
+++ b/tests/fixtures/csv/with-header.csv
@@ -1,0 +1,3 @@
+name,score
+Alice,100
+Bob,95


### PR DESCRIPTION
## Summary

Implements CSV validation as described in [draft-bormann-cbor-cddl-csv-07](https://datatracker.ietf.org/doc/draft-bormann-cbor-cddl-csv/07/). CSV data is parsed per RFC 4180 and mapped to the CDDL generic data model where each row becomes an array of fields. Fields are coerced to their JSON representation (integers, floats, strings) and validated by delegating to the existing JSON validator.

Closes #151

## Changes

### New feature flag: `csv-validate`
- Adds a `csv-validate` feature flag that depends on `std`, `json`, and the `csv` crate
- Enabled by default alongside `json` and `cbor`

### CSV Validator (`src/validator/csv_validator.rs`)
- `parse_csv_to_json()` - Parses CSV data into a JSON array-of-arrays representation matching the CDDL generic data model:
  ```cddl
  csv = [?header, *record]
  header = [+header-field]
  record = [+field]
  header-field = text
  field = text
  ```
- `coerce_field()` - Coerces text fields to their JSON representation (uint, int, float, or text) per the spec
- `validate_csv_from_str()` - Public API for validating CSV against CDDL, with support for:
  - Optional header row detection
  - Feature-gated additional controls
  - Both native and wasm32 targets
- Error types for CSV parsing, CDDL parsing, JSON validation delegation

### CLI Support
- `--csv <file>` flag for validating CSV files
- `--csv-header` flag to indicate the CSV has a header row
- Example: `cddl validate --cddl schema.cddl --csv data.csv --csv-header`

### Test Coverage
- 11 integration tests covering:
  - Simple CSV validation
  - Header row handling
  - SID file format (from the draft spec)
  - Type mismatch detection
  - Empty CSV
  - Empty fields
  - Wrong field count detection
  - Inline CDDL definitions
  - Mixed/choice record types
  - Negative numbers
  - Float values
- Unit tests for field coercion and CSV parsing

### Test Fixtures
- `csv-simple.cddl` + `simple.csv` - Basic name/age records
- `csv-with-header.cddl` + `with-header.csv` - CSV with header row
- `csv-sid-file.cddl` + `sid-file.csv` - SID file format from draft-bormann-cbor-cddl-csv-07

## Local Verification
- `cargo fmt --all -- --check` ✅
- `cargo clippy --all` ✅
- `cargo clippy --lib --target wasm32-unknown-unknown` ✅
- `cargo check --lib --target wasm32-unknown-unknown` ✅
- `cargo +stable check --all --bins --examples --tests` ✅
- `cargo +stable check --all --bins --examples --tests --no-default-features` ✅
- `cargo test --all` ✅ (222 tests, 0 failures)