### PR TITLE
Store CDDL comments in the AST and consume them in cddl-derive

### DIFF
--- a/cddl-derive/src/codegen.rs
+++ b/cddl-derive/src/codegen.rs
@@ -72,6 +72,65 @@ pub(crate) struct RustEnumVariant {
   pub rename: Option<String>,
 }
 
+/// Clean a slice of raw comment texts (each the substring following `;`) into
+/// trimmed documentation lines, dropping bare newline markers.
+fn clean_comment_lines(raw: &[&str]) -> Vec<String> {
+  raw
+    .iter()
+    .filter(|c| **c != "\n")
+    .map(|c| c.trim().to_string())
+    .filter(|c| !c.is_empty())
+    .collect()
+}
+
+/// Doc comment lines attached directly to a rule in the AST (the contiguous
+/// `; ...` block immediately above it), as populated by the parser.
+fn ast_rule_doc(rule: &Rule<'_>) -> Vec<String> {
+  rule
+    .comments_before_rule()
+    .map(|c| clean_comment_lines(&c.0))
+    .unwrap_or_default()
+}
+
+/// Doc comment lines attached directly to a group entry in the AST: its leading
+/// comment block followed by any trailing same-line comment.
+fn ast_entry_doc(entry: &GroupEntry<'_>) -> Vec<String> {
+  let (leading, trailing) = match entry {
+    GroupEntry::ValueMemberKey {
+      leading_comments,
+      trailing_comments,
+      ..
+    }
+    | GroupEntry::TypeGroupname {
+      leading_comments,
+      trailing_comments,
+      ..
+    } => (leading_comments, trailing_comments),
+    GroupEntry::InlineGroup { .. } => return Vec::new(),
+  };
+
+  let mut docs = Vec::new();
+  if let Some(c) = leading {
+    docs.extend(clean_comment_lines(&c.0));
+  }
+  if let Some(c) = trailing {
+    docs.extend(clean_comment_lines(&c.0));
+  }
+  docs
+}
+
+/// Prefer the rule's AST-attached doc comments; fall back to recovering them
+/// from the raw source via the line-indexed `CommentMap` when the AST carries
+/// none (e.g. a build configuration without `ast-comments`).
+fn ast_or_map_rule_doc(rule: &Rule<'_>, line: usize, comments: &CommentMap) -> Vec<String> {
+  let ast = ast_rule_doc(rule);
+  if ast.is_empty() {
+    comments.docs_for(line)
+  } else {
+    ast
+  }
+}
+
 /// Doc comments extracted from CDDL source, indexed by 1-based source line.
 ///
 /// CDDL comments (`; ...`) that appear on their own line immediately above a
@@ -275,7 +334,7 @@ fn collect_type_defs(
           // Merge all of their type choices into a single enum, emitting it
           // once at the position of the first alternate.
           if merged.insert(name.clone()) {
-            let doc = comments.docs_for(type_rule.name.span.2);
+            let doc = ast_or_map_rule_doc(rule, type_rule.name.span.2, comments);
             defs.push(merge_type_rules_to_enum(
               &name,
               alternates.unwrap(),
@@ -284,7 +343,7 @@ fn collect_type_defs(
             )?);
           }
         } else {
-          let doc = comments.docs_for(type_rule.name.span.2);
+          let doc = ast_or_map_rule_doc(rule, type_rule.name.span.2, comments);
           if let Some(def) = type_rule_to_rust_def(type_rule, comments, doc)? {
             defs.push(def);
           }
@@ -294,7 +353,7 @@ fn collect_type_defs(
         rule: group_rule, ..
       } => {
         let name = to_pascal_case(group_rule.name.ident);
-        let doc = comments.docs_for(group_rule.name.span.2);
+        let doc = ast_or_map_rule_doc(rule, group_rule.name.span.2, comments);
         if let Some(fields) = group_entry_to_fields(&group_rule.entry, comments)? {
           defs.push(RustTypeDef::Struct { name, fields, doc });
         }
@@ -695,7 +754,11 @@ fn group_entry_to_fields(
 ) -> Result<Option<Vec<RustField>>, CodegenError> {
   match entry {
     GroupEntry::ValueMemberKey { ge, .. } => {
-      if let Some(field) = value_member_key_to_field(ge, comments)? {
+      if let Some(mut field) = value_member_key_to_field(ge, comments)? {
+        let ast_doc = ast_entry_doc(entry);
+        if !ast_doc.is_empty() {
+          field.doc = ast_doc;
+        }
         Ok(Some(vec![field]))
       } else {
         Ok(None)
@@ -710,7 +773,12 @@ fn group_entry_to_fields(
         .as_ref()
         .map(|o| matches!(o.occur, Occur::Optional { .. }))
         .unwrap_or(false);
-      let doc = comments.docs_for(ge.name.span.2);
+      let ast_doc = ast_entry_doc(entry);
+      let doc = if ast_doc.is_empty() {
+        comments.docs_for(ge.name.span.2)
+      } else {
+        ast_doc
+      };
       Ok(Some(vec![RustField {
         name: field_name,
         original_name: ident.to_string(),
@@ -1596,6 +1664,28 @@ person = {
     );
     assert!(result.contains("/// The person's name."));
     assert!(result.contains("/// Age in years."));
+  }
+
+  #[test]
+  fn test_nested_struct_field_comments_from_ast() {
+    // Comments nested inside CDDL structures are preserved via the AST, not by
+    // scanning raw source lines.
+    let result = gen(
+      r#"person = {
+  ; Mailing address.
+  address: address,
+}
+
+address = {
+  ; Street line.
+  street: tstr,
+  city: tstr, ; City name.
+}
+"#,
+    );
+    assert!(result.contains("/// Mailing address."));
+    assert!(result.contains("/// Street line."));
+    assert!(result.contains("/// City name."));
   }
 
   #[test]

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -316,6 +316,9 @@ pub enum Rule<'a> {
 
     #[cfg(feature = "ast-comments")]
     #[doc(hidden)]
+    comments_before_rule: Option<Comments<'a>>,
+    #[cfg(feature = "ast-comments")]
+    #[doc(hidden)]
     comments_after_rule: Option<Comments<'a>>,
   },
   /// Group expression
@@ -326,6 +329,9 @@ pub enum Rule<'a> {
     #[cfg(feature = "ast-span")]
     span: Span,
 
+    #[cfg(feature = "ast-comments")]
+    #[doc(hidden)]
+    comments_before_rule: Option<Comments<'a>>,
     #[cfg(feature = "ast-comments")]
     #[doc(hidden)]
     comments_after_rule: Option<Comments<'a>>,
@@ -391,10 +397,19 @@ impl fmt::Display for Rule<'_> {
       Rule::Type {
         rule,
         #[cfg(feature = "ast-comments")]
+        comments_before_rule,
+        #[cfg(feature = "ast-comments")]
         comments_after_rule,
         ..
       } => {
         let mut rule_str = String::new();
+
+        #[cfg(feature = "ast-comments")]
+        if let Some(comments) = comments_before_rule {
+          if comments.any_non_newline() {
+            rule_str.push_str(&comments.to_string());
+          }
+        }
 
         rule_str.push_str(&rule.to_string());
 
@@ -414,10 +429,19 @@ impl fmt::Display for Rule<'_> {
       Rule::Group {
         rule,
         #[cfg(feature = "ast-comments")]
+        comments_before_rule,
+        #[cfg(feature = "ast-comments")]
         comments_after_rule,
         ..
       } => {
         let mut rule_str = String::new();
+
+        #[cfg(feature = "ast-comments")]
+        if let Some(comments) = comments_before_rule {
+          if comments.any_non_newline() {
+            rule_str.push_str(&comments.to_string());
+          }
+        }
 
         rule_str.push_str(&rule.to_string());
 
@@ -444,6 +468,23 @@ impl Rule<'_> {
     match self {
       Rule::Type { rule, .. } => rule.name.to_string(),
       Rule::Group { rule, .. } => rule.name.to_string(),
+    }
+  }
+
+  /// Returns the comments appearing on their own line(s) immediately before a
+  /// rule, if any
+  #[cfg(feature = "ast-comments")]
+  #[doc(hidden)]
+  pub fn comments_before_rule(&self) -> Option<&Comments<'_>> {
+    match self {
+      Rule::Type {
+        comments_before_rule,
+        ..
+      }
+      | Rule::Group {
+        comments_before_rule,
+        ..
+      } => comments_before_rule.as_ref(),
     }
   }
 
@@ -2145,6 +2186,88 @@ impl<'a> GroupChoice<'a> {
 impl fmt::Display for GroupChoice<'_> {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     let mut gc_str = String::new();
+
+    // When any entry carries its own leading or trailing doc comment (as
+    // populated by the parser from CDDL `; ...` comments), render the choice as
+    // a comment-preserving, one-entry-per-line block. This is handled up front
+    // and in isolation so the formatting heuristics below are unaffected for
+    // the (common) comment-free case.
+    #[cfg(feature = "ast-comments")]
+    {
+      let has_entry_doc_comments = self.group_entries.iter().any(|(ge, _)| {
+        matches!(ge,
+          GroupEntry::ValueMemberKey {
+            leading_comments,
+            trailing_comments,
+            ..
+          }
+          | GroupEntry::TypeGroupname {
+            leading_comments,
+            trailing_comments,
+            ..
+          } if leading_comments
+            .as_ref()
+            .map(|c| c.any_non_newline())
+            .unwrap_or(false)
+            || trailing_comments
+              .as_ref()
+              .map(|c| c.any_non_newline())
+              .unwrap_or(false))
+      });
+
+      if has_entry_doc_comments {
+        if let Some(comments) = &self.comments_before_grpchoice {
+          if comments.any_non_newline() {
+            gc_str.push_str(&comments.to_string());
+          }
+        }
+
+        for (ge, _comma) in self.group_entries.iter() {
+          if !gc_str.ends_with('\n') {
+            gc_str.push('\n');
+          }
+
+          let (leading, core, trailing) = match ge {
+            GroupEntry::ValueMemberKey {
+              ge: vmke,
+              leading_comments,
+              trailing_comments,
+              ..
+            } => (leading_comments, vmke.to_string(), trailing_comments),
+            GroupEntry::TypeGroupname {
+              ge: tge,
+              leading_comments,
+              trailing_comments,
+              ..
+            } => (leading_comments, tge.to_string(), trailing_comments),
+            other => {
+              gc_str.push_str(&other.to_string());
+              gc_str.push_str(",\n");
+              continue;
+            }
+          };
+
+          if let Some(c) = leading {
+            if c.any_non_newline() {
+              gc_str.push_str(&c.to_string());
+            }
+          }
+
+          gc_str.push_str(&core);
+          gc_str.push(',');
+
+          match trailing {
+            Some(c) if c.any_non_newline() => {
+              // `Comments` renders a trailing newline of its own.
+              let _ = write!(gc_str, " {}", c);
+            }
+            _ => gc_str.push('\n'),
+          }
+        }
+
+        return write!(f, "{}", gc_str);
+      }
+    }
 
     if self.group_entries.len() == 1 {
       let _ = write!(

--- a/src/pest_bridge.rs
+++ b/src/pest_bridge.rs
@@ -1217,6 +1217,190 @@ fn position_from_span(byte_offset: usize, input: &str) -> Position {
   }
 }
 
+/// Index of the document's comment tokens, keyed by 1-based source line.
+///
+/// `pure` holds comments that occupy a line on their own (used as "leading"
+/// documentation for the rule or entry on the following line), while `trailing`
+/// holds comments that follow code on the same line. The index is built from
+/// the grammar's real `COMMENT` tokens, so semicolons that appear inside text
+/// or byte strings are never mistaken for comments.
+#[cfg(all(feature = "ast-comments", feature = "ast-span"))]
+struct CommentIndex<'a> {
+  input: &'a str,
+  pure: HashMap<usize, &'a str>,
+  trailing: HashMap<usize, &'a str>,
+}
+
+#[cfg(all(feature = "ast-comments", feature = "ast-span"))]
+impl<'a> CommentIndex<'a> {
+  fn build(pair: &Pair<'a, Rule>, input: &'a str) -> Self {
+    let mut spans = Vec::new();
+    collect_comment_spans(pair, &mut spans);
+
+    let mut pure = HashMap::new();
+    let mut trailing = HashMap::new();
+
+    for span in spans {
+      let start = span.start();
+      let end = span.end();
+      // Text following the leading ';'.
+      let text = &input[start + 1..end];
+      let line = line_of_byte(input, start);
+      let line_start = input[..start].rfind('\n').map(|i| i + 1).unwrap_or(0);
+      if input[line_start..start].trim().is_empty() {
+        pure.insert(line, text);
+      } else {
+        trailing.insert(line, text);
+      }
+    }
+
+    CommentIndex {
+      input,
+      pure,
+      trailing,
+    }
+  }
+
+  /// Contiguous stand-alone comment lines immediately above `line`.
+  fn leading(&self, line: usize) -> Option<ast::Comments<'a>> {
+    let mut texts = Vec::new();
+    let mut l = line;
+    while l > 1 {
+      l -= 1;
+      match self.pure.get(&l) {
+        Some(text) => texts.push(*text),
+        None => break,
+      }
+    }
+
+    if texts.is_empty() {
+      return None;
+    }
+
+    texts.reverse();
+    Some(ast::Comments(texts))
+  }
+
+  /// A trailing comment on `line`, if present.
+  fn trailing_on(&self, line: usize) -> Option<ast::Comments<'a>> {
+    self
+      .trailing
+      .get(&line)
+      .map(|text| ast::Comments(vec![*text]))
+  }
+}
+
+#[cfg(all(feature = "ast-comments", feature = "ast-span"))]
+fn line_of_byte(input: &str, byte: usize) -> usize {
+  input[..byte].bytes().filter(|&b| b == b'\n').count() + 1
+}
+
+#[cfg(all(feature = "ast-comments", feature = "ast-span"))]
+fn collect_comment_spans<'a>(pair: &Pair<'a, Rule>, out: &mut Vec<PestSpan<'a>>) {
+  for inner in pair.clone().into_inner() {
+    if inner.as_rule() == Rule::COMMENT {
+      out.push(inner.as_span());
+    } else {
+      collect_comment_spans(&inner, out);
+    }
+  }
+}
+
+/// Attach indexed comments to the rules and their nested group entries.
+#[cfg(all(feature = "ast-comments", feature = "ast-span"))]
+fn attach_comments<'a>(rules: &mut [ast::Rule<'a>], idx: &CommentIndex<'a>) {
+  for rule in rules.iter_mut() {
+    match rule {
+      ast::Rule::Type {
+        rule,
+        span,
+        comments_before_rule,
+        ..
+      } => {
+        if comments_before_rule.is_none() {
+          *comments_before_rule = idx.leading(span.2);
+        }
+        attach_type(&mut rule.value, idx);
+      }
+      ast::Rule::Group {
+        rule,
+        span,
+        comments_before_rule,
+        ..
+      } => {
+        if comments_before_rule.is_none() {
+          *comments_before_rule = idx.leading(span.2);
+        }
+        attach_group_entry(&mut rule.entry, idx);
+      }
+    }
+  }
+}
+
+#[cfg(all(feature = "ast-comments", feature = "ast-span"))]
+fn attach_type<'a>(ty: &mut ast::Type<'a>, idx: &CommentIndex<'a>) {
+  for tc in ty.type_choices.iter_mut() {
+    attach_type2(&mut tc.type1.type2, idx);
+  }
+}
+
+#[cfg(all(feature = "ast-comments", feature = "ast-span"))]
+fn attach_type2<'a>(t2: &mut ast::Type2<'a>, idx: &CommentIndex<'a>) {
+  match t2 {
+    ast::Type2::Map { group, .. }
+    | ast::Type2::Array { group, .. }
+    | ast::Type2::ChoiceFromInlineGroup { group, .. } => attach_group(group, idx),
+    ast::Type2::ParenthesizedType { pt, .. } => attach_type(pt, idx),
+    ast::Type2::TaggedData { t, .. } => attach_type(t, idx),
+    _ => {}
+  }
+}
+
+#[cfg(all(feature = "ast-comments", feature = "ast-span"))]
+fn attach_group<'a>(group: &mut ast::Group<'a>, idx: &CommentIndex<'a>) {
+  for gc in group.group_choices.iter_mut() {
+    for (entry, _comma) in gc.group_entries.iter_mut() {
+      attach_group_entry(entry, idx);
+    }
+  }
+}
+
+#[cfg(all(feature = "ast-comments", feature = "ast-span"))]
+fn attach_group_entry<'a>(entry: &mut ast::GroupEntry<'a>, idx: &CommentIndex<'a>) {
+  match entry {
+    ast::GroupEntry::ValueMemberKey {
+      ge,
+      span,
+      leading_comments,
+      trailing_comments,
+    } => {
+      if leading_comments.is_none() {
+        *leading_comments = idx.leading(span.2);
+      }
+      if trailing_comments.is_none() {
+        *trailing_comments = idx.trailing_on(line_of_byte(idx.input, span.1));
+      }
+      attach_type(&mut ge.entry_type, idx);
+    }
+    ast::GroupEntry::TypeGroupname {
+      span,
+      leading_comments,
+      trailing_comments,
+      ..
+    } => {
+      if leading_comments.is_none() {
+        *leading_comments = idx.leading(span.2);
+      }
+      if trailing_comments.is_none() {
+        *trailing_comments = idx.trailing_on(line_of_byte(idx.input, span.1));
+      }
+    }
+    ast::GroupEntry::InlineGroup { group, .. } => {
+      attach_group(group, idx);
+    }
+  }
+}
+
 /// Convert Pest Pairs to CDDL AST
 fn convert_cddl<'a>(mut pairs: Pairs<'a, Rule>, input: &'a str) -> Result<ast::CDDL<'a>, Error> {
   let pair = pairs.next().ok_or_else(|| Error::PARSER {
@@ -1230,6 +1414,13 @@ fn convert_cddl<'a>(mut pairs: Pairs<'a, Rule>, input: &'a str) -> Result<ast::C
 
   let mut rules = Vec::new();
 
+  // Build an index of the document's comment tokens so they can be attached to
+  // the AST nodes they document. This uses the real `COMMENT` tokens produced
+  // by the grammar (so semicolons inside text/byte strings are never mistaken
+  // for comments) and runs as a post-pass once the rules have been built.
+  #[cfg(all(feature = "ast-comments", feature = "ast-span"))]
+  let comment_index = CommentIndex::build(&pair, input);
+
   for inner_pair in pair.into_inner() {
     match inner_pair.as_rule() {
       Rule::rule => {
@@ -1239,6 +1430,9 @@ fn convert_cddl<'a>(mut pairs: Pairs<'a, Rule>, input: &'a str) -> Result<ast::C
       _ => {}
     }
   }
+
+  #[cfg(all(feature = "ast-comments", feature = "ast-span"))]
+  attach_comments(&mut rules, &comment_index);
 
   // Check for duplicate rule names (non-alternate rules)
   let mut seen_names: HashMap<String, usize> = HashMap::new();
@@ -1335,6 +1529,8 @@ fn convert_rule<'a>(pair: Pair<'a, Rule>, input: &'a str) -> Result<ast::Rule<'a
         #[cfg(feature = "ast-span")]
         span,
         #[cfg(feature = "ast-comments")]
+        comments_before_rule: None,
+        #[cfg(feature = "ast-comments")]
         comments_after_rule: None,
       })
     }
@@ -1385,6 +1581,8 @@ fn convert_rule<'a>(pair: Pair<'a, Rule>, input: &'a str) -> Result<ast::Rule<'a
         }),
         #[cfg(feature = "ast-span")]
         span,
+        #[cfg(feature = "ast-comments")]
+        comments_before_rule: None,
         #[cfg(feature = "ast-comments")]
         comments_after_rule: None,
       })
@@ -3168,6 +3366,83 @@ mod tests {
 
     let cddl = result.unwrap();
     assert_eq!(cddl.rules.len(), 1);
+  }
+
+  #[cfg(all(feature = "ast-comments", feature = "ast-span"))]
+  #[test]
+  fn test_ast_comments_populated_for_rule_and_nested_entries() {
+    let input = "; A person.\n; identity info.\nperson = {\n  ; full name\n  name: tstr, ; trailing name\n  address: {\n    ; street line\n    street: tstr,\n  },\n}\n";
+    let cddl = cddl_from_pest_str(input).unwrap();
+
+    let rule = &cddl.rules[0];
+    let before = rule
+      .comments_before_rule()
+      .expect("rule should have leading comments");
+    assert_eq!(before.0, vec![" A person.", " identity info."]);
+
+    let ast::Rule::Type { rule, .. } = rule else {
+      panic!("expected type rule");
+    };
+
+    let ast::Type2::Map { group, .. } = &rule.value.type_choices[0].type1.type2 else {
+      panic!("expected map");
+    };
+
+    let entries = &group.group_choices[0].group_entries;
+
+    // First entry: leading + trailing comments.
+    let ast::GroupEntry::ValueMemberKey {
+      leading_comments,
+      trailing_comments,
+      ..
+    } = &entries[0].0
+    else {
+      panic!("expected value member key");
+    };
+    assert_eq!(
+      leading_comments.as_ref().map(|c| c.0.clone()),
+      Some(vec![" full name"])
+    );
+    assert_eq!(
+      trailing_comments.as_ref().map(|c| c.0.clone()),
+      Some(vec![" trailing name"])
+    );
+
+    // Second entry is a nested map; its inner entry carries a leading comment,
+    // demonstrating comments nested inside CDDL structures are preserved in the
+    // AST.
+    let ast::GroupEntry::ValueMemberKey { ge, .. } = &entries[1].0 else {
+      panic!("expected value member key");
+    };
+    let ast::Type2::Map { group: inner, .. } = &ge.entry_type.type_choices[0].type1.type2 else {
+      panic!("expected nested map");
+    };
+    let ast::GroupEntry::ValueMemberKey {
+      leading_comments, ..
+    } = &inner.group_choices[0].group_entries[0].0
+    else {
+      panic!("expected nested value member key");
+    };
+    assert_eq!(
+      leading_comments.as_ref().map(|c| c.0.clone()),
+      Some(vec![" street line"])
+    );
+  }
+
+  #[cfg(all(feature = "ast-comments", feature = "ast-span"))]
+  #[test]
+  fn test_ast_comments_roundtrip_reparses() {
+    // A commented map must format back into valid, re-parseable CDDL.
+    let input = "person = {\n  ; full name\n  name: tstr, ; trailing\n  age: uint,\n}\n";
+    let cddl = cddl_from_pest_str(input).unwrap();
+    let formatted = cddl.to_string();
+    assert!(
+      cddl_from_pest_str(&formatted).is_ok(),
+      "formatted output should re-parse:\n{}",
+      formatted
+    );
+    assert!(formatted.contains("; full name"));
+    assert!(formatted.contains("; trailing"));
   }
 
   #[test]


### PR DESCRIPTION
## Summary

Addresses [#533 (comment-4836714435)](https://github.com/anweiss/cddl/issues/533#issuecomment-4836714435).

PR #583 added CDDL → Rust doc-comment generation in `cddl-derive`, but recovered the comments by **scanning the raw `.cddl` source at codegen time**. As @SebastienGllmt pointed out, that approach is fragile for comments nested inside CDDL structures, since it relies on line-position heuristics over the original text rather than the parsed structure. The right fix is to keep the comments **in the AST**, populated by the parser.

This PR makes comments AST-native and rewires `cddl-derive` to consume them.

## Changes

**`src/ast/mod.rs`**
- Add `comments_before_rule` to `Rule::Type` / `Rule::Group` (the leading doc block above a rule), alongside the existing `comments_after_rule`.
- Add a `Rule::comments_before_rule()` accessor and render the leading comments in `Display`.
- Add an isolated, comment-aware branch to `GroupChoice`'s `Display` so that maps/groups carrying entry-level comments format as a one-entry-per-line block that **round-trips to valid CDDL** (comma placed before the trailing comment). The comment-free formatting path is untouched.

**`src/pest_bridge.rs`**
- Build a `CommentIndex` from the real `COMMENT` tokens emitted by the pest grammar. Using actual comment tokens (rather than scanning for `;`) is robust against semicolons inside text/byte strings.
- Run a focused mutable post-pass (`attach_comments`) that walks the freshly-built AST and fills:
  - `comments_before_rule` (leading block above each rule), and
  - group-entry `leading_comments` / `trailing_comments`, **including comments nested inside groups and maps**.
- Gated on `all(ast-comments, ast-span)`; when those features are off, the fields stay `None` (prior behavior).

**`cddl-derive/src/codegen.rs`**
- Prefer AST comments for struct / enum / type-alias and field doc comments (`ast_rule_doc`, `ast_entry_doc`, `ast_or_map_rule_doc`).
- Keep the raw-source `CommentMap` only as a **fallback** for positions not yet populated in the AST (e.g. type-choice / enum variants).

## Testing

- New parser tests: AST comment fields are populated for rule-leading and nested group entries, and a commented schema round-trips (format → re-parse).
- New codegen test: nested struct field comments are sourced from the AST.
- PR #583's `cddl_doc_comments` integration tests now flow through the AST path unchanged (regression coverage).
- Full local suite verified: `cargo fmt --all -- --check`, `cargo clippy --all`, clippy + check on `wasm32-unknown-unknown`, `cargo check --all` with default **and** `--no-default-features`, and `cargo test --all` (all green).

Closes #533

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>