### PR TITLE
fix(www): resolve dompurify, http-proxy-middleware and uuid security advisories

### DIFF
--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -1896,9 +1896,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -2666,10 +2666,11 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",
@@ -4882,12 +4883,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/www/package.json
+++ b/www/package.json
@@ -48,6 +48,8 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.5",
-    "dompurify": ">=3.4.0"
+    "dompurify": "^3.4.11",
+    "http-proxy-middleware": "^2.0.10",
+    "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
Clears the remaining open Dependabot security alerts in the `www` workspace that had no auto-generated PR. All three are transitive dependencies with no first-party usage, so they are pinned to patched versions via npm `overrides`.

| Package | Via | Pinned to | Advisories cleared |
| --- | --- | --- | --- |
| dompurify | monaco-editor | `^3.4.11` | GHSA-cmwh-pvxp-8882 + related `<=3.4.10` XSS / prototype-pollution alerts |
| http-proxy-middleware | webpack-dev-server | `^2.0.10` | GHSA-64mm-vxmg-q3vj |
| uuid | webpack-dev-server → sockjs | `^11.1.1` | GHSA-w5hq-g745-h8pq |

The pre-existing `dompurify: ">=3.4.0"` override was too loose (it permitted the vulnerable 3.4.0) and has been tightened.

## Verification
- Lockfile regenerated; resolved versions confirmed: dompurify `3.4.11`, http-proxy-middleware `2.0.10`, uuid `11.1.1`.
- `npm run build` (production webpack build) succeeds.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>