### PR TITLE
fix(validator) control ops validation on uint

### DIFF
--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -999,23 +999,15 @@ where
         self.add_error(format!("expected type bstr, got {:?}", self.cbor));
         return Ok(());
       } else if is_ident_uint_data_type(self.state.cddl, target_ident) {
-        // For uint, we need to check that it's an integer and it's non-negative
-        if !matches!(self.cbor, Value::Integer(_)) {
-          self.add_error(format!("expected type uint, got {:?}", self.cbor));
-          return Ok(());
-        } else if let Value::Integer(i) = &self.cbor {
-          if i128::from(*i) < 0 {
+        // For uint, we need to check that it's an integer and it's non-negative,
+        // then fall through so the control operator is enforced
+        match &self.cbor {
+          Value::Integer(i) if i128::from(*i) >= 0 => {}
+          _ => {
             self.add_error(format!("expected type uint, got {:?}", self.cbor));
             return Ok(());
           }
         }
-        // For bitfield, fall through to the match ctrl block
-        #[cfg(feature = "freezer")]
-        if ctrl != ControlOperator::BITFIELD {
-          return Ok(());
-        }
-        #[cfg(not(feature = "freezer"))]
-        return Ok(());
       } else if is_ident_integer_data_type(self.state.cddl, target_ident)
         && !matches!(self.cbor, Value::Integer(_))
       {

--- a/tests/cbor.rs
+++ b/tests/cbor.rs
@@ -130,6 +130,28 @@ fn validate_cbor_integer() {
 }
 
 #[test]
+fn validate_cbor_uint_control_ops() {
+  // ensure control ops over uint targets aren't skipped
+  const INT_8: &[u8] = b"\x08";
+  const INT_255: &[u8] = b"\x18\xff";
+  const INT_256: &[u8] = b"\x19\x01\x00";
+  for (cddl_input, accept, reject) in [
+    ("thing = uint .le 23", cbor::INT_23, cbor::INT_24),
+    ("thing = uint .lt 24", cbor::INT_23, cbor::INT_24),
+    ("thing = uint .gt 23", cbor::INT_24, cbor::INT_23),
+    ("thing = uint .ge 24", cbor::INT_24, cbor::INT_23),
+    ("thing = uint .eq 23", cbor::INT_23, cbor::INT_24),
+    ("thing = uint .ne 23", cbor::INT_24, cbor::INT_23),
+    ("thing = uint .size 1", INT_255, INT_256),
+    ("thing = uint .bits 3", INT_8, cbor::INT_23),
+  ] {
+    validate_cbor_from_slice(cddl_input, accept, None).unwrap();
+    validate_cbor_from_slice(cddl_input, reject, None).unwrap_err();
+    validate_cbor_from_slice(cddl_input, cbor::NINT_1000, None).unwrap_err();
+  }
+}
+
+#[test]
 fn validate_cbor_textstring() {
   let cddl_input = r#"thing = tstr"#;
   validate_cbor_from_slice(cddl_input, cbor::TEXT_EMPTY, None).unwrap();


### PR DESCRIPTION
# What's the bug

The end of the validation for `is_ident_uint_data_type` assumes that returning `Ok()` will move on to validating the control ops block: 
https://github.com/anweiss/cddl/blob/main/src/validator/cbor.rs#L1013-L1018

However, the control ops validation actually happens *in the same function*
https://github.com/anweiss/cddl/blob/main/src/validator/cbor.rs#L1042

that means that control ops never get checked

## Why this happened

This bug was introduced in https://github.com/anweiss/cddl/pull/431

In fact, the AI code failure analysis on that PR actually found this exact bug

<img width="1054" height="598" alt="image" src="https://github.com/user-attachments/assets/1bc01c65-c13e-48a8-a776-f518ca604856" />

however, the contributor either didn't see that part of the bug report (or didn't understand), and bug analysis was not re-run so it didn't realize the contributor's fix didn't actually solve the bug

## Why this is correct

The new behavior (after this PR):
- matches the Ruby `cddl` gem 0.12.14
- matches 3.8 of the [cddl spec](https://datatracker.ietf.org/doc/html/rfc8610#section-3.8)