### PR TITLE
fix(pest_bridge): colon member key misparsed as arrow key on => in value

### DIFF
--- a/src/pest_bridge.rs
+++ b/src/pest_bridge.rs
@@ -2656,27 +2656,17 @@ fn convert_group_entry<'a>(
   let mut generic_args = None;
   let mut inline_group = None;
   let mut is_cut = false;
-  let mut is_arrow_map = false;
 
-  // Check the full matched text to determine the entry type
-  let full_text = pair.as_str();
-  let has_member_key = pair
-    .clone()
-    .into_inner()
-    .any(|p| p.as_rule() == Rule::member_key);
+  // Arrow vs. colon is decided structurally in convert_member_key_simple from
+  // the member_key's child rule (a Rule::type1 child is the arrow form;
+  // bareword/typename/value are colon keys), never from the entry text
+  // (otherwise, a substring scan can wrongly fire inside the entry's value)
+  // Cut (^) is the one bit we must precompute here: the member_key child is
+  // visited before the Rule::cut child in the loop below, so is_cut has to be
+  // known before the member_key conversion call.
   let has_cut = pair.clone().into_inner().any(|p| p.as_rule() == Rule::cut);
-  // Determine colon vs arrow by checking for "=>" in the text
-  // We need to be careful: "=>" could appear inside a text value
-  // Use the grammar structure: arrow alternative has cut? child and comes first
-  let has_arrow = has_member_key && (has_cut || full_text.contains("=>"));
-  let has_colon = has_member_key && !has_arrow && full_text.contains(':');
-
   if has_cut {
     is_cut = true;
-  }
-
-  if has_arrow {
-    is_arrow_map = true;
   }
 
   for inner in pair.into_inner() {
@@ -2688,17 +2678,13 @@ fn convert_group_entry<'a>(
         is_cut = true;
       }
       Rule::member_key => {
-        if has_colon || has_arrow {
-          // This is a real member key
-          member_key = Some(convert_member_key_simple(
-            inner,
-            input,
-            is_arrow_map,
-            is_cut,
-            #[cfg(feature = "ast-span")]
-            span,
-          )?);
-        }
+        member_key = Some(convert_member_key_simple(
+          inner,
+          input,
+          is_cut,
+          #[cfg(feature = "ast-span")]
+          span,
+        )?);
       }
       Rule::type_expr => {
         entry_type = Some(convert_type_expr(inner, input)?);
@@ -2892,7 +2878,6 @@ fn convert_occurrence<'a>(
 fn convert_member_key_simple<'a>(
   pair: Pair<'a, Rule>,
   input: &'a str,
-  is_arrow_map: bool,
   is_cut: bool,
   span: ast::Span,
 ) -> Result<ast::MemberKey<'a>, Error> {
@@ -2900,7 +2885,8 @@ fn convert_member_key_simple<'a>(
     match inner.as_rule() {
       Rule::type1 => {
         // type1 form (RFC 8610 §3.5.1): "type1 S [\"^\" S] \"=>\"".
-        // Always an arrow-map member key; ignore is_arrow_map flag here.
+        // The grammar only produces a type1 child behind the "=>" lookahead,
+        // so this is always the arrow form.
         let t1 = convert_type1(inner, input)?;
         return Ok(ast::MemberKey::Type1 {
           t1: Box::new(t1),
@@ -2916,96 +2902,33 @@ fn convert_member_key_simple<'a>(
         });
       }
       Rule::bareword => {
-        if is_arrow_map {
-          // Convert bareword to Type1 for arrow map
-          let type1 = ast::Type1 {
-            type2: ast::Type2::Typename {
-              ident: ast::Identifier {
-                ident: inner.as_str(),
-                socket: None,
-                #[cfg(feature = "ast-span")]
-                span: pest_span_to_ast_span(&inner.as_span(), input),
-              },
-              generic_args: None,
-              #[cfg(feature = "ast-span")]
-              span: pest_span_to_ast_span(&inner.as_span(), input),
-            },
-            operator: None,
+        return Ok(ast::MemberKey::Bareword {
+          ident: ast::Identifier {
+            ident: inner.as_str(),
+            socket: None,
             #[cfg(feature = "ast-span")]
             span: pest_span_to_ast_span(&inner.as_span(), input),
-            #[cfg(feature = "ast-comments")]
-            comments_after_type: None,
-          };
-          return Ok(ast::MemberKey::Type1 {
-            t1: Box::new(type1),
-            is_cut,
-            #[cfg(feature = "ast-span")]
-            span,
-            #[cfg(feature = "ast-comments")]
-            comments_before_cut: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_cut: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_arrowmap: None,
-          });
-        } else {
-          return Ok(ast::MemberKey::Bareword {
-            ident: ast::Identifier {
-              ident: inner.as_str(),
-              socket: None,
-              #[cfg(feature = "ast-span")]
-              span: pest_span_to_ast_span(&inner.as_span(), input),
-            },
-            #[cfg(feature = "ast-span")]
-            span,
-            #[cfg(feature = "ast-comments")]
-            comments: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_colon: None,
-          });
-        }
+          },
+          #[cfg(feature = "ast-span")]
+          span,
+          #[cfg(feature = "ast-comments")]
+          comments: None,
+          #[cfg(feature = "ast-comments")]
+          comments_after_colon: None,
+        });
       }
       Rule::typename => {
         let ident = convert_identifier(inner.clone(), input, false)?;
 
-        if is_arrow_map {
-          // Convert typename to Type1 for arrow map
-          let type1 = ast::Type1 {
-            type2: ast::Type2::Typename {
-              ident: ident.clone(),
-              generic_args: None,
-              #[cfg(feature = "ast-span")]
-              span: pest_span_to_ast_span(&inner.as_span(), input),
-            },
-            operator: None,
-            #[cfg(feature = "ast-span")]
-            span: pest_span_to_ast_span(&inner.as_span(), input),
-            #[cfg(feature = "ast-comments")]
-            comments_after_type: None,
-          };
-          return Ok(ast::MemberKey::Type1 {
-            t1: Box::new(type1),
-            is_cut,
-            #[cfg(feature = "ast-span")]
-            span,
-            #[cfg(feature = "ast-comments")]
-            comments_before_cut: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_cut: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_arrowmap: None,
-          });
-        } else {
-          return Ok(ast::MemberKey::Bareword {
-            ident,
-            #[cfg(feature = "ast-span")]
-            span,
-            #[cfg(feature = "ast-comments")]
-            comments: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_colon: None,
-          });
-        }
+        return Ok(ast::MemberKey::Bareword {
+          ident,
+          #[cfg(feature = "ast-span")]
+          span,
+          #[cfg(feature = "ast-comments")]
+          comments: None,
+          #[cfg(feature = "ast-comments")]
+          comments_after_colon: None,
+        });
       }
       Rule::value => {
         let value_type2 = convert_value_to_type2(
@@ -3014,30 +2937,6 @@ fn convert_member_key_simple<'a>(
           #[cfg(feature = "ast-span")]
           span,
         )?;
-
-        if is_arrow_map {
-          // For arrow maps, wrap the value as a Type1 member key
-          let type1 = ast::Type1 {
-            type2: value_type2,
-            operator: None,
-            #[cfg(feature = "ast-span")]
-            span,
-            #[cfg(feature = "ast-comments")]
-            comments_after_type: None,
-          };
-          return Ok(ast::MemberKey::Type1 {
-            t1: Box::new(type1),
-            is_cut,
-            #[cfg(feature = "ast-span")]
-            span,
-            #[cfg(feature = "ast-comments")]
-            comments_before_cut: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_cut: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_arrowmap: None,
-          });
-        }
 
         // Extract Value from Type2 for colon member keys
         let value = match value_type2 {
@@ -3085,7 +2984,6 @@ fn convert_member_key_simple<'a>(
 fn convert_member_key_simple<'a>(
   pair: Pair<'a, Rule>,
   input: &'a str,
-  is_arrow_map: bool,
   is_cut: bool,
 ) -> Result<ast::MemberKey<'a>, Error> {
   for inner in pair.into_inner() {
@@ -3105,99 +3003,30 @@ fn convert_member_key_simple<'a>(
         });
       }
       Rule::bareword => {
-        if is_arrow_map {
-          // Convert bareword to Type1 for arrow map
-          let type1 = ast::Type1 {
-            type2: ast::Type2::Typename {
-              ident: ast::Identifier {
-                ident: inner.as_str(),
-                socket: None,
-              },
-              generic_args: None,
-            },
-            operator: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_type: None,
-          };
-          return Ok(ast::MemberKey::Type1 {
-            t1: Box::new(type1),
-            is_cut,
-            #[cfg(feature = "ast-comments")]
-            comments_before_cut: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_cut: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_arrowmap: None,
-          });
-        } else {
-          return Ok(ast::MemberKey::Bareword {
-            ident: ast::Identifier {
-              ident: inner.as_str(),
-              socket: None,
-            },
-            #[cfg(feature = "ast-comments")]
-            comments: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_colon: None,
-          });
-        }
+        return Ok(ast::MemberKey::Bareword {
+          ident: ast::Identifier {
+            ident: inner.as_str(),
+            socket: None,
+          },
+          #[cfg(feature = "ast-comments")]
+          comments: None,
+          #[cfg(feature = "ast-comments")]
+          comments_after_colon: None,
+        });
       }
       Rule::typename => {
         let ident = convert_identifier(inner.clone(), input, false)?;
 
-        if is_arrow_map {
-          // Convert typename to Type1 for arrow map
-          let type1 = ast::Type1 {
-            type2: ast::Type2::Typename {
-              ident: ident.clone(),
-              generic_args: None,
-            },
-            operator: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_type: None,
-          };
-          return Ok(ast::MemberKey::Type1 {
-            t1: Box::new(type1),
-            is_cut,
-            #[cfg(feature = "ast-comments")]
-            comments_before_cut: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_cut: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_arrowmap: None,
-          });
-        } else {
-          return Ok(ast::MemberKey::Bareword {
-            ident,
-            #[cfg(feature = "ast-comments")]
-            comments: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_colon: None,
-          });
-        }
+        return Ok(ast::MemberKey::Bareword {
+          ident,
+          #[cfg(feature = "ast-comments")]
+          comments: None,
+          #[cfg(feature = "ast-comments")]
+          comments_after_colon: None,
+        });
       }
       Rule::value => {
         let value_type2 = convert_value_to_type2(inner.clone(), input)?;
-
-        if is_arrow_map {
-          // For arrow maps, wrap the value as a Type1 member key
-          let type1 = ast::Type1 {
-            type2: value_type2,
-            operator: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_type: None,
-          };
-          return Ok(ast::MemberKey::Type1 {
-            t1: Box::new(type1),
-            is_cut,
-            #[cfg(feature = "ast-comments")]
-            comments_before_cut: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_cut: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_arrowmap: None,
-          });
-        }
 
         // Extract Value from Type2 for colon member keys
         let value = match value_type2 {
@@ -3228,123 +3057,6 @@ fn convert_member_key_simple<'a>(
   }
 
   Err(Error::PARSER {
-    msg: ErrorMsg {
-      short: "Invalid member key".to_string(),
-      extended: None,
-    },
-  })
-}
-
-/// Convert member key (original - now unused but kept for reference)
-fn _convert_member_key<'a>(
-  pair: Pair<'a, Rule>,
-  input: &'a str,
-) -> Result<ast::MemberKey<'a>, Error> {
-  #[cfg(feature = "ast-span")]
-  let span = pest_span_to_ast_span(&pair.as_span(), input);
-
-  // Member keys can be:
-  // - bareword :
-  // - typename :
-  // - value :
-  // - type1 =>
-
-  let full_str = pair.as_str();
-
-  if full_str.contains("=>") {
-    // Type1 with arrow
-    for inner in pair.into_inner() {
-      if inner.as_rule() == Rule::type1 {
-        return Ok(ast::MemberKey::Type1 {
-          t1: Box::new(convert_type1(inner, input)?),
-          is_cut: false,
-          #[cfg(feature = "ast-span")]
-          span,
-          #[cfg(feature = "ast-comments")]
-          comments_before_cut: None,
-          #[cfg(feature = "ast-comments")]
-          comments_after_cut: None,
-          #[cfg(feature = "ast-comments")]
-          comments_after_arrowmap: None,
-        });
-      }
-    }
-  } else if full_str.contains(":") {
-    // Bareword or value with colon
-    for inner in pair.into_inner() {
-      match inner.as_rule() {
-        Rule::bareword => {
-          return Ok(ast::MemberKey::Bareword {
-            ident: ast::Identifier {
-              ident: inner.as_str(),
-              socket: None,
-              #[cfg(feature = "ast-span")]
-              span: pest_span_to_ast_span(&inner.as_span(), input),
-            },
-            #[cfg(feature = "ast-span")]
-            span,
-            #[cfg(feature = "ast-comments")]
-            comments: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_colon: None,
-          });
-        }
-        Rule::typename => {
-          return Ok(ast::MemberKey::Bareword {
-            ident: convert_identifier(inner, input, false)?,
-            #[cfg(feature = "ast-span")]
-            span,
-            #[cfg(feature = "ast-comments")]
-            comments: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_colon: None,
-          });
-        }
-        Rule::value => {
-          // Convert value to Value enum
-          let value_type2 = convert_value_to_type2(
-            inner.clone(),
-            input,
-            #[cfg(feature = "ast-span")]
-            span,
-          )?;
-
-          // Extract Value from Type2
-          let value = match value_type2 {
-            ast::Type2::IntValue { value, .. } => Value::INT(value),
-            ast::Type2::UintValue { value, .. } => Value::UINT(value),
-            ast::Type2::FloatValue { value, .. } => Value::FLOAT(value),
-            ast::Type2::TextValue { value, .. } => Value::TEXT(value),
-            _ => {
-              return Err(Error::PARSER {
-                #[cfg(feature = "ast-span")]
-                position: pest_span_to_position(&inner.as_span(), input),
-                msg: ErrorMsg {
-                  short: "Invalid member key value".to_string(),
-                  extended: None,
-                },
-              });
-            }
-          };
-
-          return Ok(ast::MemberKey::Value {
-            value,
-            #[cfg(feature = "ast-span")]
-            span,
-            #[cfg(feature = "ast-comments")]
-            comments: None,
-            #[cfg(feature = "ast-comments")]
-            comments_after_colon: None,
-          });
-        }
-        _ => {}
-      }
-    }
-  }
-
-  Err(Error::PARSER {
-    #[cfg(feature = "ast-span")]
-    position: Position::default(),
     msg: ErrorMsg {
       short: "Invalid member key".to_string(),
       extended: None,

--- a/tests/grammar.rs
+++ b/tests/grammar.rs
@@ -357,4 +357,49 @@ payload = any";
       bridge_result.err()
     );
   }
+
+  #[test]
+  fn test_bareword_colon_key_not_misparsed_as_arrow() {
+    // Regression: a colon/bareword member key must stay a Bareword even when the
+    // entry's VALUE contains "=>". The arrow-vs-colon distinction is structural
+    // (which member_key alternative matched), not a substring of the entry text;
+    // an earlier heuristic scanned the whole entry for "=>" and flipped `b` to a
+    // Type1 (arrow) key whenever the value happened to contain it. RFC 8610
+    // §3.5.1: `b:` is the text key "b"; only `b =>` makes `b` a type key.
+    use cddl::ast::{GroupEntry, MemberKey, Rule as AstRule, Type2};
+
+    fn first_member_key_variant(src: &str) -> &'static str {
+      let cddl = cddl::pest_bridge::cddl_from_pest_str(src).expect("parse failed");
+      let AstRule::Type { rule, .. } = &cddl.rules[0] else {
+        panic!("expected type rule");
+      };
+      let Type2::Map { group, .. } = &rule.value.type_choices[0].type1.type2 else {
+        panic!("expected map");
+      };
+      let (ge, _) = &group.group_choices[0].group_entries[0];
+      let GroupEntry::ValueMemberKey { ge, .. } = ge else {
+        panic!("expected value member key");
+      };
+      match ge.member_key.as_ref().expect("member key present") {
+        MemberKey::Bareword { .. } => "Bareword",
+        MemberKey::Type1 { .. } => "Type1",
+        MemberKey::Value { .. } => "Value",
+        MemberKey::NonMemberKey { .. } => "NonMemberKey",
+      }
+    }
+
+    // The bug: "=>" inside the value must not change the key's form.
+    assert_eq!(first_member_key_variant(r#"foo = { b: "=>" }"#), "Bareword");
+    assert_eq!(
+      first_member_key_variant("foo = { b: { * uint => uint } }"),
+      "Bareword"
+    );
+    // Plain colon keys.
+    assert_eq!(first_member_key_variant("foo = { b: uint }"), "Bareword");
+    assert_eq!(first_member_key_variant("foo = { 1: uint }"), "Value");
+    // Genuine arrow keys (any type1) must remain Type1 — cut (^) included.
+    assert_eq!(first_member_key_variant("foo = { b => uint }"), "Type1");
+    assert_eq!(first_member_key_variant("foo = { 1 => uint }"), "Type1");
+    assert_eq!(first_member_key_variant("foo = { b ^ => uint }"), "Type1");
+  }
 }


### PR DESCRIPTION
# Fix: bareword (colon) member key mis-parsed as a type-1 (arrow) key when the entry value contains `=>`

## Problem

In the Pest bridge, a colon-form member key (`name: type`, RFC 8610 §3.5.1) is silently converted
into an arrow-form type-1 member key (`type => type`) whenever the surrounding group entry's text
contains the substring `=>` **anywhere — including inside the entry's value**.

```cddl
foo = { x: uint, b: "=>" }
```

- **Expected:** `b` is `MemberKey::Bareword` — the text key `"b"`, whose value is the string `"=>"`.
- **Actual:** `b` is `MemberKey::Type1` — a *type* key named `b`.

There is no arrow member key anywhere in that entry; the only `=>` is two characters inside a string
literal. The same misfire happens for any entry whose value legitimately contains an arrow, e.g. a
nested map:

```cddl
foo = { b: { * uint => uint } }   ; `b` should be Bareword; the `=>` belongs to the inner map
```

This matters because the two forms mean different things (RFC 8610 §3.5.1): `b: T` matches a fixed
field whose key is the text `"b"`, while `b => T` matches any key of *type* `b`. Since `b` is usually
not a defined type, the misparse also turns a well-formed schema into one with an undefined type
reference. Any consumer that distinguishes text keys from type keys (validators, code generators) is
affected.

## Root cause and relation to the Pest migration / #536

The grammar is **not** at fault — it disambiguates correctly. The defect is in the AST conversion,
which re-derives the arrow-vs-colon distinction from a raw substring scan of the whole entry instead
of reading the parse tree:

```rust
// src/pest_bridge.rs, convert_group_entry (before)
let full_text = pair.as_str();                                    // spans key AND value
let has_arrow = has_member_key && (has_cut || full_text.contains("=>"));
let has_colon = has_member_key && !has_arrow && full_text.contains(':');
```

`full_text` spans the entire entry, so any `=>` in the value corrupts the classification.

- This heuristic is **original to the Pest migration** (`c3db585` "refactor for Pest", finalized in
  #339), not new. The bug has existed since the first Pest-based release.
- **#536** (`c214c23`, "Allow any type1 as an arrow-style member key") is what makes the clean fix
  possible. Before it, `member_key` had no `type1` alternative, so a colon key and an arrow key
  produced the *same* child rule and the conversion had no structural signal to read — hence the
  substring fallback. #536 added a lookahead-gated `type1` alternative:

  ```pest
  member_key = { type1 ~ S ~ &(("^" ~ S)? ~ "=>") | bareword | typename ~ generic_args? | value }
  ```

  so a genuine arrow key now always carries a `Rule::type1` child and a colon key never does. #536
  already applied this principle to its *new* type-1 arrows (its `Rule::type1` conversion arm ignores
  the substring flag), but deliberately left the legacy `bareword`/`typename`/`value` path on the old
  heuristic — which is the path that is buggy.

## The fix

Decide arrow vs. colon **structurally** instead of substring checking or based on a boolean parameter to functions

Note: after #536, a `bareword`/`typename`/`value` child of `member_key` can
**only** occur in colon context (every arrow routes through the `type1` alternative).

This means the old `if is_arrow_map { …→Type1 }` branches in those arms were **unreachable dead code** — they only ever
fired because the substring scan mis-set the flag. Therefore, the minimal correct change is therefore not to re-derive the flag, but to delete it

Conversion is now a pure function of the parse-tree shape, with no footgun left behind.

```rust
// after — the whole arrow/colon decision moves into the type-tree-driven member-key conversion
let has_cut = pair.clone().into_inner().any(|p| p.as_rule() == Rule::cut);
if has_cut {
  is_cut = true;
}
```

## Other notes

- **Also removed `_convert_member_key`** — an unused (no callers) function that carried the same
  `full_str.contains("=>")` heuristic (keeping it as reference didn't feel like it made sense if it's wrong)

## Test plan

Added `test_bareword_colon_key_not_misparsed_as_arrow` in `tests/grammar.rs`. Existing member-key
tests only asserted parse *success* and so could not catch a wrong variant; this one asserts the
member-key **variant**:

| CDDL | key | expected |
| --- | --- | --- |
| `foo = { b: "=>" }` | `b` | `Bareword` (was `Type1` — the bug) |
| `foo = { b: { * uint => uint } }` | `b` | `Bareword` (was `Type1` — the bug) |
| `foo = { b: uint }` | `b` | `Bareword` |
| `foo = { 1: uint }` | `1` | `Value` |
| `foo = { b => uint }` | `b` | `Type1` |
| `foo = { 1 => uint }` | `1` | `Type1` |
| `foo = { b ^ => uint }` | `b` | `Type1` |

`cargo test --lib` passes (full default feature set); `cargo fmt` clean.
