### PR TITLE
Allow any type1 as an arrow-style member key (RFC 8610 §3.5.1)

### DIFF
--- a/cddl.pest
+++ b/cddl.pest
@@ -181,8 +181,22 @@ group_entry = { occur? ~ S ~ member_key ~ S ~ cut? ~ S ~ "=>" ~ S ~ type_expr
 // Cut marker (^) prevents backtracking past this point in validation
 cut = { "^" }
 
-// Member keys can be barewords, type names, or literal values
-member_key = { bareword | typename ~ generic_args? | value }
+// Member keys can be:
+//   type1 [^] =>       (any type1 expression as a computed key, per RFC 8610 §3.5.1)
+//   bareword :         (identifier-style key for maps)
+//   value :            (literal value key)
+// The type1-form is gated by a lookahead for "=>" (with optional cut "^") so
+// it does not steal parses from the bareword/value ":"-form. The optional cut
+// "^" itself is left for `group_entry` to consume so that the existing AST
+// conversion (which looks for a Rule::cut child) keeps working unchanged.
+// The bareword/typename/value alternatives keep their original shape so the
+// AST conversion code does not need to change for the common cases.
+member_key = {
+    type1 ~ S ~ &(("^" ~ S)? ~ "=>")
+  | bareword
+  | typename ~ generic_args?
+  | value
+}
 
 // =============================================================================
 // OCCURRENCE INDICATORS

--- a/src/pest_bridge.rs
+++ b/src/pest_bridge.rs
@@ -2700,6 +2700,23 @@ fn convert_member_key_simple<'a>(
 ) -> Result<ast::MemberKey<'a>, Error> {
   for inner in pair.into_inner() {
     match inner.as_rule() {
+      Rule::type1 => {
+        // type1 form (RFC 8610 §3.5.1): "type1 S [\"^\" S] \"=>\"".
+        // Always an arrow-map member key; ignore is_arrow_map flag here.
+        let t1 = convert_type1(inner, input)?;
+        return Ok(ast::MemberKey::Type1 {
+          t1: Box::new(t1),
+          is_cut,
+          #[cfg(feature = "ast-span")]
+          span,
+          #[cfg(feature = "ast-comments")]
+          comments_before_cut: None,
+          #[cfg(feature = "ast-comments")]
+          comments_after_cut: None,
+          #[cfg(feature = "ast-comments")]
+          comments_after_arrowmap: None,
+        });
+      }
       Rule::bareword => {
         if is_arrow_map {
           // Convert bareword to Type1 for arrow map
@@ -2875,6 +2892,20 @@ fn convert_member_key_simple<'a>(
 ) -> Result<ast::MemberKey<'a>, Error> {
   for inner in pair.into_inner() {
     match inner.as_rule() {
+      Rule::type1 => {
+        // type1 form (RFC 8610 §3.5.1): always an arrow-map member key.
+        let t1 = convert_type1(inner, input)?;
+        return Ok(ast::MemberKey::Type1 {
+          t1: Box::new(t1),
+          is_cut,
+          #[cfg(feature = "ast-comments")]
+          comments_before_cut: None,
+          #[cfg(feature = "ast-comments")]
+          comments_after_cut: None,
+          #[cfg(feature = "ast-comments")]
+          comments_after_arrowmap: None,
+        });
+      }
       Rule::bareword => {
         if is_arrow_map {
           // Convert bareword to Type1 for arrow map

--- a/tests/fixtures/cddl/tricky.cddl
+++ b/tests/fixtures/cddl/tricky.cddl
@@ -9,3 +9,12 @@ e = ( f )
 f = ( g )
 g = h
 h = ()
+
+; RFC 8610 §3.5.1: memberkey may be any type1.
+; Range-typed memberkey with an occurrence indicator.
+ranged_keys = {? 0 : [* int], * 3 .. 255 => [* int]}
+
+; Array-typed memberkey carrying an internal control op, under `+`.
+arr_keys = { + [tag : k_tag, index : uint .size 4] => [ data : payload ] }
+k_tag = uint
+payload = any

--- a/tests/grammar.rs
+++ b/tests/grammar.rs
@@ -317,4 +317,44 @@ ct-tag-number = 1668546817..1668612095"#;
       result.err()
     );
   }
+
+  #[test]
+  fn test_type1_memberkey_range() {
+    // RFC 8610 §3.5.1: memberkey may be any type1, including a range, with an
+    // occurrence indicator (e.g. `* 3 .. 255 => ...`).
+    let input = "ranged_keys = {? 0 : [* int], * 3 .. 255 => [* int]}";
+    let result = CDDLParser::parse(Rule::cddl, input);
+    assert!(
+      result.is_ok(),
+      "ranged memberkey with occurrence should parse: {:?}",
+      result.err()
+    );
+    let bridge_result = cddl::pest_bridge::cddl_from_pest_str_checked(input);
+    assert!(
+      bridge_result.is_ok(),
+      "ranged memberkey should pass full bridge + reference check: {:?}",
+      bridge_result.err()
+    );
+  }
+
+  #[test]
+  fn test_type1_memberkey_array_with_control() {
+    // RFC 8610 §3.5.1: memberkey may be a typed array with a control op as
+    // type1 (e.g. `+ [tag : .., index : uint .size 4] => ...`).
+    let input = "arr_keys = { + [tag : k_tag, index : uint .size 4] => [ data : payload ] }
+k_tag = uint
+payload = any";
+    let result = CDDLParser::parse(Rule::cddl, input);
+    assert!(
+      result.is_ok(),
+      "array-typed memberkey with control op should parse: {:?}",
+      result.err()
+    );
+    let bridge_result = cddl::pest_bridge::cddl_from_pest_str_checked(input);
+    assert!(
+      bridge_result.is_ok(),
+      "array-typed memberkey should pass full bridge + reference check: {:?}",
+      bridge_result.err()
+    );
+  }
 }


### PR DESCRIPTION
Hi! 
Some CDDL out there uses stuff like:
- 3 .. 255 => [* int]
- [tag : k_tag, index : uint .size 4] => [ data : payload ]

before a `=>`, which the current grammar rejects. Per §3.5.1 any `type1` is allowed in that position, so I added it as an alternative in `member_key`, gated by a lookahead for `=>` so the `:`-style keys are unaffected.