### PR TITLE
Bump dompurify override to >=3.4.0 (GHSA-39q2-94rc-95cp)

### DIFF
--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -1912,13 +1912,10 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
-      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "engines": {
-        "node": ">=20"
-      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }

--- a/www/package.json
+++ b/www/package.json
@@ -48,6 +48,6 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.5",
-    "dompurify": ">=3.3.2"
+    "dompurify": ">=3.4.0"
   }
 }


### PR DESCRIPTION
Fixes Dependabot alert [#210](https://github.com/anweiss/cddl/security/dependabot/210).

DOMPurify `<=3.3.3` has a logic bug where `ADD_TAGS` as a function bypasses `FORBID_TAGS` due to short-circuit evaluation (CWE-783, CVSS 5.3).

monaco-editor still pins `dompurify@3.2.7` as a transitive dependency, so this bumps the existing npm `overrides` entry from `>=3.3.2` to `>=3.4.0` to force resolution to the patched release. Verified via `npm audit` — no dompurify advisories remain.