### PR TITLE
fix(validator) array validation sequence semantics

### DIFF
--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -12,7 +12,6 @@ use crate::{
 use core::convert::TryInto;
 use std::{
   borrow::Cow,
-  collections::HashMap,
   convert::TryFrom,
   fmt::{self, Write},
 };
@@ -158,9 +157,6 @@ pub struct CBORValidator<'a> {
   values_to_validate: Option<Vec<Value>>,
   // Whether or not the validator is validating a map entry value
   validating_value: bool,
-  // Collect invalid array item errors where the key is the index of the invalid
-  // array item
-  array_errors: Option<HashMap<usize, Vec<ValidationError>>>,
   range_upper: Option<usize>,
 }
 
@@ -178,7 +174,6 @@ impl<'a> CBORValidator<'a> {
       validated_keys: None,
       values_to_validate: None,
       validating_value: false,
-      array_errors: None,
       range_upper: None,
     }
   }
@@ -196,7 +191,6 @@ impl<'a> CBORValidator<'a> {
       validated_keys: None,
       values_to_validate: None,
       validating_value: false,
-      array_errors: None,
       range_upper: None,
     }
   }
@@ -214,7 +208,6 @@ impl<'a> CBORValidator<'a> {
       validated_keys: None,
       values_to_validate: None,
       validating_value: false,
-      array_errors: None,
       range_upper: None,
     }
   }
@@ -232,7 +225,6 @@ impl<'a> CBORValidator<'a> {
       validated_keys: None,
       values_to_validate: None,
       validating_value: false,
-      array_errors: None,
       range_upper: None,
     }
   }
@@ -264,153 +256,16 @@ impl<'a> CBORValidator<'a> {
   where
     cbor::Error<T>: From<cbor::Error<std::io::Error>>,
   {
-    if let Value::Array(a) = &self.cbor {
+    // Arrays are matched against array-shaped types by the sequence matcher
+    // (seq_match_group); reaching this point means an array value is being
+    // validated against a non-array type
+    if let Value::Array(_) = &self.cbor {
       // Member keys are annotation only in an array context
       if self.state.is_member_key {
         return Ok(());
       }
 
-      match validate_array_occurrence(
-        self.state.occurrence.as_ref(),
-        self.state.entry_counts.as_ref().map(|ec| &ec[..]),
-        a,
-      ) {
-        Ok((iter_items, allow_empty_array)) => {
-          if iter_items {
-            for (idx, v) in a.iter().enumerate() {
-              if let Some(indices) = &self.state.valid_array_items {
-                if self.state.is_multi_type_choice && indices.contains(&idx) {
-                  continue;
-                }
-              }
-
-              #[cfg(all(feature = "additional-controls", target_arch = "wasm32"))]
-              let mut cv = self.new_with_recursion_state(v.clone());
-              #[cfg(all(feature = "additional-controls", not(target_arch = "wasm32")))]
-              let mut cv = self.new_with_recursion_state(v.clone());
-              #[cfg(not(feature = "additional-controls"))]
-              let mut cv = self.new_with_recursion_state(v.clone());
-
-              cv.state.generic_rules = self.state.generic_rules.clone();
-              cv.state.eval_generic_rule = self.state.eval_generic_rule;
-              cv.state.ctrl = self.state.ctrl;
-              cv.state.is_multi_type_choice = self.state.is_multi_type_choice;
-              let _ = write!(
-                cv.state.data_location,
-                "{}/{}",
-                self.state.data_location, idx
-              );
-
-              match token {
-                ArrayItemToken::Value(value) => cv.visit_value(value)?,
-                ArrayItemToken::Range(lower, upper, is_inclusive) => {
-                  cv.visit_range(lower, upper, *is_inclusive)?
-                }
-                // Special handling for nested arrays when using the Group variant
-                ArrayItemToken::Group(group) if v.is_array() => {
-                  // Special handling for nested arrays
-                  cv.visit_group(group)?;
-                }
-                ArrayItemToken::Group(group) => cv.visit_group(group)?,
-                ArrayItemToken::Identifier(ident) => cv.visit_identifier(ident)?,
-                ArrayItemToken::TaggedData(tagged_data) => cv.visit_type2(tagged_data)?,
-              }
-
-              if self.state.is_multi_type_choice && cv.errors.is_empty() {
-                if let Some(indices) = &mut self.state.valid_array_items {
-                  indices.push(idx);
-                } else {
-                  // Element index out of bounds, add error only if occurrence requires it
-                  match self.state.occurrence {
-                    #[cfg(feature = "ast-span")]
-                    Some(Occur::OneOrMore { .. }) | Some(Occur::Exact { .. }) => {
-                      self.add_error(format!(
-                        "expected array element at index {}, but array only has {} elements",
-                        idx,
-                        a.len()
-                      ));
-                    }
-                    #[cfg(not(feature = "ast-span"))]
-                    Some(Occur::OneOrMore {}) | Some(Occur::Exact { .. }) => {
-                      self.add_error(format!(
-                        "expected array element at index {}, but array only has {} elements",
-                        idx,
-                        a.len()
-                      ));
-                    }
-                    _ => {} // Do nothing if occurrence is Optional, ZeroOrMore, or None
-                  }
-                  return Ok(());
-                }
-                continue;
-              }
-
-              if let Some(errors) = &mut self.array_errors {
-                if let Some(error) = errors.get_mut(&idx) {
-                  error.append(&mut cv.errors);
-                } else {
-                  errors.insert(idx, cv.errors);
-                }
-              } else {
-                let mut errors = HashMap::new();
-                errors.insert(idx, cv.errors);
-                self.array_errors = Some(errors)
-              }
-            }
-          } else {
-            let idx = if !self.state.is_multi_type_choice {
-              self.state.group_entry_idx.take()
-            } else {
-              self.state.group_entry_idx
-            };
-
-            if let Some(idx) = idx {
-              if let Some(v) = a.get(idx) {
-                #[cfg(all(feature = "additional-controls", target_arch = "wasm32"))]
-                let mut cv = self.new_with_recursion_state(v.clone());
-                #[cfg(all(feature = "additional-controls", not(target_arch = "wasm32")))]
-                let mut cv = self.new_with_recursion_state(v.clone());
-                #[cfg(not(feature = "additional-controls"))]
-                let mut cv = self.new_with_recursion_state(v.clone());
-
-                cv.state.ctrl = self.state.ctrl;
-                cv.state.is_multi_type_choice = self.state.is_multi_type_choice;
-                let _ = write!(
-                  cv.state.data_location,
-                  "{}/{}",
-                  self.state.data_location, idx
-                );
-
-                match token {
-                  ArrayItemToken::Value(value) => cv.visit_value(value)?,
-                  ArrayItemToken::Range(lower, upper, is_inclusive) => {
-                    cv.visit_range(lower, upper, *is_inclusive)?
-                  }
-                  // Special nested array handling when using the Group variant
-                  ArrayItemToken::Group(group) if v.is_array() => {
-                    // Special handling for nested arrays
-                    cv.visit_group(group)?;
-                  }
-                  ArrayItemToken::Group(group) => cv.visit_group(group)?,
-                  ArrayItemToken::Identifier(ident) => cv.visit_identifier(ident)?,
-                  ArrayItemToken::TaggedData(tagged_data) => cv.visit_type2(tagged_data)?,
-                }
-
-                self.errors.append(&mut cv.errors);
-              } else if !allow_empty_array {
-                self.add_error(token.error_msg(Some(idx)));
-              }
-            } else if !self.state.is_multi_type_choice {
-              self.add_error(format!("{}, got {:?}", token.error_msg(None), self.cbor));
-            }
-          }
-        }
-        Err(errors) => {
-          for e in errors.into_iter() {
-            self.add_error(e);
-          }
-        }
-      }
+      self.add_error(format!("{}, got {:?}", token.error_msg(None), self.cbor));
     }
 
     Ok(())
@@ -445,6 +300,423 @@ impl<'a> CBORValidator<'a> {
         ))
       }
       _ => Err(format!("Expected uint value or type name, got {}", bound)),
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Array sequence matcher (RFC 8610 Appendix A PEG semantics).
+  //
+  // Matching a group against an array is "sequence matching" over the array's
+  // elements with a cursor:
+  // 1. a leaf entry consumes exactly one element
+  // 2. a group (inline, group-rule reference or unwrap) matches a subsequence
+  // 3. an occurrence indicator greedily quantifies its entry (no backtracking out of a repetition)
+  // 4. "//" is prioritized choice that locks in the first successful alternative.
+  // Leaf checks delegate to the existing single-value machinery via a child validator,
+  // which is what resolves "/=" chains, generics, tags and control operators.
+  //
+  // All matcher functions return
+  // - Ok(Some(new_cursor)) on a match,
+  // - Ok(None) on a (silent, speculative) mismatch
+  // - Err only for fatal errors that abort validation entirely.
+  // ---------------------------------------------------------------------
+
+  /// Match a group against elems[cursor..]:
+  /// prioritized choice over the group's choices
+  fn seq_match_group<T: std::fmt::Debug + 'static>(
+    &mut self,
+    group: &Group<'a>,
+    elems: &[Value],
+    cursor: usize,
+    ctx: &mut ArraySeqCtx<'a, ValidationError>,
+  ) -> std::result::Result<Option<usize>, Error<T>>
+  where
+    cbor::Error<T>: From<cbor::Error<std::io::Error>>,
+  {
+    for gc in group.group_choices.iter() {
+      if let Some(end) = self.seq_match_group_choice(gc, elems, cursor, ctx)? {
+        return Ok(Some(end));
+      }
+    }
+
+    Ok(None)
+  }
+
+  /// Match a single group choice:
+  /// fold its entries over the cursor from left to right
+  fn seq_match_group_choice<T: std::fmt::Debug + 'static>(
+    &mut self,
+    gc: &GroupChoice<'a>,
+    elems: &[Value],
+    cursor: usize,
+    ctx: &mut ArraySeqCtx<'a, ValidationError>,
+  ) -> std::result::Result<Option<usize>, Error<T>>
+  where
+    cbor::Error<T>: From<cbor::Error<std::io::Error>>,
+  {
+    let mut cur = cursor;
+    for (entry, _) in gc.group_entries.iter() {
+      match self.seq_match_entry(entry, elems, cur, ctx)? {
+        Some(next) => cur = next,
+        None => return Ok(None),
+      }
+    }
+
+    Ok(Some(cur))
+  }
+
+  /// Match a group entry, applying its occurrence indicator:
+  /// greedily match up to the upper bound of iterations,
+  /// where a failed iteration rewinds only itself,
+  /// then require the lower bound
+  fn seq_match_entry<T: std::fmt::Debug + 'static>(
+    &mut self,
+    entry: &GroupEntry<'a>,
+    elems: &[Value],
+    cursor: usize,
+    ctx: &mut ArraySeqCtx<'a, ValidationError>,
+  ) -> std::result::Result<Option<usize>, Error<T>>
+  where
+    cbor::Error<T>: From<cbor::Error<std::io::Error>>,
+  {
+    let occur = match entry {
+      GroupEntry::ValueMemberKey { ge, .. } => ge.occur.as_ref().map(|o| o.occur),
+      GroupEntry::TypeGroupname { ge, .. } => ge.occur.as_ref().map(|o| o.occur),
+      GroupEntry::InlineGroup { occur, .. } => occur.as_ref().map(|o| o.occur),
+    };
+
+    let (min, max) = match occur {
+      None => (1, Some(1)),
+      Some(Occur::Optional { .. }) => (0, Some(1)),
+      Some(Occur::ZeroOrMore { .. }) => (0, None),
+      Some(Occur::OneOrMore { .. }) => (1, None),
+      Some(Occur::Exact { lower, upper, .. }) => (lower.unwrap_or(0), upper),
+    };
+
+    let mut cur = cursor;
+    let mut count = 0usize;
+    while max.is_none_or(|m| count < m) {
+      match self.seq_match_entry_once(entry, elems, cur, ctx)? {
+        Some(next) => {
+          count += 1;
+          if next == cur {
+            // Zero-width iteration: no further progress is possible, and any
+            // remaining minimum is trivially satisfiable by more zero-width
+            // matches. Stop to guarantee termination (e.g. [* ()]).
+            count = count.max(min);
+            break;
+          }
+          cur = next;
+        }
+        None => break,
+      }
+    }
+
+    if count >= min {
+      Ok(Some(cur))
+    } else {
+      Ok(None)
+    }
+  }
+
+  /// Match a single iteration of a group entry, ignoring its occurrence
+  /// indicator.
+  ///
+  /// Subsequences (inline groups, group-rule references, unwraps
+  /// of array/map rules) recurse into the matcher;
+  ///
+  /// everything else is a leaf that consumes exactly one element
+  /// validated with the single-value machinery.
+  fn seq_match_entry_once<T: std::fmt::Debug + 'static>(
+    &mut self,
+    entry: &GroupEntry<'a>,
+    elems: &[Value],
+    cursor: usize,
+    ctx: &mut ArraySeqCtx<'a, ValidationError>,
+  ) -> std::result::Result<Option<usize>, Error<T>>
+  where
+    cbor::Error<T>: From<cbor::Error<std::io::Error>>,
+  {
+    match entry {
+      GroupEntry::InlineGroup { group, .. } => self.seq_match_group(group, elems, cursor, ctx),
+      GroupEntry::TypeGroupname { ge, .. } => {
+        let grule = group_rule_from_ident(self.state.cddl, &ge.name);
+        let alternates = group_choice_alternates_from_ident(self.state.cddl, &ge.name);
+        if grule.is_some() || !alternates.is_empty() {
+          return self.seq_match_group_ref(ge, grule, &alternates, elems, cursor, ctx);
+        }
+
+        // Leaf: validate one element against the named type
+        self.seq_match_leaf(elems, cursor, ctx, |cv| {
+          if let Some(ga) = &ge.generic_args {
+            if let Some(rule) = rule_from_ident(cv.state.cddl, &ge.name) {
+              if let Some(gr) = cv
+                .state
+                .generic_rules
+                .iter_mut()
+                .find(|gr| gr.name == ge.name.ident)
+              {
+                for arg in ga.args.iter() {
+                  gr.args.push((*arg.arg).clone());
+                }
+              } else if let Some(params) = generic_params_from_rule(rule) {
+                cv.state.generic_rules.push(GenericRule {
+                  name: ge.name.ident,
+                  params,
+                  args: ga.args.iter().cloned().map(|arg| *arg.arg).collect(),
+                });
+              }
+
+              cv.state.eval_generic_rule = Some(ge.name.ident);
+              return cv.visit_rule(rule);
+            }
+          }
+
+          // Type socket with no main rule definition: its "/=" alternates
+          // are the only choices (visit_identifier cannot resolve these)
+          if rule_from_ident(cv.state.cddl, &ge.name).is_none() {
+            let alternates = type_choice_alternates_from_ident(cv.state.cddl, &ge.name);
+            if !alternates.is_empty() {
+              cv.state.is_multi_type_choice = true;
+              for t in alternates {
+                let error_count = cv.errors.len();
+                cv.visit_type(t)?;
+                if cv.errors.len() == error_count {
+                  cv.errors.clear();
+                  break;
+                }
+              }
+              return Ok(());
+            }
+          }
+
+          cv.visit_identifier(&ge.name)
+        })
+      }
+      GroupEntry::ValueMemberKey { ge, .. } => {
+        // RFC 8610 3.7: an unwrapped array/map rule contributes the
+        // referenced rule's group as a subsequence, not as a single element
+        // (a member key, being annotation-only in an array context, does not
+        // change this)
+        if ge.entry_type.type_choices.len() == 1 {
+          let tc = &ge.entry_type.type_choices[0];
+          if tc.type1.operator.is_none() {
+            if let Type2::Unwrap {
+              ident,
+              generic_args,
+              ..
+            } = &tc.type1.type2
+            {
+              if let Some(rule) = unwrap_rule_from_ident(self.state.cddl, ident) {
+                if let Rule::Type { rule: trule, .. } = rule {
+                  if trule
+                    .value
+                    .type_choices
+                    .iter()
+                    .any(|tc| matches!(tc.type1.type2, Type2::Array { .. } | Type2::Map { .. }))
+                  {
+                    return self.seq_match_unwrap(
+                      ident,
+                      generic_args.as_ref(),
+                      rule,
+                      elems,
+                      cursor,
+                      ctx,
+                    );
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        // Leaf: member keys are annotation-only in an array context;
+        // validate one element against the entry type
+        self.seq_match_leaf(elems, cursor, ctx, |cv| cv.visit_type(&ge.entry_type))
+      }
+    }
+  }
+
+  /// Match a group-rule reference (possibly generic, possibly with "//="
+  /// alternates) as a subsequence
+  fn seq_match_group_ref<T: std::fmt::Debug + 'static>(
+    &mut self,
+    ge: &TypeGroupnameEntry<'a>,
+    grule: Option<&'a GroupRule<'a>>,
+    alternates: &[&'a GroupEntry<'a>],
+    elems: &[Value],
+    cursor: usize,
+    ctx: &mut ArraySeqCtx<'a, ValidationError>,
+  ) -> std::result::Result<Option<usize>, Error<T>>
+  where
+    cbor::Error<T>: From<cbor::Error<std::io::Error>>,
+  {
+    let key = (ge.name.ident, cursor);
+    if ctx.active_group_refs.contains(&key) {
+      // Recursive group reference without progress cannot match
+      return Ok(None);
+    }
+    ctx.active_group_refs.push(key);
+
+    // Snapshot generic state so args registered for this (possibly failing,
+    // speculative) descent don't leak into sibling alternatives or later
+    // iterations
+    let prev_eval = self.state.eval_generic_rule;
+    let prev_generic_rules = ge
+      .generic_args
+      .as_ref()
+      .map(|_| self.state.generic_rules.clone());
+    if let Some(ga) = &ge.generic_args {
+      if let Some(rule) = rule_from_ident(self.state.cddl, &ge.name) {
+        if let Some(gr) = self
+          .state
+          .generic_rules
+          .iter_mut()
+          .find(|gr| gr.name == ge.name.ident)
+        {
+          for arg in ga.args.iter() {
+            gr.args.push((*arg.arg).clone());
+          }
+        } else if let Some(params) = generic_params_from_rule(rule) {
+          self.state.generic_rules.push(GenericRule {
+            name: ge.name.ident,
+            params,
+            args: ga.args.iter().cloned().map(|arg| *arg.arg).collect(),
+          });
+        }
+
+        self.state.eval_generic_rule = Some(ge.name.ident);
+      }
+    }
+
+    let mut result = None;
+    if let Some(grule) = grule {
+      result = self.seq_match_entry(&grule.entry, elems, cursor, ctx)?;
+    }
+    if result.is_none() {
+      for alt in alternates {
+        result = self.seq_match_entry(alt, elems, cursor, ctx)?;
+        if result.is_some() {
+          break;
+        }
+      }
+    }
+
+    self.state.eval_generic_rule = prev_eval;
+    if let Some(prev) = prev_generic_rules {
+      self.state.generic_rules = prev;
+    }
+    ctx.active_group_refs.pop();
+
+    Ok(result)
+  }
+
+  /// Match an unwrapped rule (~rule, RFC 8610 3.7) as a subsequence: the
+  /// group inside the referenced array/map rule is matched in place
+  fn seq_match_unwrap<T: std::fmt::Debug + 'static>(
+    &mut self,
+    ident: &Identifier<'a>,
+    generic_args: Option<&GenericArgs<'a>>,
+    rule: &'a Rule<'a>,
+    elems: &[Value],
+    cursor: usize,
+    ctx: &mut ArraySeqCtx<'a, ValidationError>,
+  ) -> std::result::Result<Option<usize>, Error<T>>
+  where
+    cbor::Error<T>: From<cbor::Error<std::io::Error>>,
+  {
+    // Guard against recursive unwrap references that would loop without
+    // consuming elements (e.g. a = [~b], b = [~b])
+    let key = (ident.ident, cursor);
+    if ctx.active_group_refs.contains(&key) {
+      return Ok(None);
+    }
+    ctx.active_group_refs.push(key);
+
+    // Snapshot generic state so args registered for this (possibly failing,
+    // speculative) descent don't leak into sibling alternatives or later
+    // iterations
+    let prev_eval = self.state.eval_generic_rule;
+    let prev_generic_rules = generic_args.map(|_| self.state.generic_rules.clone());
+    if let Some(ga) = generic_args {
+      if let Some(gr) = self
+        .state
+        .generic_rules
+        .iter_mut()
+        .find(|gr| gr.name == ident.ident)
+      {
+        for arg in ga.args.iter() {
+          gr.args.push((*arg.arg).clone());
+        }
+      } else if let Some(params) = generic_params_from_rule(rule) {
+        self.state.generic_rules.push(GenericRule {
+          name: ident.ident,
+          params,
+          args: ga.args.iter().cloned().map(|arg| *arg.arg).collect(),
+        });
+      }
+
+      self.state.eval_generic_rule = Some(ident.ident);
+    }
+
+    let mut result = None;
+    if let Rule::Type { rule: trule, .. } = rule {
+      for tc in trule.value.type_choices.iter() {
+        if let Type2::Array { group, .. } | Type2::Map { group, .. } = &tc.type1.type2 {
+          result = self.seq_match_group(group, elems, cursor, ctx)?;
+          if result.is_some() {
+            break;
+          }
+        }
+      }
+    }
+
+    self.state.eval_generic_rule = prev_eval;
+    if let Some(prev) = prev_generic_rules {
+      self.state.generic_rules = prev;
+    }
+    ctx.active_group_refs.pop();
+
+    Ok(result)
+  }
+
+  /// Validate elems[cursor] against a leaf entry by spawning a child
+  /// validator on the element value. Failures are silent (speculative):
+  /// the child's errors are recorded in the context for later reporting
+  /// but never bubble into self.errors here.
+  fn seq_match_leaf<T, F>(
+    &mut self,
+    elems: &[Value],
+    cursor: usize,
+    ctx: &mut ArraySeqCtx<'a, ValidationError>,
+    f: F,
+  ) -> std::result::Result<Option<usize>, Error<T>>
+  where
+    T: std::fmt::Debug + 'static,
+    cbor::Error<T>: From<cbor::Error<std::io::Error>>,
+    F: FnOnce(&mut CBORValidator<'a>) -> visitor::Result<Error<T>>,
+  {
+    let value = match elems.get(cursor) {
+      Some(v) => v.clone(),
+      // Ran out of elements
+      None => return Ok(None),
+    };
+
+    let mut cv = self.new_with_recursion_state(value);
+    cv.state.ctrl = self.state.ctrl;
+    let _ = write!(
+      cv.state.data_location,
+      "{}/{}",
+      self.state.data_location, cursor
+    );
+
+    f(&mut cv)?;
+
+    if cv.errors.is_empty() {
+      Ok(Some(cursor + 1))
+    } else {
+      ctx.note_failure(cursor, cv.errors);
+      Ok(None)
     }
   }
 }
@@ -595,50 +867,6 @@ where
   }
 
   fn visit_type(&mut self, t: &Type<'a>) -> visitor::Result<Error<T>> {
-    // Special case for nested array in literal position
-    if let Value::Array(outer_array) = &self.cbor {
-      if let Some(idx) = self.state.group_entry_idx {
-        // We're processing a specific array item
-        if let Some(item) = outer_array.get(idx) {
-          if item.is_array() {
-            // This is a nested array, check if we're supposed to validate against an array type
-            for tc in t.type_choices.iter() {
-              if let Type2::Array { .. } = &tc.type1.type2 {
-                #[cfg(all(feature = "additional-controls", target_arch = "wasm32"))]
-                let mut cv = CBORValidator::new(
-                  self.state.cddl,
-                  item.clone(),
-                  self.state.enabled_features.clone(),
-                );
-                #[cfg(all(feature = "additional-controls", not(target_arch = "wasm32")))]
-                let mut cv =
-                  CBORValidator::new(self.state.cddl, item.clone(), self.state.enabled_features);
-                #[cfg(not(feature = "additional-controls"))]
-                let mut cv = CBORValidator::new(self.state.cddl, item.clone());
-
-                cv.state.generic_rules = self.state.generic_rules.clone();
-                cv.state.eval_generic_rule = self.state.eval_generic_rule;
-                cv.state.is_multi_type_choice = self.state.is_multi_type_choice;
-
-                let _ = write!(
-                  cv.state.data_location,
-                  "{}/{}",
-                  self.state.data_location, idx
-                );
-
-                // Visit the type choice with the inner array value
-                cv.visit_type_choice(tc)?;
-
-                self.errors.append(&mut cv.errors);
-                return Ok(());
-              }
-            }
-          }
-        }
-      }
-    }
-
-    // Regular type processing
     if t.type_choices.len() > 1 {
       self.state.is_multi_type_choice = true;
     }
@@ -726,8 +954,10 @@ where
     }
 
     // If we got here and choice_validation_succeeded is true (for array case),
-    // then validation succeeded
+    // then validation succeeded; drop errors accumulated by other, failing
+    // alternatives so they don't leak into the overall result
     if choice_validation_succeeded {
+      self.errors.truncate(initial_error_count);
       return Ok(());
     }
     Ok(())
@@ -809,10 +1039,8 @@ where
       return Ok(());
     }
 
-    for (idx, ge) in gc.group_entries.iter().enumerate() {
-      self.state.group_entry_idx = Some(idx);
-
-      self.visit_group_entry(&ge.0)?;
+    for (ge, _) in gc.group_entries.iter() {
+      self.visit_group_entry(ge)?;
     }
 
     Ok(())
@@ -1049,11 +1277,9 @@ where
               return self.visit_type2(controller);
             }
           }
-          Type2::Array { group, .. } => {
+          Type2::Array { .. } => {
             if let Value::Array(_) = &self.cbor {
-              self.state.entry_counts = Some(entry_counts_from_group(self.state.cddl, group));
               self.visit_type2(controller)?;
-              self.state.entry_counts = None;
               return Ok(());
             }
           }
@@ -2419,31 +2645,38 @@ where
             return Ok(());
           }
 
-          self.state.entry_counts = Some(entry_counts_from_group(self.state.cddl, group));
-          self.visit_group(group)?;
-          self.state.entry_counts = None;
-
-          if let Some(errors) = &mut self.array_errors {
-            if let Some(indices) = &self.state.valid_array_items {
-              for idx in indices.iter() {
-                errors.remove(idx);
+          let elems = a.clone();
+          let mut ctx = ArraySeqCtx::default();
+          match self.seq_match_group::<T>(group, &elems, 0, &mut ctx)? {
+            Some(end) if end == elems.len() => (),
+            Some(end) => {
+              self.add_error(format!(
+                "array validation failed: group {} matched the first {} element(s), but the array has {} elements",
+                group,
+                end,
+                elems.len()
+              ));
+            }
+            None => {
+              if let Some((idx, errors)) = ctx.best_failure.take() {
+                self.errors.extend(errors);
+                self.add_error(format!(
+                  "array validation failed: element sequence does not match group {} (mismatch at element index {})",
+                  group, idx
+                ));
+              } else {
+                self.add_error(format!(
+                  "array validation failed: element sequence does not match group {}",
+                  group
+                ));
               }
             }
-
-            for error in errors.values_mut() {
-              self.errors.append(error);
-            }
           }
-
-          self.state.valid_array_items = None;
-          self.array_errors = None;
 
           Ok(())
         }
         Value::Map(m) if self.state.is_member_key => {
           let current_location = self.state.data_location.clone();
-
-          self.state.entry_counts = Some(entry_counts_from_group(self.state.cddl, group));
 
           for (k, v) in m.iter() {
             #[cfg(all(feature = "additional-controls", target_arch = "wasm32"))]
@@ -2459,7 +2692,6 @@ where
             let mut cv = CBORValidator::new(self.state.cddl, k.clone());
 
             cv.state.generic_rules = self.state.generic_rules.clone();
-            cv.state.entry_counts = self.state.entry_counts.clone();
             cv.state.eval_generic_rule = self.state.eval_generic_rule;
             cv.state.is_multi_type_choice = self.state.is_multi_type_choice;
             cv.state.is_multi_group_choice = self.state.is_multi_group_choice;
@@ -2479,8 +2711,6 @@ where
 
             self.errors.append(&mut cv.errors);
           }
-
-          self.state.entry_counts = None;
 
           Ok(())
         }
@@ -3920,124 +4150,6 @@ where
 
       Ok(())
     } else if !self.state.advance_to_next_entry {
-      // This path handles array elements (when object_value is None)
-      if let Value::Array(a) = &self.cbor {
-        // Check array length against entry counts on the first entry to catch
-        // arrays with extra elements (e.g. 3-element array vs [a: tstr, b: int]).
-        // Skip the check when an occurrence indicator is active (e.g. * Node),
-        // because those allow variable-length arrays.
-        if self.state.group_entry_idx == Some(0) && self.state.occurrence.is_none() {
-          let length_errors: Vec<String> =
-            if let Some(entry_counts) = self.state.entry_counts.as_ref() {
-              let len = a.len();
-              if !validate_entry_count(entry_counts, len) {
-                if entry_counts.len() > 1 {
-                  let counts: Vec<String> =
-                    entry_counts.iter().map(|ec| ec.count.to_string()).collect();
-                  vec![format!(
-                    "expected array with length matching one of [{}], got {}",
-                    counts.join(", "),
-                    len
-                  )]
-                } else {
-                  entry_counts
-                    .iter()
-                    .map(|ec| {
-                      if let Some(occur) = &ec.entry_occurrence {
-                        format!("expected array with length per occurrence {}", occur)
-                      } else {
-                        format!("expected array with length {}, got {}", ec.count, len)
-                      }
-                    })
-                    .collect()
-                }
-              } else {
-                Vec::new()
-              }
-            } else {
-              Vec::new()
-            };
-
-          if !length_errors.is_empty() {
-            for e in length_errors {
-              self.add_error(e);
-            }
-            return Ok(());
-          }
-        }
-
-        // Use the index set by visit_group_choice
-        if let Some(idx) = self.state.group_entry_idx {
-          if let Some(element_value) = a.get(idx) {
-            // Create a new validator instance for the specific array element
-            #[cfg(all(feature = "additional-controls", target_arch = "wasm32"))]
-            let mut cv = CBORValidator::new(
-              self.state.cddl,
-              element_value.clone(),
-              self.state.enabled_features.clone(),
-            );
-            #[cfg(all(feature = "additional-controls", not(target_arch = "wasm32")))]
-            let mut cv = CBORValidator::new(
-              self.state.cddl,
-              element_value.clone(),
-              self.state.enabled_features,
-            );
-            #[cfg(not(feature = "additional-controls"))]
-            let mut cv = CBORValidator::new(self.cddl, element_value.clone());
-
-            // Copy necessary state from parent validator 'self' to child 'cv'
-            cv.state.generic_rules = self.state.generic_rules.clone();
-            cv.state.eval_generic_rule = self.state.eval_generic_rule;
-            // Let cv.visit_type determine is_multi_type_choice based on entry.entry_type
-            cv.state.is_multi_group_choice = self.state.is_multi_group_choice; // Inherit group choice status if needed
-            let _ = write!(
-              cv.state.data_location,
-              "{}/{}",
-              self.state.data_location, idx
-            ); // Set correct location for the element
-            cv.state.type_group_name_entry = self.state.type_group_name_entry; // Inherit for error reporting context
-
-            // Validate the element's type against the element's value
-            cv.visit_type(&entry.entry_type)?;
-
-            // Append any errors from the element validation back to the parent validator
-            self.errors.append(&mut cv.errors);
-
-            // Reset occurrence if it was handled for this entry
-            if entry.occur.is_some() {
-              self.state.occurrence = None;
-            }
-
-            return Ok(()); // Finished processing this element
-          } else {
-            // Element index out of bounds, add error only if occurrence requires it
-            #[cfg(feature = "ast-span")]
-            if !matches!(
-              self.state.occurrence,
-              Some(Occur::Optional { .. }) | Some(Occur::ZeroOrMore { .. })
-            ) {
-              self.add_error(format!(
-                "expected array element at index {}, but array only has {} elements",
-                idx,
-                a.len()
-              ));
-            }
-            #[cfg(not(feature = "ast-span"))]
-            if !matches!(
-              self.state.occurrence,
-              Some(Occur::Optional {}) | Some(Occur::ZeroOrMore {})
-            ) {
-              self.add_error(format!(
-                "expected array element at index {}, but array only has {} elements",
-                idx,
-                a.len()
-              ));
-            }
-            return Ok(());
-          }
-        }
-      }
-      // Fallback to original behavior if not an array or index is missing (shouldn't happen in valid CDDL/CBOR)
       self.visit_type(&entry.entry_type)
     } else {
       Ok(())

--- a/src/validator/json.rs
+++ b/src/validator/json.rs
@@ -11,7 +11,6 @@ use crate::{
 
 use std::{
   borrow::Cow,
-  collections::HashMap,
   convert::TryFrom,
   fmt::{self, Write},
 };
@@ -169,9 +168,6 @@ pub struct JSONValidator<'a> {
   validated_keys: Option<Vec<String>>,
   // Collect map entry values that have yet to be validated
   values_to_validate: Option<Vec<Value>>,
-  // Collect invalid array item errors where the key is the index of the invalid
-  // array item
-  array_errors: Option<HashMap<usize, Vec<ValidationError>>>,
 }
 
 impl<'a> JSONValidator<'a> {
@@ -187,7 +183,6 @@ impl<'a> JSONValidator<'a> {
       cut_value: None,
       validated_keys: None,
       values_to_validate: None,
-      array_errors: None,
     }
   }
 
@@ -203,7 +198,6 @@ impl<'a> JSONValidator<'a> {
       cut_value: None,
       validated_keys: None,
       values_to_validate: None,
-      array_errors: None,
     }
   }
 
@@ -219,7 +213,6 @@ impl<'a> JSONValidator<'a> {
       cut_value: None,
       validated_keys: None,
       values_to_validate: None,
-      array_errors: None,
     }
   }
 
@@ -235,151 +228,20 @@ impl<'a> JSONValidator<'a> {
       cut_value: None,
       validated_keys: None,
       values_to_validate: None,
-      array_errors: None,
     }
   }
 
   fn validate_array_items(&mut self, token: &ArrayItemToken) -> visitor::Result<Error> {
-    if let Value::Array(a) = &self.json {
+    // Arrays are matched against array-shaped types by the sequence matcher
+    // (seq_match_group); reaching this point means an array value is being
+    // validated against a non-array type
+    if let Value::Array(_) = &self.json {
       // Member keys are annotation only in an array context
       if self.state.is_member_key {
         return Ok(());
       }
 
-      match validate_array_occurrence(
-        self.state.occurrence.as_ref(),
-        self.state.entry_counts.as_ref().map(|ec| &ec[..]),
-        a,
-      ) {
-        Ok((iter_items, allow_empty_array)) => {
-          if iter_items {
-            for (idx, v) in a.iter().enumerate() {
-              if let Some(indices) = &self.state.valid_array_items {
-                if self.state.is_multi_type_choice && indices.contains(&idx) {
-                  continue;
-                }
-              }
-
-              #[cfg(all(feature = "additional-controls", target_arch = "wasm32"))]
-              let mut jv = JSONValidator::new(
-                self.state.cddl,
-                v.clone(),
-                self.state.enabled_features.clone(),
-              );
-              #[cfg(all(feature = "additional-controls", not(target_arch = "wasm32")))]
-              let mut jv =
-                JSONValidator::new(self.state.cddl, v.clone(), self.state.enabled_features);
-              #[cfg(not(feature = "additional-controls"))]
-              let mut jv = JSONValidator::new(self.state.cddl, v.clone());
-
-              jv.state.generic_rules = self.state.generic_rules.clone();
-              jv.state.eval_generic_rule = self.state.eval_generic_rule;
-              jv.state.is_multi_type_choice = self.state.is_multi_type_choice;
-              jv.state.ctrl = self.state.ctrl;
-              let _ = write!(
-                jv.state.data_location,
-                "{}/{}",
-                self.state.data_location, idx
-              );
-
-              match token {
-                ArrayItemToken::Value(value) => jv.visit_value(value)?,
-                ArrayItemToken::Range(lower, upper, is_inclusive) => {
-                  jv.visit_range(lower, upper, *is_inclusive)?
-                }
-                ArrayItemToken::Group(group) => jv.visit_group(group)?,
-                ArrayItemToken::Identifier(ident) => jv.visit_identifier(ident)?,
-                ArrayItemToken::TaggedData(tag_data) => {
-                  // Handle tagged data
-                  jv.add_error(format!(
-                    "Tagged data not supported in arrays: {:?}",
-                    tag_data
-                  ))
-                }
-              }
-
-              if self.state.is_multi_type_choice && jv.errors.is_empty() {
-                if let Some(indices) = &mut self.state.valid_array_items {
-                  indices.push(idx);
-                } else {
-                  self.state.valid_array_items = Some(vec![idx]);
-                }
-                continue;
-              }
-
-              if let Some(errors) = &mut self.array_errors {
-                if let Some(error) = errors.get_mut(&idx) {
-                  error.append(&mut jv.errors);
-                } else {
-                  errors.insert(idx, jv.errors);
-                }
-              } else {
-                let mut errors = HashMap::new();
-                errors.insert(idx, jv.errors);
-                self.array_errors = Some(errors)
-              }
-            }
-          } else if let Some(idx) = self.state.group_entry_idx {
-            if let Some(v) = a.get(idx) {
-              #[cfg(all(feature = "additional-controls", target_arch = "wasm32"))]
-              let mut jv = JSONValidator::new(
-                self.state.cddl,
-                v.clone(),
-                self.state.enabled_features.clone(),
-              );
-              #[cfg(all(feature = "additional-controls", not(target_arch = "wasm32")))]
-              let mut jv =
-                JSONValidator::new(self.state.cddl, v.clone(), self.state.enabled_features);
-              #[cfg(not(feature = "additional-controls"))]
-              let mut jv = JSONValidator::new(self.state.cddl, v.clone());
-
-              jv.state.generic_rules = self.state.generic_rules.clone();
-              jv.state.eval_generic_rule = self.state.eval_generic_rule;
-              jv.state.is_multi_type_choice = self.state.is_multi_type_choice;
-              jv.state.ctrl = self.state.ctrl;
-              let _ = write!(
-                jv.state.data_location,
-                "{}/{}",
-                self.state.data_location, idx
-              );
-
-              match token {
-                ArrayItemToken::Value(value) => jv.visit_value(value)?,
-                ArrayItemToken::Range(lower, upper, is_inclusive) => {
-                  jv.visit_range(lower, upper, *is_inclusive)?
-                }
-
-                ArrayItemToken::Identifier(ident) => jv.visit_identifier(ident)?,
-                ArrayItemToken::TaggedData(tag_data) => {
-                  // Handle tagged data
-                  jv.add_error(format!(
-                    "Tagged data not supported in arrays: {:?}",
-                    tag_data
-                  ))
-                }
-                // Special nested array handling - using Group variant instead
-                // as Array variant doesn't exist
-                ArrayItemToken::Group(group) if v.is_array() => {
-                  // Special handling for nested arrays
-                  jv.visit_group(group)?;
-                }
-                ArrayItemToken::Group(group) => jv.visit_group(group)?,
-              }
-
-              self.errors.append(&mut jv.errors);
-            } else if !allow_empty_array {
-              self.add_error(token.error_msg(Some(idx)));
-            }
-          } else if !self.state.is_multi_type_choice {
-            self.add_error(format!("{}, got {}", token.error_msg(None), self.json));
-          }
-        }
-        Err(errors) => {
-          for e in errors.into_iter() {
-            self.add_error(e);
-          }
-        }
-      }
+      self.add_error(format!("{}, got {}", token.error_msg(None), self.json));
     }
 
     Ok(())
@@ -593,6 +455,412 @@ impl<'a> JSONValidator<'a> {
     }
     None
   }
+
+  // ---------------------------------------------------------------------
+  // Array sequence matcher (RFC 8610 Appendix A PEG semantics).
+  //
+  // Mirror of the matcher in src/validator/cbor.rs; see the comments there.
+  // Matching a group against an array is sequence matching over the array's
+  // elements with a cursor:
+  // - a leaf entry consumes exactly one element
+  // - a group (inline, group-rule reference or unwrap) matches a subsequence,
+  // - an occurrence indicator greedily quantifies its entry (no backtracking out of a repetition)
+  // - "//" is prioritized choice that locks in the first successful alternative.
+  // Leaf checks delegate to the existing
+  // single-value machinery via a child validator.
+  //
+  // All matcher functions return
+  // - Ok(Some(new_cursor)) on a match
+  // - Ok(None) on a (silent, speculative) mismatch
+  // - Err only for fatal errors that abort validation entirely.
+  // ---------------------------------------------------------------------
+
+  /// Match a group against elems[cursor..]:
+  /// prioritized choice over the group's choices
+  fn seq_match_group(
+    &mut self,
+    group: &Group<'a>,
+    elems: &[Value],
+    cursor: usize,
+    ctx: &mut ArraySeqCtx<'a, ValidationError>,
+  ) -> std::result::Result<Option<usize>, Error> {
+    for gc in group.group_choices.iter() {
+      if let Some(end) = self.seq_match_group_choice(gc, elems, cursor, ctx)? {
+        return Ok(Some(end));
+      }
+    }
+
+    Ok(None)
+  }
+
+  /// Match a single group choice:
+  /// fold its entries over the cursor from left to right
+  fn seq_match_group_choice(
+    &mut self,
+    gc: &GroupChoice<'a>,
+    elems: &[Value],
+    cursor: usize,
+    ctx: &mut ArraySeqCtx<'a, ValidationError>,
+  ) -> std::result::Result<Option<usize>, Error> {
+    let mut cur = cursor;
+    for (entry, _) in gc.group_entries.iter() {
+      match self.seq_match_entry(entry, elems, cur, ctx)? {
+        Some(next) => cur = next,
+        None => return Ok(None),
+      }
+    }
+
+    Ok(Some(cur))
+  }
+
+  /// Match a group entry, applying its occurrence indicator: greedily match
+  /// up to the upper bound of iterations, where a failed iteration rewinds
+  /// only itself, then require the lower bound
+  fn seq_match_entry(
+    &mut self,
+    entry: &GroupEntry<'a>,
+    elems: &[Value],
+    cursor: usize,
+    ctx: &mut ArraySeqCtx<'a, ValidationError>,
+  ) -> std::result::Result<Option<usize>, Error> {
+    let occur = match entry {
+      GroupEntry::ValueMemberKey { ge, .. } => ge.occur.as_ref().map(|o| o.occur),
+      GroupEntry::TypeGroupname { ge, .. } => ge.occur.as_ref().map(|o| o.occur),
+      GroupEntry::InlineGroup { occur, .. } => occur.as_ref().map(|o| o.occur),
+    };
+
+    let (min, max) = match occur {
+      None => (1, Some(1)),
+      Some(Occur::Optional { .. }) => (0, Some(1)),
+      Some(Occur::ZeroOrMore { .. }) => (0, None),
+      Some(Occur::OneOrMore { .. }) => (1, None),
+      Some(Occur::Exact { lower, upper, .. }) => (lower.unwrap_or(0), upper),
+    };
+
+    let mut cur = cursor;
+    let mut count = 0usize;
+    while max.is_none_or(|m| count < m) {
+      match self.seq_match_entry_once(entry, elems, cur, ctx)? {
+        Some(next) => {
+          count += 1;
+          if next == cur {
+            // Zero-width iteration: no further progress is possible, and any
+            // remaining minimum is trivially satisfiable by more zero-width
+            // matches. Stop to guarantee termination (e.g. [* ()]).
+            count = count.max(min);
+            break;
+          }
+          cur = next;
+        }
+        None => break,
+      }
+    }
+
+    if count >= min {
+      Ok(Some(cur))
+    } else {
+      Ok(None)
+    }
+  }
+
+  /// Match a single iteration of a group entry, ignoring its occurrence
+  /// indicator.
+  ///
+  /// Subsequences (inline groups, group-rule references, unwraps
+  /// of array/map rules) recurse into the matcher;
+  ///
+  /// everything else is a leaf that consumes exactly one element
+  /// validated with the single-value machinery.
+  fn seq_match_entry_once(
+    &mut self,
+    entry: &GroupEntry<'a>,
+    elems: &[Value],
+    cursor: usize,
+    ctx: &mut ArraySeqCtx<'a, ValidationError>,
+  ) -> std::result::Result<Option<usize>, Error> {
+    match entry {
+      GroupEntry::InlineGroup { group, .. } => self.seq_match_group(group, elems, cursor, ctx),
+      GroupEntry::TypeGroupname { ge, .. } => {
+        let grule = group_rule_from_ident(self.state.cddl, &ge.name);
+        let alternates = group_choice_alternates_from_ident(self.state.cddl, &ge.name);
+        if grule.is_some() || !alternates.is_empty() {
+          return self.seq_match_group_ref(ge, grule, &alternates, elems, cursor, ctx);
+        }
+
+        // Leaf: validate one element against the named type
+        self.seq_match_leaf(elems, cursor, ctx, |jv| {
+          if let Some(ga) = &ge.generic_args {
+            if let Some(rule) = rule_from_ident(jv.state.cddl, &ge.name) {
+              if let Some(gr) = jv
+                .state
+                .generic_rules
+                .iter_mut()
+                .find(|gr| gr.name == ge.name.ident)
+              {
+                for arg in ga.args.iter() {
+                  gr.args.push((*arg.arg).clone());
+                }
+              } else if let Some(params) = generic_params_from_rule(rule) {
+                jv.state.generic_rules.push(GenericRule {
+                  name: ge.name.ident,
+                  params,
+                  args: ga.args.iter().cloned().map(|arg| *arg.arg).collect(),
+                });
+              }
+
+              jv.state.eval_generic_rule = Some(ge.name.ident);
+              return jv.visit_rule(rule);
+            }
+          }
+
+          // Type socket with no main rule definition: its "/=" alternates
+          // are the only choices (visit_identifier cannot resolve these)
+          if rule_from_ident(jv.state.cddl, &ge.name).is_none() {
+            let alternates = type_choice_alternates_from_ident(jv.state.cddl, &ge.name);
+            if !alternates.is_empty() {
+              jv.state.is_multi_type_choice = true;
+              for t in alternates {
+                let error_count = jv.errors.len();
+                jv.visit_type(t)?;
+                if jv.errors.len() == error_count {
+                  jv.errors.clear();
+                  break;
+                }
+              }
+              return Ok(());
+            }
+          }
+
+          jv.visit_identifier(&ge.name)
+        })
+      }
+      GroupEntry::ValueMemberKey { ge, .. } => {
+        // RFC 8610 3.7: an unwrapped array/map rule contributes the
+        // referenced rule's group as a subsequence, not as a single element
+        // (a member key, being annotation-only in an array context, does not
+        // change this)
+        if ge.entry_type.type_choices.len() == 1 {
+          let tc = &ge.entry_type.type_choices[0];
+          if tc.type1.operator.is_none() {
+            if let Type2::Unwrap {
+              ident,
+              generic_args,
+              ..
+            } = &tc.type1.type2
+            {
+              if let Some(rule) = unwrap_rule_from_ident(self.state.cddl, ident) {
+                if let Rule::Type { rule: trule, .. } = rule {
+                  if trule
+                    .value
+                    .type_choices
+                    .iter()
+                    .any(|tc| matches!(tc.type1.type2, Type2::Array { .. } | Type2::Map { .. }))
+                  {
+                    return self.seq_match_unwrap(
+                      ident,
+                      generic_args.as_ref(),
+                      rule,
+                      elems,
+                      cursor,
+                      ctx,
+                    );
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        // Leaf: member keys are annotation-only in an array context;
+        // validate one element against the entry type
+        self.seq_match_leaf(elems, cursor, ctx, |jv| jv.visit_type(&ge.entry_type))
+      }
+    }
+  }
+
+  /// Match a group-rule reference (possibly generic, possibly with "//="
+  /// alternates) as a subsequence
+  fn seq_match_group_ref(
+    &mut self,
+    ge: &TypeGroupnameEntry<'a>,
+    grule: Option<&'a GroupRule<'a>>,
+    alternates: &[&'a GroupEntry<'a>],
+    elems: &[Value],
+    cursor: usize,
+    ctx: &mut ArraySeqCtx<'a, ValidationError>,
+  ) -> std::result::Result<Option<usize>, Error> {
+    let key = (ge.name.ident, cursor);
+    if ctx.active_group_refs.contains(&key) {
+      // Recursive group reference without progress cannot match
+      return Ok(None);
+    }
+    ctx.active_group_refs.push(key);
+
+    // Snapshot generic state so args registered for this (possibly failing,
+    // speculative) descent don't leak into sibling alternatives or later
+    // iterations
+    let prev_eval = self.state.eval_generic_rule;
+    let prev_generic_rules = ge
+      .generic_args
+      .as_ref()
+      .map(|_| self.state.generic_rules.clone());
+    if let Some(ga) = &ge.generic_args {
+      if let Some(rule) = rule_from_ident(self.state.cddl, &ge.name) {
+        if let Some(gr) = self
+          .state
+          .generic_rules
+          .iter_mut()
+          .find(|gr| gr.name == ge.name.ident)
+        {
+          for arg in ga.args.iter() {
+            gr.args.push((*arg.arg).clone());
+          }
+        } else if let Some(params) = generic_params_from_rule(rule) {
+          self.state.generic_rules.push(GenericRule {
+            name: ge.name.ident,
+            params,
+            args: ga.args.iter().cloned().map(|arg| *arg.arg).collect(),
+          });
+        }
+
+        self.state.eval_generic_rule = Some(ge.name.ident);
+      }
+    }
+
+    let mut result = None;
+    if let Some(grule) = grule {
+      result = self.seq_match_entry(&grule.entry, elems, cursor, ctx)?;
+    }
+    if result.is_none() {
+      for alt in alternates {
+        result = self.seq_match_entry(alt, elems, cursor, ctx)?;
+        if result.is_some() {
+          break;
+        }
+      }
+    }
+
+    self.state.eval_generic_rule = prev_eval;
+    if let Some(prev) = prev_generic_rules {
+      self.state.generic_rules = prev;
+    }
+    ctx.active_group_refs.pop();
+
+    Ok(result)
+  }
+
+  /// Match an unwrapped rule (~rule, RFC 8610 3.7) as a subsequence: the
+  /// group inside the referenced array/map rule is matched in place
+  fn seq_match_unwrap(
+    &mut self,
+    ident: &Identifier<'a>,
+    generic_args: Option<&GenericArgs<'a>>,
+    rule: &'a Rule<'a>,
+    elems: &[Value],
+    cursor: usize,
+    ctx: &mut ArraySeqCtx<'a, ValidationError>,
+  ) -> std::result::Result<Option<usize>, Error> {
+    // Guard against recursive unwrap references that would loop without
+    // consuming elements (e.g. a = [~b], b = [~b])
+    let key = (ident.ident, cursor);
+    if ctx.active_group_refs.contains(&key) {
+      return Ok(None);
+    }
+    ctx.active_group_refs.push(key);
+
+    // Snapshot generic state so args registered for this (possibly failing,
+    // speculative) descent don't leak into sibling alternatives or later
+    // iterations
+    let prev_eval = self.state.eval_generic_rule;
+    let prev_generic_rules = generic_args.map(|_| self.state.generic_rules.clone());
+    if let Some(ga) = generic_args {
+      if let Some(gr) = self
+        .state
+        .generic_rules
+        .iter_mut()
+        .find(|gr| gr.name == ident.ident)
+      {
+        for arg in ga.args.iter() {
+          gr.args.push((*arg.arg).clone());
+        }
+      } else if let Some(params) = generic_params_from_rule(rule) {
+        self.state.generic_rules.push(GenericRule {
+          name: ident.ident,
+          params,
+          args: ga.args.iter().cloned().map(|arg| *arg.arg).collect(),
+        });
+      }
+
+      self.state.eval_generic_rule = Some(ident.ident);
+    }
+
+    let mut result = None;
+    if let Rule::Type { rule: trule, .. } = rule {
+      for tc in trule.value.type_choices.iter() {
+        if let Type2::Array { group, .. } | Type2::Map { group, .. } = &tc.type1.type2 {
+          result = self.seq_match_group(group, elems, cursor, ctx)?;
+          if result.is_some() {
+            break;
+          }
+        }
+      }
+    }
+
+    self.state.eval_generic_rule = prev_eval;
+    if let Some(prev) = prev_generic_rules {
+      self.state.generic_rules = prev;
+    }
+    ctx.active_group_refs.pop();
+
+    Ok(result)
+  }
+
+  /// Validate elems[cursor] against a leaf entry by spawning a child
+  /// validator on the element value. Failures are silent (speculative):
+  /// the child's errors are recorded in the context for later reporting
+  /// but never bubble into self.errors here.
+  fn seq_match_leaf<F>(
+    &mut self,
+    elems: &[Value],
+    cursor: usize,
+    ctx: &mut ArraySeqCtx<'a, ValidationError>,
+    f: F,
+  ) -> std::result::Result<Option<usize>, Error>
+  where
+    F: FnOnce(&mut JSONValidator<'a>) -> visitor::Result<Error>,
+  {
+    let value = match elems.get(cursor) {
+      Some(v) => v.clone(),
+      // Ran out of elements
+      None => return Ok(None),
+    };
+
+    #[cfg(all(feature = "additional-controls", target_arch = "wasm32"))]
+    let mut jv = JSONValidator::new(self.state.cddl, value, self.state.enabled_features.clone());
+    #[cfg(all(feature = "additional-controls", not(target_arch = "wasm32")))]
+    let mut jv = JSONValidator::new(self.state.cddl, value, self.state.enabled_features);
+    #[cfg(not(feature = "additional-controls"))]
+    let mut jv = JSONValidator::new(self.state.cddl, value);
+
+    jv.state.generic_rules = self.state.generic_rules.clone();
+    jv.state.eval_generic_rule = self.state.eval_generic_rule;
+    jv.state.visited_rules = self.state.visited_rules.clone();
+    jv.state.ctrl = self.state.ctrl;
+    let _ = write!(
+      jv.state.data_location,
+      "{}/{}",
+      self.state.data_location, cursor
+    );
+
+    f(&mut jv)?;
+
+    if jv.errors.is_empty() {
+      Ok(Some(cursor + 1))
+    } else {
+      ctx.note_failure(cursor, jv.errors);
+      Ok(None)
+    }
+  }
 }
 
 impl<'a> Validator<'a, '_, Error> for JSONValidator<'a> {
@@ -736,50 +1004,6 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
   }
 
   fn visit_type(&mut self, t: &Type<'a>) -> visitor::Result<Error> {
-    // Special case for nested array in literal position
-    if let Value::Array(outer_array) = &self.json {
-      if let Some(idx) = self.state.group_entry_idx {
-        // We're processing a specific array item
-        if let Some(item) = outer_array.get(idx) {
-          if item.is_array() {
-            // This is a nested array, check if we're supposed to validate against an array type
-            for tc in t.type_choices.iter() {
-              if let Type2::Array { .. } = &tc.type1.type2 {
-                #[cfg(all(feature = "additional-controls", target_arch = "wasm32"))]
-                let mut jv = JSONValidator::new(
-                  self.state.cddl,
-                  item.clone(),
-                  self.state.enabled_features.clone(),
-                );
-                #[cfg(all(feature = "additional-controls", not(target_arch = "wasm32")))]
-                let mut jv =
-                  JSONValidator::new(self.state.cddl, item.clone(), self.state.enabled_features);
-                #[cfg(not(feature = "additional-controls"))]
-                let mut jv = JSONValidator::new(self.state.cddl, item.clone());
-
-                jv.state.generic_rules = self.state.generic_rules.clone();
-                jv.state.eval_generic_rule = self.state.eval_generic_rule;
-                jv.state.is_multi_type_choice = self.state.is_multi_type_choice;
-
-                let _ = write!(
-                  jv.state.data_location,
-                  "{}/{}",
-                  self.state.data_location, idx
-                );
-
-                // Visit the type choice with the inner array value
-                jv.visit_type_choice(tc)?;
-
-                self.errors.append(&mut jv.errors);
-                return Ok(());
-              }
-            }
-          }
-        }
-      }
-    }
-
-    // Regular type processing
     if t.type_choices.len() > 1 {
       self.state.is_multi_type_choice = true;
     }
@@ -869,8 +1093,10 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
     }
 
     // If we got here and choice_validation_succeeded is true (for array case),
-    // then validation succeeded
+    // then validation succeeded; drop errors accumulated by other, failing
+    // alternatives so they don't leak into the overall result
     if choice_validation_succeeded {
+      self.errors.truncate(initial_error_count);
       return Ok(());
     }
 
@@ -971,16 +1197,8 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
       return Ok(());
     }
 
-    for (idx, ge) in gc.group_entries.iter().enumerate() {
-      if let Some(current_index) = self.state.group_entry_idx.as_mut() {
-        if idx != 0 {
-          *current_index += 1;
-        }
-      } else {
-        self.state.group_entry_idx = Some(idx);
-      }
-
-      self.visit_group_entry(&ge.0)?;
+    for (ge, _) in gc.group_entries.iter() {
+      self.visit_group_entry(ge)?;
     }
 
     Ok(())
@@ -1221,11 +1439,9 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
             return self.visit_type2(controller);
           }
         }
-        Type2::Array { group, .. } => {
+        Type2::Array { .. } => {
           if let Value::Array(_) = &self.json {
-            self.state.entry_counts = Some(entry_counts_from_group(self.state.cddl, group));
             self.visit_type2(controller)?;
-            self.state.entry_counts = None;
             return Ok(());
           }
         }
@@ -2044,30 +2260,34 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
             return Ok(());
           }
 
-          self.state.entry_counts = Some(entry_counts_from_group(self.state.cddl, group));
-          self.visit_group(group)?;
-          self.state.entry_counts = None;
-
-          if let Some(errors) = &mut self.array_errors {
-            if let Some(indices) = &self.state.valid_array_items {
-              for idx in indices.iter() {
-                errors.remove(idx);
-              }
+          let elems = a.clone();
+          let mut ctx = ArraySeqCtx::default();
+          match self.seq_match_group(group, &elems, 0, &mut ctx)? {
+            Some(end) if end == elems.len() => (),
+            Some(end) => {
+              self.add_error(format!(
+                "array validation failed: group {} matched the first {} element(s), but the array has {} elements",
+                group,
+                end,
+                elems.len()
+              ));
             }
-
-            for error in errors.values_mut() {
-              self.errors.append(error);
+            None => {
+              if let Some((idx, errors)) = ctx.best_failure.take() {
+                self.errors.extend(errors);
+                self.add_error(format!(
+                  "array validation failed: element sequence does not match group {} (mismatch at element index {})",
+                  group, idx
+                ));
+              } else {
+                self.add_error(format!(
+                  "array validation failed: element sequence does not match group {}",
+                  group
+                ));
+              }
             }
           }
 
-          self.state.valid_array_items = None;
-          self.array_errors = None;
-
-          Ok(())
-        }
-        // Special case for nested array validation
-        _ if matches!(self.json, Value::Array(_)) => {
-          self.validate_array_items(&ArrayItemToken::Group(group))?;
           Ok(())
         }
         _ => {
@@ -2929,8 +3149,8 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
   }
 
   fn visit_value(&mut self, value: &token::Value<'a>) -> visitor::Result<Error> {
-    // FIXME: If during traversal the type being validated is supposed to be a value,
-    // this fails
+    // An array can never match a literal value; validate_array_items reports
+    // the type mismatch (unless the value is an annotation-only member key)
     if let Value::Array(_) = &self.json {
       return self.validate_array_items(&ArrayItemToken::Value(value));
     }

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -89,9 +89,9 @@ pub struct GenericRule<'a> {
 ///    methods like `visit_identifier` and `visit_value`.
 /// 4. Implement the `Validator` trait for your entry point.
 ///
-/// The shared state handles occurrence tracking, group entry indexing,
-/// generic rule management, control operator tracking, feature flags,
-/// and recursion detection — all of which are identical across validators.
+/// The shared state handles occurrence tracking, generic rule management,
+/// control operator tracking, feature flags, and recursion detection — all
+/// of which are identical across validators.
 #[derive(Clone)]
 pub struct ValidationState<'a> {
   /// Reference to the CDDL AST being validated against
@@ -104,8 +104,6 @@ pub struct ValidationState<'a> {
   pub data_location: String,
   /// Occurrence indicator detected in current state of AST evaluation
   pub occurrence: Option<Occur>,
-  /// Current group entry index detected in current state of AST evaluation
-  pub group_entry_idx: Option<usize>,
   /// Is member key detected in current state of AST evaluation
   pub is_member_key: bool,
   /// Is a cut detected in current state of AST evaluation
@@ -132,10 +130,6 @@ pub struct ValidationState<'a> {
   pub advance_to_next_entry: bool,
   /// Is validation checking for map equality
   pub is_ctrl_map_equality: bool,
-  /// Entry counts for array/map validation
-  pub entry_counts: Option<Vec<EntryCount>>,
-  /// Collect valid array indices when entries are type choices
-  pub valid_array_items: Option<Vec<usize>>,
   /// Is colon shortcut present in member key
   pub is_colon_shortcut_present: bool,
   /// Is the current rule the root rule
@@ -170,7 +164,6 @@ impl<'a> ValidationState<'a> {
       cddl_location: String::new(),
       data_location: String::new(),
       occurrence: None,
-      group_entry_idx: None,
       is_member_key: false,
       is_cut_present: false,
       eval_generic_rule: None,
@@ -182,8 +175,6 @@ impl<'a> ValidationState<'a> {
       type_group_name_entry: None,
       advance_to_next_entry: false,
       is_ctrl_map_equality: false,
-      entry_counts: None,
-      valid_array_items: None,
       is_colon_shortcut_present: false,
       is_root: false,
       is_multi_type_choice_type_rule_validating_array: false,
@@ -203,7 +194,6 @@ impl<'a> ValidationState<'a> {
       cddl_location: String::new(),
       data_location: String::new(),
       occurrence: None,
-      group_entry_idx: None,
       is_member_key: false,
       is_cut_present: false,
       eval_generic_rule: None,
@@ -215,8 +205,6 @@ impl<'a> ValidationState<'a> {
       type_group_name_entry: None,
       advance_to_next_entry: false,
       is_ctrl_map_equality: false,
-      entry_counts: None,
-      valid_array_items: None,
       is_colon_shortcut_present: false,
       is_root: false,
       is_multi_type_choice_type_rule_validating_array: false,
@@ -233,7 +221,6 @@ impl<'a> ValidationState<'a> {
       cddl_location: String::new(),
       data_location: String::new(),
       occurrence: None,
-      group_entry_idx: None,
       is_member_key: false,
       is_cut_present: false,
       eval_generic_rule: None,
@@ -245,8 +232,6 @@ impl<'a> ValidationState<'a> {
       type_group_name_entry: None,
       advance_to_next_entry: false,
       is_ctrl_map_equality: false,
-      entry_counts: None,
-      valid_array_items: None,
       is_colon_shortcut_present: false,
       is_root: false,
       is_multi_type_choice_type_rule_validating_array: false,
@@ -266,7 +251,6 @@ impl<'a> ValidationState<'a> {
       cddl_location: String::new(),
       data_location: String::new(),
       occurrence: None,
-      group_entry_idx: None,
       is_member_key: false,
       is_cut_present: false,
       eval_generic_rule: None,
@@ -278,8 +262,6 @@ impl<'a> ValidationState<'a> {
       type_group_name_entry: None,
       advance_to_next_entry: false,
       is_ctrl_map_equality: false,
-      entry_counts: None,
-      valid_array_items: None,
       is_colon_shortcut_present: false,
       is_root: false,
       is_multi_type_choice_type_rule_validating_array: false,
@@ -1105,137 +1087,11 @@ pub fn is_ident_byte_string_data_type(cddl: &CDDL, ident: &Identifier) -> bool {
   })
 }
 
-/// Validate array length and \[non\]homogeneity based on a given optional
-/// occurrence indicator. The first bool in the returned tuple indicates whether
-/// or not a subsequent validation of the array's elements shouch be homogenous.
-/// The second bool in the returned tuple indicates whether or not an empty
-/// array is allowed during a subsequent validation of the array's elements.
-pub fn validate_array_occurrence<T>(
-  occurrence: Option<&Occur>,
-  entry_counts: Option<&[EntryCount]>,
-  values: &[T],
-) -> std::result::Result<(bool, bool), Vec<String>> {
-  let mut iter_items = false;
-  #[cfg(feature = "ast-span")]
-  let allow_empty_array = matches!(occurrence, Some(Occur::Optional { .. }));
-  #[cfg(not(feature = "ast-span"))]
-  let allow_empty_array = matches!(occurrence, Some(Occur::Optional {}));
-
-  let mut errors = Vec::new();
-
-  match occurrence {
-    #[cfg(feature = "ast-span")]
-    Some(Occur::ZeroOrMore { .. }) => iter_items = true,
-    #[cfg(not(feature = "ast-span"))]
-    Some(Occur::ZeroOrMore {}) => iter_items = true,
-    #[cfg(feature = "ast-span")]
-    Some(Occur::OneOrMore { .. }) => {
-      if values.is_empty() {
-        errors.push("array must have at least one item".to_string());
-      } else {
-        iter_items = true;
-      }
-    }
-    #[cfg(not(feature = "ast-span"))]
-    Some(Occur::OneOrMore {}) => {
-      if values.is_empty() {
-        errors.push("array must have at least one item".to_string());
-      } else {
-        iter_items = true;
-      }
-    }
-    Some(Occur::Exact { lower, upper, .. }) => {
-      if let Some(lower) = lower {
-        if let Some(upper) = upper {
-          if lower == upper && values.len() != *lower {
-            errors.push(format!("array must have exactly {} items", lower));
-          }
-          if values.len() < *lower || values.len() > *upper {
-            errors.push(format!(
-              "array must have between {} and {} items",
-              lower, upper
-            ));
-          }
-        } else if values.len() < *lower {
-          errors.push(format!("array must have at least {} items", lower));
-        }
-      } else if let Some(upper) = upper {
-        if values.len() > *upper {
-          errors.push(format!("array must have not more than {} items", upper));
-        }
-      }
-
-      iter_items = true;
-    }
-    #[cfg(feature = "ast-span")]
-    Some(Occur::Optional { .. }) => {
-      if values.len() > 1 {
-        errors.push("array must have 0 or 1 items".to_string());
-      }
-
-      iter_items = false;
-    }
-    #[cfg(not(feature = "ast-span"))]
-    Some(Occur::Optional {}) => {
-      if values.len() > 1 {
-        errors.push("array must have 0 or 1 items".to_string());
-      }
-
-      iter_items = false;
-    }
-    None => {
-      if values.is_empty() {
-        errors.push("array must have exactly one item".to_string());
-      } else {
-        iter_items = false;
-      }
-    }
-  }
-
-  if !iter_items && !allow_empty_array {
-    if let Some(entry_counts) = entry_counts {
-      let len = values.len();
-      if !validate_entry_count(entry_counts, len) {
-        // For multiple entry counts (multiple group choices), only report one error
-        // instead of errors for each mismatched count
-        if entry_counts.len() > 1 {
-          let counts: Vec<String> = entry_counts.iter().map(|ec| ec.count.to_string()).collect();
-          errors.push(format!(
-            "expected array with length matching one of [{}], got {}",
-            counts.join(", "),
-            len
-          ));
-        } else {
-          for ec in entry_counts.iter() {
-            if let Some(occur) = &ec.entry_occurrence {
-              errors.push(format!(
-                "expected array with length per occurrence {}",
-                occur,
-              ));
-            } else {
-              errors.push(format!(
-                "expected array with length {}, got {}",
-                ec.count, len
-              ));
-            }
-          }
-        }
-      }
-    }
-  }
-
-  if !errors.is_empty() {
-    return Err(errors);
-  }
-
-  Ok((iter_items, allow_empty_array))
-}
-
 /// Retrieve number of group entries from a group. This is currently only used
-/// for determining map equality/inequality and for validating the number of
-/// entries in arrays, but may be useful in other contexts. The occurrence is
-/// only captured for the second element of the CDDL array to avoid ambiguity in
-/// non-homogenous array definitions
+/// for determining map equality/inequality (the `.eq`/`.ne` control
+/// operators), but may be useful in other contexts. The occurrence is only
+/// captured for the second entry of the group choice to avoid ambiguity in
+/// non-homogenous definitions
 pub fn entry_counts_from_group<'a, 'b: 'a>(
   cddl: &'a CDDL,
   group: &'b Group<'a>,
@@ -1370,6 +1226,42 @@ pub struct EntryCount {
   pub count: u64,
   /// Optional occurrence
   pub entry_occurrence: Option<Occur>,
+}
+
+/// Shared bookkeeping for the array sequence matcher (RFC 8610 Appendix A
+/// PEG semantics), generic over the validator's error type
+pub struct ArraySeqCtx<'a, E> {
+  /// Farthest element index at which a leaf validation failed, together with
+  /// the child validator errors produced there. Used for error reporting once
+  /// the overall match fails.
+  pub best_failure: Option<(usize, Vec<E>)>,
+  /// (group rule name, cursor) pairs currently being expanded; guards against
+  /// recursive group rule references that would loop without consuming
+  /// elements
+  pub active_group_refs: Vec<(&'a str, usize)>,
+}
+
+impl<E> Default for ArraySeqCtx<'_, E> {
+  fn default() -> Self {
+    ArraySeqCtx {
+      best_failure: None,
+      active_group_refs: Vec::new(),
+    }
+  }
+}
+
+impl<E> ArraySeqCtx<'_, E> {
+  /// Record a leaf failure at the given element index, keeping only the
+  /// farthest one
+  pub fn note_failure(&mut self, idx: usize, errors: Vec<E>) {
+    if self
+      .best_failure
+      .as_ref()
+      .is_none_or(|(best, _)| idx >= *best)
+    {
+      self.best_failure = Some((idx, errors));
+    }
+  }
 }
 
 /// Regex needs to be formatted in a certain way so it can be parsed. See

--- a/tests/cbor.rs
+++ b/tests/cbor.rs
@@ -190,14 +190,19 @@ fn validate_cbor_homogenous_array() {
 }
 
 #[test]
-#[ignore] // FIXME: broken
 fn validate_cbor_array_groups() {
   let cddl_input = r#"thing = [int, (int, int)]"#;
   validate_cbor_from_slice(cddl_input, cbor::ARRAY_123, None).unwrap();
-  // TODO: try splitting arrays into groups a few other ways:
-  // [(int, int, int)]
-  // [* (int)]
-  // [* (int, int)]
+
+  let cddl_input = r#"thing = [(int, int, int)]"#;
+  validate_cbor_from_slice(cddl_input, cbor::ARRAY_123, None).unwrap();
+
+  let cddl_input = r#"thing = [* (int)]"#;
+  validate_cbor_from_slice(cddl_input, cbor::ARRAY_123, None).unwrap();
+
+  // Three elements cannot be consumed by repetitions of a two-entry group
+  let cddl_input = r#"thing = [* (int, int)]"#;
+  validate_cbor_from_slice(cddl_input, cbor::ARRAY_123, None).unwrap_err();
 }
 
 #[test]

--- a/tests/cbor_array_sequence.rs
+++ b/tests/cbor_array_sequence.rs
@@ -1,0 +1,1543 @@
+//! Array group/occurrence sequence-matching tests.
+//!
+//! Generated from a vector set cross-checked against the Ruby reference
+//! implementation (cddl gem 0.12.14)
+//!
+//! - `regression`: behavior that was already correct before the sequence
+//!   matcher landed and must not change.
+//! - `post_fix`: spec-correct behavior (confirmed by the Ruby reference
+//!   implementation) that the old positional array validator got wrong, in
+//!   both directions: spec-valid instances rejected AND spec-invalid
+//!   instances accepted. Fixed by the array sequence matcher.
+#![cfg(feature = "std")]
+#![cfg(feature = "cbor")]
+#![cfg(not(target_arch = "wasm32"))]
+
+use cddl::validate_cbor_from_slice;
+
+// RFC 8610 Section 3.3 defines the primitive names used throughout
+// these tests (for example, int, tstr, and bool). Per-test comments cite
+// the structural rules that motivate each expected match result.
+//
+// Two normative appendices underpin every verdict in this file:
+// - Appendix C (Matching Rules): an array matches when its element sequence
+//   matches the group, and "an occurrence indicator modifies the group given
+//   to its right by requiring the group to match the sequence ... in
+//   sequence", i.e. repetition quantifies the group's whole entry sequence,
+//   not the array length.
+// - Appendix A (PEGs): matching semantics are PEG — occurrence indicators
+//   are greedy with no backtracking out of a repetition ('"*a a" in CDDL
+//   syntax never can match anything'), and "/" and "//" are prioritized
+//   choice that locks in the first successful alternative.
+//
+// Known tension between the two: Appendix C's "a (possibly infinite) group
+// choice" wording, read alone, could permit shorter-than-greedy matches
+// (e.g. [* int, int] matching [1]). Appendix A's explicit '*a a' example
+// resolves it as greedy, and the Ruby reference implementation agrees; the
+// greedy_star_then_int tests encode that resolution.
+
+mod regression {
+  use super::*;
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.8, 3.8.4.
+  #[test]
+  fn cbor_control_elem() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [* bytes .cbor b]\nb = [int, tstr]", &[0x80], None).unwrap();
+    // ACCEPT [h'82016178']
+    validate_cbor_from_slice(
+      "a = [* bytes .cbor b]\nb = [int, tstr]",
+      &[0x81, 0x44, 0x82, 0x01, 0x61, 0x78],
+      None,
+    )
+    .unwrap();
+    // REJECT [h'8101']
+    validate_cbor_from_slice(
+      "a = [* bytes .cbor b]\nb = [int, tstr]",
+      &[0x81, 0x42, 0x81, 0x01],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.8, 3.8.4.
+  #[test]
+  fn cbor_control_group_inside() {
+    // REJECT [h'8101']
+    validate_cbor_from_slice(
+      "a = [bytes .cbor b]\nb = [* (int, tstr)]",
+      &[0x81, 0x42, 0x81, 0x01],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 2.2.2, 3.2, 3.4, 3.11.
+  #[test]
+  fn choice_diff_lengths() {
+    // ACCEPT [true]
+    validate_cbor_from_slice("a = [(bool // int, tstr)]", &[0x81, 0xf5], None).unwrap();
+    // ACCEPT [1, "x"]
+    validate_cbor_from_slice("a = [(bool // int, tstr)]", &[0x82, 0x01, 0x61, 0x78], None).unwrap();
+    // REJECT [1]
+    validate_cbor_from_slice("a = [(bool // int, tstr)]", &[0x81, 0x01], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.2.2.2, 3.2, 3.4; Appendix B (& group choice).
+  #[test]
+  fn choice_from_group() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [* &(1, 2)]", &[0x80], None).unwrap();
+    // ACCEPT [1, 2, 1]
+    validate_cbor_from_slice("a = [* &(1, 2)]", &[0x83, 0x01, 0x02, 0x01], None).unwrap();
+    // REJECT [3]
+    validate_cbor_from_slice("a = [* &(1, 2)]", &[0x81, 0x03], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.2.2.2, 3.2, 3.4; Appendix B (& groupname).
+  #[test]
+  fn choice_from_named_group() {
+    // REJECT [3]
+    validate_cbor_from_slice("a = [* e]\ne = &g\ng = (1, 2)", &[0x81, 0x03], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.4.
+  #[test]
+  fn empty_array() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = []", &[0x80], None).unwrap();
+    // REJECT [1]
+    validate_cbor_from_slice("a = []", &[0x81, 0x01], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix A (greedy PEG occurrence must terminate
+  // on zero-width repetitions); Appendix B (parenthesized group).
+  #[test]
+  fn empty_group_star() {
+    // NOTE: Ruby gem infinite-loops on zero-width group repetition; expected per RFC: () matches trivially, then int matches. Matcher must terminate.
+    // ACCEPT [1]
+    validate_cbor_from_slice("a = [* (), int]", &[0x81, 0x01], None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn exact_1_1() {
+    // REJECT []
+    validate_cbor_from_slice("a = [1*1 (int, tstr)]", &[0x80], None).unwrap_err();
+    // REJECT [1]
+    validate_cbor_from_slice("a = [1*1 (int, tstr)]", &[0x81, 0x01], None).unwrap_err();
+    // REJECT [1, "x", 2, "y"]
+    validate_cbor_from_slice(
+      "a = [1*1 (int, tstr)]",
+      &[0x84, 0x01, 0x61, 0x78, 0x02, 0x61, 0x79],
+      None,
+    )
+    .unwrap_err();
+    // REJECT ["x", 1]
+    validate_cbor_from_slice("a = [1*1 (int, tstr)]", &[0x82, 0x61, 0x78, 0x01], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn exact_2_2() {
+    // REJECT [1, "x"]
+    validate_cbor_from_slice("a = [2*2 (int, tstr)]", &[0x82, 0x01, 0x61, 0x78], None).unwrap_err();
+    // REJECT [1, "x", 2, "y", 3, "z"]
+    validate_cbor_from_slice(
+      "a = [2*2 (int, tstr)]",
+      &[0x86, 0x01, 0x61, 0x78, 0x02, 0x61, 0x79, 0x03, 0x61, 0x7a],
+      None,
+    )
+    .unwrap_err();
+    // REJECT [1, "x", 2]
+    validate_cbor_from_slice(
+      "a = [2*2 (int, tstr)]",
+      &[0x83, 0x01, 0x61, 0x78, 0x02],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.10.
+  #[test]
+  fn generic_elem() {
+    // REJECT [["x"]]
+    validate_cbor_from_slice(
+      "a = [* box<int>]\nbox<T> = [T]",
+      &[0x81, 0x81, 0x61, 0x78],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.10; Appendix B (groupname entry).
+  #[test]
+  fn generic_group_elem() {
+    // REJECT [1] (Ruby-verified)
+    validate_cbor_from_slice("a = [* g<int>]\ng<T> = (T, T)", &[0x81, 0x01], None).unwrap_err();
+    // REJECT [1, "x"] (Ruby-verified)
+    validate_cbor_from_slice(
+      "a = [* g<int>]\ng<T> = (T, T)",
+      &[0x82, 0x01, 0x61, 0x78],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn group_between_siblings() {
+    // REJECT [true, 1, false]
+    validate_cbor_from_slice(
+      "a = [bool, * (int, tstr), bool]",
+      &[0x83, 0xf5, 0x01, 0xf4],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 2.2.2, 3.2, 3.4.
+  #[test]
+  fn group_choice_inside() {
+    // REJECT [1, 2]
+    validate_cbor_from_slice(
+      "a = [1*1 (int, tstr // tstr, int)]",
+      &[0x82, 0x01, 0x02],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (groupname entry).
+  #[test]
+  fn groupref_after_sibling() {
+    // REJECT ["h", 1]
+    validate_cbor_from_slice(
+      "a = [tstr, * pair]\npair = (int, tstr)",
+      &[0x82, 0x61, 0x68, 0x01],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (groupname entry).
+  #[test]
+  fn groupref_exact() {
+    // REJECT [1]
+    validate_cbor_from_slice("a = [1*1 b]\nb = (int, tstr)", &[0x81, 0x01], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (groupname entry).
+  #[test]
+  fn groupref_star() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [* pair]\npair = (int, tstr)", &[0x80], None).unwrap();
+    // REJECT [1, "x", 2]
+    validate_cbor_from_slice(
+      "a = [* pair]\npair = (int, tstr)",
+      &[0x83, 0x01, 0x61, 0x78, 0x02],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn homogeneous_alias() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [* zip]\nzip = int", &[0x80], None).unwrap();
+    // ACCEPT [1, 2]
+    validate_cbor_from_slice("a = [* zip]\nzip = int", &[0x82, 0x01, 0x02], None).unwrap();
+    // REJECT ["x"]
+    validate_cbor_from_slice("a = [* zip]\nzip = int", &[0x81, 0x61, 0x78], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn homogeneous_exact() {
+    // ACCEPT [1, 2, 3]
+    validate_cbor_from_slice("a = [3*3 int]", &[0x83, 0x01, 0x02, 0x03], None).unwrap();
+    // REJECT [1, 2]
+    validate_cbor_from_slice("a = [3*3 int]", &[0x82, 0x01, 0x02], None).unwrap_err();
+    // REJECT [1, 2, 3, 4]
+    validate_cbor_from_slice("a = [3*3 int]", &[0x84, 0x01, 0x02, 0x03, 0x04], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn homogeneous_lower() {
+    // ACCEPT [1, 2, 3]
+    validate_cbor_from_slice("a = [3* int]", &[0x83, 0x01, 0x02, 0x03], None).unwrap();
+    // ACCEPT [1, 2, 3, 4]
+    validate_cbor_from_slice("a = [3* int]", &[0x84, 0x01, 0x02, 0x03, 0x04], None).unwrap();
+    // REJECT [1, 2]
+    validate_cbor_from_slice("a = [3* int]", &[0x82, 0x01, 0x02], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn homogeneous_opt() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [? int]", &[0x80], None).unwrap();
+    // ACCEPT [1]
+    validate_cbor_from_slice("a = [? int]", &[0x81, 0x01], None).unwrap();
+    // REJECT [1, 2]
+    validate_cbor_from_slice("a = [? int]", &[0x82, 0x01, 0x02], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn homogeneous_plus() {
+    // ACCEPT [1]
+    validate_cbor_from_slice("a = [+ int]", &[0x81, 0x01], None).unwrap();
+    // ACCEPT [1, 2, 3]
+    validate_cbor_from_slice("a = [+ int]", &[0x83, 0x01, 0x02, 0x03], None).unwrap();
+    // REJECT []
+    validate_cbor_from_slice("a = [+ int]", &[0x80], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn homogeneous_range() {
+    // ACCEPT [1]
+    validate_cbor_from_slice("a = [1*3 int]", &[0x81, 0x01], None).unwrap();
+    // ACCEPT [1, 2, 3]
+    validate_cbor_from_slice("a = [1*3 int]", &[0x83, 0x01, 0x02, 0x03], None).unwrap();
+    // REJECT []
+    validate_cbor_from_slice("a = [1*3 int]", &[0x80], None).unwrap_err();
+    // REJECT [1, 2, 3, 4]
+    validate_cbor_from_slice("a = [1*3 int]", &[0x84, 0x01, 0x02, 0x03, 0x04], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn homogeneous_star() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [* int]", &[0x80], None).unwrap();
+    // ACCEPT [1, 2, 3]
+    validate_cbor_from_slice("a = [* int]", &[0x83, 0x01, 0x02, 0x03], None).unwrap();
+    // REJECT [1, "x"]
+    validate_cbor_from_slice("a = [* int]", &[0x82, 0x01, 0x61, 0x78], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 2.2.1, 3.4.
+  #[test]
+  fn literal_elements() {
+    // ACCEPT [1, 2, 3]
+    validate_cbor_from_slice("a = [1, 2, 3]", &[0x83, 0x01, 0x02, 0x03], None).unwrap();
+    // REJECT [1, 2]
+    validate_cbor_from_slice("a = [1, 2, 3]", &[0x82, 0x01, 0x02], None).unwrap_err();
+    // REJECT [1, 2, 4]
+    validate_cbor_from_slice("a = [1, 2, 3]", &[0x83, 0x01, 0x02, 0x04], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn lower_bound_only() {
+    // REJECT [1, "x"]
+    validate_cbor_from_slice("a = [2* (int, tstr)]", &[0x82, 0x01, 0x61, 0x78], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.5, 3.5.1; Appendix B (groupname entry).
+  #[test]
+  fn map_group_ref() {
+    // ACCEPT {"x": 1, "y": "h"}
+    validate_cbor_from_slice(
+      "a = {g}\ng = (x: int, y: tstr)",
+      &[0xa2, 0x61, 0x78, 0x01, 0x61, 0x79, 0x61, 0x68],
+      None,
+    )
+    .unwrap();
+    // REJECT {"x": 1}
+    validate_cbor_from_slice(
+      "a = {g}\ng = (x: int, y: tstr)",
+      &[0xa1, 0x61, 0x78, 0x01],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.5.1.
+  #[test]
+  fn map_in_array() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [* {k: int}]", &[0x80], None).unwrap();
+    // ACCEPT [{"k": 1}]
+    validate_cbor_from_slice("a = [* {k: int}]", &[0x81, 0xa1, 0x61, 0x6b, 0x01], None).unwrap();
+    // REJECT [{"k": "x"}]
+    validate_cbor_from_slice(
+      "a = [* {k: int}]",
+      &[0x81, 0xa1, 0x61, 0x6b, 0x61, 0x78],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.5.1; Appendix B (groupname entry).
+  #[test]
+  fn map_in_array_with_group() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [* {g}]\ng = (x: int)", &[0x80], None).unwrap();
+    // ACCEPT [{"x": 1}]
+    validate_cbor_from_slice(
+      "a = [* {g}]\ng = (x: int)",
+      &[0x81, 0xa1, 0x61, 0x78, 0x01],
+      None,
+    )
+    .unwrap();
+    // REJECT [{"x": "h"}]
+    validate_cbor_from_slice(
+      "a = [* {g}]\ng = (x: int)",
+      &[0x81, 0xa1, 0x61, 0x78, 0x61, 0x68],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.5.1; Appendix B (parenthesized group).
+  #[test]
+  fn map_inline_group() {
+    // ACCEPT {"x": 1, "y": "h"}
+    validate_cbor_from_slice(
+      "a = {(x: int, y: tstr)}",
+      &[0xa2, 0x61, 0x78, 0x01, 0x61, 0x79, 0x61, 0x68],
+      None,
+    )
+    .unwrap();
+    // REJECT {"x": 1}
+    validate_cbor_from_slice("a = {(x: int, y: tstr)}", &[0xa1, 0x61, 0x78, 0x01], None)
+      .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.5.1.
+  #[test]
+  fn map_optional_member() {
+    // ACCEPT {"x": 1}
+    validate_cbor_from_slice("a = {x: int, ? y: tstr}", &[0xa1, 0x61, 0x78, 0x01], None).unwrap();
+    // ACCEPT {"x": 1, "y": "h"}
+    validate_cbor_from_slice(
+      "a = {x: int, ? y: tstr}",
+      &[0xa2, 0x61, 0x78, 0x01, 0x61, 0x79, 0x61, 0x68],
+      None,
+    )
+    .unwrap();
+    // REJECT {}
+    validate_cbor_from_slice("a = {x: int, ? y: tstr}", &[0xa0], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.5.1.
+  #[test]
+  fn map_record() {
+    // ACCEPT {"x": 1, "y": "h"}
+    validate_cbor_from_slice(
+      "a = {x: int, y: tstr}",
+      &[0xa2, 0x61, 0x78, 0x01, 0x61, 0x79, 0x61, 0x68],
+      None,
+    )
+    .unwrap();
+    // REJECT {"x": 1}
+    validate_cbor_from_slice("a = {x: int, y: tstr}", &[0xa1, 0x61, 0x78, 0x01], None).unwrap_err();
+    // REJECT {"x": "h", "y": "h"}
+    validate_cbor_from_slice(
+      "a = {x: int, y: tstr}",
+      &[0xa2, 0x61, 0x78, 0x61, 0x68, 0x61, 0x79, 0x61, 0x68],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.5.2.
+  #[test]
+  fn map_star_members() {
+    // ACCEPT {}
+    validate_cbor_from_slice("a = {* tstr => int}", &[0xa0], None).unwrap();
+    // ACCEPT {"a": 1, "b": 2}
+    validate_cbor_from_slice(
+      "a = {* tstr => int}",
+      &[0xa2, 0x61, 0x61, 0x01, 0x61, 0x62, 0x02],
+      None,
+    )
+    .unwrap();
+    // REJECT {"a": "x"}
+    validate_cbor_from_slice("a = {* tstr => int}", &[0xa1, 0x61, 0x61, 0x61, 0x78], None)
+      .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.2.2, 3.2, 3.4; Appendix B (choice extension).
+  #[test]
+  fn named_type_choice_elem() {
+    // REJECT [true]
+    validate_cbor_from_slice(
+      "a = [* elem]\nelem = int\nelem /= tstr",
+      &[0x81, 0xf5],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn nested_array() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [* [int]]", &[0x80], None).unwrap();
+    // ACCEPT [[1], [2]]
+    validate_cbor_from_slice("a = [* [int]]", &[0x82, 0x81, 0x01, 0x81, 0x02], None).unwrap();
+    // REJECT [1]
+    validate_cbor_from_slice("a = [* [int]]", &[0x81, 0x01], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.4.
+  #[test]
+  fn nested_array_literal() {
+    // ACCEPT [1, [2, 3], [4, 5]]
+    validate_cbor_from_slice(
+      "a = [int, [int, int], [int, int]]",
+      &[0x83, 0x01, 0x82, 0x02, 0x03, 0x82, 0x04, 0x05],
+      None,
+    )
+    .unwrap();
+    // REJECT [1, [2, 3]]
+    validate_cbor_from_slice(
+      "a = [int, [int, int], [int, int]]",
+      &[0x82, 0x01, 0x82, 0x02, 0x03],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn nested_parens() {
+    // REJECT [1]
+    validate_cbor_from_slice("a = [1*1 (int, (tstr))]", &[0x81, 0x01], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn nested_star_of_star() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [* [* (int, tstr)]]", &[0x80], None).unwrap();
+    // ACCEPT [[]]
+    validate_cbor_from_slice("a = [* [* (int, tstr)]]", &[0x81, 0x80], None).unwrap();
+    // REJECT [[1]]
+    validate_cbor_from_slice("a = [* [* (int, tstr)]]", &[0x81, 0x81, 0x01], None).unwrap_err();
+    // REJECT [1, "x"]
+    validate_cbor_from_slice("a = [* [* (int, tstr)]]", &[0x82, 0x01, 0x61, 0x78], None)
+      .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn occur_inside_occur() {
+    // REJECT [1, "x"]
+    validate_cbor_from_slice("a = [* (int, 2*2 tstr)]", &[0x82, 0x01, 0x61, 0x78], None)
+      .unwrap_err();
+    // REJECT [1, "x", "y", "z"]
+    validate_cbor_from_slice(
+      "a = [* (int, 2*2 tstr)]",
+      &[0x84, 0x01, 0x61, 0x78, 0x61, 0x79, 0x61, 0x7a],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn occur_on_single_entry_group() {
+    // REJECT [1, "x", 2]
+    validate_cbor_from_slice(
+      "a = [2*2 (int, 1*1 (tstr))]",
+      &[0x83, 0x01, 0x61, 0x78, 0x02],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn one_or_more() {
+    // REJECT []
+    validate_cbor_from_slice("a = [+ (int, tstr)]", &[0x80], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn optional() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [? (int, tstr)]", &[0x80], None).unwrap();
+    // REJECT [1, "x", 2, "y"]
+    validate_cbor_from_slice(
+      "a = [? (int, tstr)]",
+      &[0x84, 0x01, 0x61, 0x78, 0x02, 0x61, 0x79],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn optional_middle() {
+    // REJECT [1, "x"]
+    validate_cbor_from_slice("a = [int, ? tstr, bool]", &[0x82, 0x01, 0x61, 0x78], None)
+      .unwrap_err();
+    // REJECT [1, "x", true, true]
+    validate_cbor_from_slice(
+      "a = [int, ? tstr, bool]",
+      &[0x84, 0x01, 0x61, 0x78, 0xf5, 0xf5],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn prefix_then_star() {
+    // REJECT [1]
+    validate_cbor_from_slice("a = [tstr, * int]", &[0x81, 0x01], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 2.2.2, 3.2, 3.4; Appendix A (prioritized choice).
+  #[test]
+  fn prioritized_choice_locks() {
+    // ACCEPT [1]
+    validate_cbor_from_slice("a = [(int // int, tstr)]", &[0x81, 0x01], None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn range_1_2() {
+    // REJECT []
+    validate_cbor_from_slice("a = [1*2 (int, tstr)]", &[0x80], None).unwrap_err();
+    // REJECT [1, "x", 2, "y", 3, "z"]
+    validate_cbor_from_slice(
+      "a = [1*2 (int, tstr)]",
+      &[0x86, 0x01, 0x61, 0x78, 0x02, 0x61, 0x79, 0x03, 0x61, 0x7a],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.4, 3.5.1.
+  #[test]
+  fn record() {
+    // ACCEPT [1, 2, 3]
+    validate_cbor_from_slice(
+      "a = [x: int, y: int, z: int]",
+      &[0x83, 0x01, 0x02, 0x03],
+      None,
+    )
+    .unwrap();
+    // REJECT [1, 2]
+    validate_cbor_from_slice("a = [x: int, y: int, z: int]", &[0x82, 0x01, 0x02], None)
+      .unwrap_err();
+    // REJECT [1, 2, 3, 4]
+    validate_cbor_from_slice(
+      "a = [x: int, y: int, z: int]",
+      &[0x84, 0x01, 0x02, 0x03, 0x04],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.4, 3.5.1.
+  #[test]
+  fn record_mixed() {
+    // ACCEPT ["h", 1]
+    validate_cbor_from_slice("a = [x: tstr, y: int]", &[0x82, 0x61, 0x68, 0x01], None).unwrap();
+    // REJECT [1, "h"]
+    validate_cbor_from_slice("a = [x: tstr, y: int]", &[0x82, 0x01, 0x61, 0x68], None).unwrap_err();
+    // REJECT ["h"]
+    validate_cbor_from_slice("a = [x: tstr, y: int]", &[0x81, 0x61, 0x68], None).unwrap_err();
+    // REJECT ["h", 1, 2]
+    validate_cbor_from_slice(
+      "a = [x: tstr, y: int]",
+      &[0x83, 0x61, 0x68, 0x01, 0x02],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn sibling_after() {
+    // REJECT [1, "x"]
+    validate_cbor_from_slice("a = [(int, tstr), bool]", &[0x82, 0x01, 0x61, 0x78], None)
+      .unwrap_err();
+    // REJECT [1, true]
+    validate_cbor_from_slice("a = [(int, tstr), bool]", &[0x82, 0x01, 0xf5], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn sibling_before_no_occur() {
+    // REJECT [true, 1]
+    validate_cbor_from_slice("a = [bool, (int, tstr)]", &[0x82, 0xf5, 0x01], None).unwrap_err();
+    // REJECT [true, "x", 1]
+    validate_cbor_from_slice(
+      "a = [bool, (int, tstr)]",
+      &[0x83, 0xf5, 0x61, 0x78, 0x01],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn sibling_before_occur() {
+    // REJECT [true]
+    validate_cbor_from_slice("a = [bool, 1*1 (int, tstr)]", &[0x81, 0xf5], None).unwrap_err();
+    // REJECT [true, 1, "x", 2, "y"]
+    validate_cbor_from_slice(
+      "a = [bool, 1*1 (int, tstr)]",
+      &[0x85, 0xf5, 0x01, 0x61, 0x78, 0x02, 0x61, 0x79],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.8, 3.8.1.
+  #[test]
+  fn size_control_elem() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [* tstr .size 2]", &[0x80], None).unwrap();
+    // ACCEPT ["ok"]
+    validate_cbor_from_slice("a = [* tstr .size 2]", &[0x81, 0x62, 0x6f, 0x6b], None).unwrap();
+    // REJECT ["x"]
+    validate_cbor_from_slice("a = [* tstr .size 2]", &[0x81, 0x61, 0x78], None).unwrap_err();
+    // REJECT ["abc"]
+    validate_cbor_from_slice(
+      "a = [* tstr .size 2]",
+      &[0x81, 0x63, 0x61, 0x62, 0x63],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn sole_group_no_occur_inline() {
+    // ACCEPT [1, "x"]
+    validate_cbor_from_slice("a = [(int, tstr)]", &[0x82, 0x01, 0x61, 0x78], None).unwrap();
+    // REJECT [1]
+    validate_cbor_from_slice("a = [(int, tstr)]", &[0x81, 0x01], None).unwrap_err();
+    // REJECT [1, "x", 2]
+    validate_cbor_from_slice("a = [(int, tstr)]", &[0x83, 0x01, 0x61, 0x78, 0x02], None)
+      .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (groupname entry).
+  #[test]
+  fn sole_group_no_occur_ref() {
+    // ACCEPT [1, "x"]
+    validate_cbor_from_slice("a = [b]\nb = (int, tstr)", &[0x82, 0x01, 0x61, 0x78], None).unwrap();
+    // REJECT [1]
+    validate_cbor_from_slice("a = [b]\nb = (int, tstr)", &[0x81, 0x01], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn star_group_then_int() {
+    // REJECT [1, "x"]
+    validate_cbor_from_slice("a = [* (int, tstr), int]", &[0x82, 0x01, 0x61, 0x78], None)
+      .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn star_of_var_arity() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [* (int, * tstr)]", &[0x80], None).unwrap();
+    // REJECT ["x"]
+    validate_cbor_from_slice("a = [* (int, * tstr)]", &[0x81, 0x61, 0x78], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn star_then_tstr() {
+    // REJECT [1]
+    validate_cbor_from_slice("a = [* int, tstr]", &[0x81, 0x01], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 2.2.3, 3.2, 3.4, 3.6 (#6.nnn(type) tag notation).
+  #[test]
+  fn tagged_elem() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [* #6.42(tstr)]", &[0x80], None).unwrap();
+    // ACCEPT [42("x")]
+    validate_cbor_from_slice("a = [* #6.42(tstr)]", &[0x81, 0xd8, 0x2a, 0x61, 0x78], None).unwrap();
+    // REJECT [43("x")]
+    validate_cbor_from_slice("a = [* #6.42(tstr)]", &[0x81, 0xd8, 0x2b, 0x61, 0x78], None)
+      .unwrap_err();
+    // REJECT ["x"]
+    validate_cbor_from_slice("a = [* #6.42(tstr)]", &[0x81, 0x61, 0x78], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 2.2.3, 3.2, 3.4, 3.6 (#6.nnn(type) tag notation).
+  #[test]
+  fn tagged_elem_in_group() {
+    // ACCEPT [1, 42("x")]
+    validate_cbor_from_slice(
+      "a = [* (int, #6.42(tstr))]",
+      &[0x82, 0x01, 0xd8, 0x2a, 0x61, 0x78],
+      None,
+    )
+    .unwrap();
+    // REJECT [1, "x"]
+    validate_cbor_from_slice(
+      "a = [* (int, #6.42(tstr))]",
+      &[0x82, 0x01, 0x61, 0x78],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn three_level_nesting() {
+    // REJECT [1, "x"]
+    validate_cbor_from_slice(
+      "a = [1*1 (int, (tstr, (bool)))]",
+      &[0x82, 0x01, 0x61, 0x78],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn tuple_elements() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [* [int, tstr]]", &[0x80], None).unwrap();
+    // ACCEPT [[1, "x"]]
+    validate_cbor_from_slice("a = [* [int, tstr]]", &[0x81, 0x82, 0x01, 0x61, 0x78], None).unwrap();
+    // ACCEPT [[1, "x"], [2, "y"]]
+    validate_cbor_from_slice(
+      "a = [* [int, tstr]]",
+      &[0x82, 0x82, 0x01, 0x61, 0x78, 0x82, 0x02, 0x61, 0x79],
+      None,
+    )
+    .unwrap();
+    // REJECT [[1]]
+    validate_cbor_from_slice("a = [* [int, tstr]]", &[0x81, 0x81, 0x01], None).unwrap_err();
+    // REJECT [[1, "x", 2]]
+    validate_cbor_from_slice(
+      "a = [* [int, tstr]]",
+      &[0x81, 0x83, 0x01, 0x61, 0x78, 0x02],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.2.2, 3.2, 3.4, 3.11.
+  #[test]
+  fn type_choice_element() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [* (int / tstr)]", &[0x80], None).unwrap();
+    // ACCEPT [1, "x"]
+    validate_cbor_from_slice("a = [* (int / tstr)]", &[0x82, 0x01, 0x61, 0x78], None).unwrap();
+    // REJECT [true]
+    validate_cbor_from_slice("a = [* (int / tstr)]", &[0x81, 0xf5], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 2.2.1, 3.2, 3.4.
+  #[test]
+  fn type_choice_of_arrays_elem() {
+    // ACCEPT [[1]]
+    validate_cbor_from_slice("a = [* ([int] / [tstr])]", &[0x81, 0x81, 0x01], None).unwrap();
+    // REJECT [[true]]
+    validate_cbor_from_slice("a = [* ([int] / [tstr])]", &[0x81, 0x81, 0xf5], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.7.
+  #[test]
+  fn unwrap_after_sibling() {
+    // REJECT [true, 1]
+    validate_cbor_from_slice("a = [bool, ~b]\nb = [int, tstr]", &[0x82, 0xf5, 0x01], None)
+      .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4 (member keys are annotation-only in an
+  // array context), 3.7.
+  #[test]
+  fn unwrap_labeled() {
+    // ACCEPT [1, "x"]
+    validate_cbor_from_slice(
+      "a = [x: ~b]\nb = [int, tstr]",
+      &[0x82, 0x01, 0x61, 0x78],
+      None,
+    )
+    .unwrap();
+    // REJECT [1]
+    validate_cbor_from_slice("a = [x: ~b]\nb = [int, tstr]", &[0x81, 0x01], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.7.
+  #[test]
+  fn unwrap_sole() {
+    // REJECT [1]
+    validate_cbor_from_slice("a = [~b]\nb = [int, tstr]", &[0x81, 0x01], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.7.
+  #[test]
+  fn unwrap_with_occur() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [* ~b]\nb = [int, tstr]", &[0x80], None).unwrap();
+    // REJECT [1]
+    validate_cbor_from_slice("a = [* ~b]\nb = [int, tstr]", &[0x81, 0x01], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn upper_only_group() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [*2 (int, tstr)]", &[0x80], None).unwrap();
+    // REJECT [1, "x", 2, "y", 3, "z"]
+    validate_cbor_from_slice(
+      "a = [*2 (int, tstr)]",
+      &[0x86, 0x01, 0x61, 0x78, 0x02, 0x61, 0x79, 0x03, 0x61, 0x7a],
+      None,
+    )
+    .unwrap_err();
+    // REJECT [1]
+    validate_cbor_from_slice("a = [*2 (int, tstr)]", &[0x81, 0x01], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn upper_only_homogeneous() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [*2 int]", &[0x80], None).unwrap();
+    // ACCEPT [1, 2]
+    validate_cbor_from_slice("a = [*2 int]", &[0x82, 0x01, 0x02], None).unwrap();
+    // REJECT [1, 2, 3]
+    validate_cbor_from_slice("a = [*2 int]", &[0x83, 0x01, 0x02, 0x03], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn upstream_ignored_case() {
+    // ACCEPT [1, 2, 3]
+    validate_cbor_from_slice("a = [int, (int, int)]", &[0x83, 0x01, 0x02, 0x03], None).unwrap();
+    // REJECT [1, 2]
+    validate_cbor_from_slice("a = [int, (int, int)]", &[0x82, 0x01, 0x02], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn var_arity_inside() {
+    // REJECT []
+    validate_cbor_from_slice("a = [1*1 (int, * tstr)]", &[0x80], None).unwrap_err();
+    // REJECT ["x"]
+    validate_cbor_from_slice("a = [1*1 (int, * tstr)]", &[0x81, 0x61, 0x78], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn zero_or_more() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [* (int, tstr)]", &[0x80], None).unwrap();
+    // REJECT [1]
+    validate_cbor_from_slice("a = [* (int, tstr)]", &[0x81, 0x01], None).unwrap_err();
+    // REJECT [1, "x", 2]
+    validate_cbor_from_slice("a = [* (int, tstr)]", &[0x83, 0x01, 0x61, 0x78, 0x02], None)
+      .unwrap_err();
+    // REJECT ["x", 1]
+    validate_cbor_from_slice("a = [* (int, tstr)]", &[0x82, 0x61, 0x78, 0x01], None).unwrap_err();
+  }
+}
+
+mod post_fix {
+  use super::*;
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.7, 3.10.
+  #[test]
+  fn generic_group_choice_no_arg_leak() {
+    // Generic args registered while a failing choice alternative was tried
+    // speculatively must not leak into the next alternative.
+    // ACCEPT ["x", "x"] (Ruby-verified)
+    validate_cbor_from_slice(
+      "a = [(g<int> // g<tstr>)]\ng<T> = (T, T)",
+      &[0x82, 0x61, 0x78, 0x61, 0x78],
+      None,
+    )
+    .unwrap();
+    // ACCEPT [1, 1] (Ruby-verified)
+    validate_cbor_from_slice(
+      "a = [(g<int> // g<tstr>)]\ng<T> = (T, T)",
+      &[0x82, 0x01, 0x01],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.7, 3.10.
+  #[test]
+  fn unwrap_generic_choice_no_arg_leak() {
+    // ACCEPT ["x"] (Ruby-verified)
+    validate_cbor_from_slice(
+      "a = [~box<int> // ~box<tstr>]\nbox<T> = [T]",
+      &[0x81, 0x61, 0x78],
+      None,
+    )
+    .unwrap();
+    // ACCEPT [1] (Ruby-verified)
+    validate_cbor_from_slice(
+      "a = [~box<int> // ~box<tstr>]\nbox<T> = [T]",
+      &[0x81, 0x01],
+      None,
+    )
+    .unwrap();
+    // REJECT [true] (Ruby-verified)
+    validate_cbor_from_slice(
+      "a = [~box<int> // ~box<tstr>]\nbox<T> = [T]",
+      &[0x81, 0xf5],
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.7.
+  #[test]
+  fn unwrap_recursive() {
+    // Recursive unwrap references must terminate instead of overflowing the
+    // stack; the rule is unsatisfiable.
+    // REJECT [] (Ruby-verified)
+    validate_cbor_from_slice("a = [~b]\nb = [~b]", &[0x80], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.8, 3.8.4.
+  #[test]
+  fn cbor_control_group_inside() {
+    // ACCEPT [h'82016178']
+    validate_cbor_from_slice(
+      "a = [bytes .cbor b]\nb = [* (int, tstr)]",
+      &[0x81, 0x44, 0x82, 0x01, 0x61, 0x78],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.2.2.2, 3.2, 3.4; Appendix B (& groupname).
+  #[test]
+  fn choice_from_named_group() {
+    // ACCEPT [1, 2]
+    validate_cbor_from_slice("a = [* e]\ne = &g\ng = (1, 2)", &[0x82, 0x01, 0x02], None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix A (greedy PEG occurrence must terminate
+  // on zero-width repetitions); Appendix B (parenthesized group).
+  #[test]
+  fn empty_group_star() {
+    // NOTE: Ruby gem infinite-loops on zero-width group repetition; expected per RFC: trailing int unmatched in []. Matcher must terminate.
+    // REJECT []
+    validate_cbor_from_slice("a = [* (), int]", &[0x80], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn exact_1_1() {
+    // ACCEPT [1, "x"]
+    validate_cbor_from_slice("a = [1*1 (int, tstr)]", &[0x82, 0x01, 0x61, 0x78], None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn exact_2_2() {
+    // ACCEPT [1, "x", 2, "y"]
+    validate_cbor_from_slice(
+      "a = [2*2 (int, tstr)]",
+      &[0x84, 0x01, 0x61, 0x78, 0x02, 0x61, 0x79],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.10.
+  #[test]
+  fn generic_elem() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [* box<int>]\nbox<T> = [T]", &[0x80], None).unwrap();
+    // ACCEPT [[1]]
+    validate_cbor_from_slice("a = [* box<int>]\nbox<T> = [T]", &[0x81, 0x81, 0x01], None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.10; Appendix B (groupname entry).
+  #[test]
+  fn generic_group_elem() {
+    // ACCEPT [] (Ruby-verified)
+    validate_cbor_from_slice("a = [* g<int>]\ng<T> = (T, T)", &[0x80], None).unwrap();
+    // ACCEPT [1, 2] (Ruby-verified)
+    validate_cbor_from_slice("a = [* g<int>]\ng<T> = (T, T)", &[0x82, 0x01, 0x02], None).unwrap();
+    // ACCEPT [1, 2, 3, 4] (Ruby-verified)
+    validate_cbor_from_slice(
+      "a = [* g<int>]\ng<T> = (T, T)",
+      &[0x84, 0x01, 0x02, 0x03, 0x04],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix A (greedy PEG occurrence behavior).
+  #[test]
+  fn greedy_star_then_int() {
+    // REJECT [1]
+    validate_cbor_from_slice("a = [* int, int]", &[0x81, 0x01], None).unwrap_err();
+    // REJECT [1, 2]
+    validate_cbor_from_slice("a = [* int, int]", &[0x82, 0x01, 0x02], None).unwrap_err();
+    // REJECT []
+    validate_cbor_from_slice("a = [* int, int]", &[0x80], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn group_between_siblings() {
+    // ACCEPT [true, false]
+    validate_cbor_from_slice("a = [bool, * (int, tstr), bool]", &[0x82, 0xf5, 0xf4], None).unwrap();
+    // ACCEPT [true, 1, "x", false]
+    validate_cbor_from_slice(
+      "a = [bool, * (int, tstr), bool]",
+      &[0x84, 0xf5, 0x01, 0x61, 0x78, 0xf4],
+      None,
+    )
+    .unwrap();
+    // ACCEPT [true, 1, "x", 2, "y", false]
+    validate_cbor_from_slice(
+      "a = [bool, * (int, tstr), bool]",
+      &[0x86, 0xf5, 0x01, 0x61, 0x78, 0x02, 0x61, 0x79, 0xf4],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 2.2.2, 3.2, 3.4.
+  #[test]
+  fn group_choice_inside() {
+    // ACCEPT [1, "x"]
+    validate_cbor_from_slice(
+      "a = [1*1 (int, tstr // tstr, int)]",
+      &[0x82, 0x01, 0x61, 0x78],
+      None,
+    )
+    .unwrap();
+    // ACCEPT ["x", 1]
+    validate_cbor_from_slice(
+      "a = [1*1 (int, tstr // tstr, int)]",
+      &[0x82, 0x61, 0x78, 0x01],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (groupname entry).
+  #[test]
+  fn groupref_after_sibling() {
+    // ACCEPT ["h"]
+    validate_cbor_from_slice(
+      "a = [tstr, * pair]\npair = (int, tstr)",
+      &[0x81, 0x61, 0x68],
+      None,
+    )
+    .unwrap();
+    // ACCEPT ["h", 1, "x"]
+    validate_cbor_from_slice(
+      "a = [tstr, * pair]\npair = (int, tstr)",
+      &[0x83, 0x61, 0x68, 0x01, 0x61, 0x78],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (groupname entry).
+  #[test]
+  fn groupref_exact() {
+    // ACCEPT [1, "x"]
+    validate_cbor_from_slice(
+      "a = [1*1 b]\nb = (int, tstr)",
+      &[0x82, 0x01, 0x61, 0x78],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (groupname entry).
+  #[test]
+  fn groupref_star() {
+    // ACCEPT [1, "x"]
+    validate_cbor_from_slice(
+      "a = [* pair]\npair = (int, tstr)",
+      &[0x82, 0x01, 0x61, 0x78],
+      None,
+    )
+    .unwrap();
+    // ACCEPT [1, "x", 2, "y"]
+    validate_cbor_from_slice(
+      "a = [* pair]\npair = (int, tstr)",
+      &[0x84, 0x01, 0x61, 0x78, 0x02, 0x61, 0x79],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn lower_bound_only() {
+    // ACCEPT [1, "x", 2, "y"]
+    validate_cbor_from_slice(
+      "a = [2* (int, tstr)]",
+      &[0x84, 0x01, 0x61, 0x78, 0x02, 0x61, 0x79],
+      None,
+    )
+    .unwrap();
+    // ACCEPT [1, "x", 2, "y", 3, "z"]
+    validate_cbor_from_slice(
+      "a = [2* (int, tstr)]",
+      &[0x86, 0x01, 0x61, 0x78, 0x02, 0x61, 0x79, 0x03, 0x61, 0x7a],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.2.2, 3.2, 3.4; Appendix B (choice extension).
+  #[test]
+  fn named_type_choice_elem() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [* elem]\nelem = int\nelem /= tstr", &[0x80], None).unwrap();
+    // ACCEPT [1, "x"]
+    validate_cbor_from_slice(
+      "a = [* elem]\nelem = int\nelem /= tstr",
+      &[0x82, 0x01, 0x61, 0x78],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn nested_parens() {
+    // ACCEPT [1, "x"]
+    validate_cbor_from_slice("a = [1*1 (int, (tstr))]", &[0x82, 0x01, 0x61, 0x78], None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn nested_star_of_star() {
+    // ACCEPT [[1, "x"]]
+    validate_cbor_from_slice(
+      "a = [* [* (int, tstr)]]",
+      &[0x81, 0x82, 0x01, 0x61, 0x78],
+      None,
+    )
+    .unwrap();
+    // ACCEPT [[1, "x", 2, "y"], []]
+    validate_cbor_from_slice(
+      "a = [* [* (int, tstr)]]",
+      &[0x82, 0x84, 0x01, 0x61, 0x78, 0x02, 0x61, 0x79, 0x80],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn occur_inside_occur() {
+    // ACCEPT []
+    validate_cbor_from_slice("a = [* (int, 2*2 tstr)]", &[0x80], None).unwrap();
+    // ACCEPT [1, "x", "y"]
+    validate_cbor_from_slice(
+      "a = [* (int, 2*2 tstr)]",
+      &[0x83, 0x01, 0x61, 0x78, 0x61, 0x79],
+      None,
+    )
+    .unwrap();
+    // ACCEPT [1, "x", "y", 2, "p", "q"]
+    validate_cbor_from_slice(
+      "a = [* (int, 2*2 tstr)]",
+      &[
+        0x86, 0x01, 0x61, 0x78, 0x61, 0x79, 0x02, 0x61, 0x70, 0x61, 0x71,
+      ],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn occur_on_single_entry_group() {
+    // ACCEPT [1, "x", 2, "y"]
+    validate_cbor_from_slice(
+      "a = [2*2 (int, 1*1 (tstr))]",
+      &[0x84, 0x01, 0x61, 0x78, 0x02, 0x61, 0x79],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn one_or_more() {
+    // ACCEPT [1, "x"]
+    validate_cbor_from_slice("a = [+ (int, tstr)]", &[0x82, 0x01, 0x61, 0x78], None).unwrap();
+    // ACCEPT [1, "x", 2, "y"]
+    validate_cbor_from_slice(
+      "a = [+ (int, tstr)]",
+      &[0x84, 0x01, 0x61, 0x78, 0x02, 0x61, 0x79],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn optional() {
+    // ACCEPT [1, "x"]
+    validate_cbor_from_slice("a = [? (int, tstr)]", &[0x82, 0x01, 0x61, 0x78], None).unwrap();
+    // REJECT [1]
+    validate_cbor_from_slice("a = [? (int, tstr)]", &[0x81, 0x01], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn optional_middle() {
+    // ACCEPT [1, true]
+    validate_cbor_from_slice("a = [int, ? tstr, bool]", &[0x82, 0x01, 0xf5], None).unwrap();
+    // ACCEPT [1, "x", true]
+    validate_cbor_from_slice(
+      "a = [int, ? tstr, bool]",
+      &[0x83, 0x01, 0x61, 0x78, 0xf5],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn prefix_then_star() {
+    // ACCEPT ["h"]
+    validate_cbor_from_slice("a = [tstr, * int]", &[0x81, 0x61, 0x68], None).unwrap();
+    // ACCEPT ["h", 1, 2]
+    validate_cbor_from_slice("a = [tstr, * int]", &[0x83, 0x61, 0x68, 0x01, 0x02], None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 2.2.2, 3.2, 3.4; Appendix A (prioritized choice).
+  #[test]
+  fn prioritized_choice_locks() {
+    // REJECT [1, "x"]
+    validate_cbor_from_slice("a = [(int // int, tstr)]", &[0x82, 0x01, 0x61, 0x78], None)
+      .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 2.2.1, 3.2, 3.4. Errors recorded while trying a
+  // failing type-choice alternative must not poison a successful one,
+  // regardless of the order the alternatives appear in.
+  #[test]
+  fn type_choice_alternative_order() {
+    // ACCEPT [["x"]]
+    validate_cbor_from_slice("a = [* ([int] / [tstr])]", &[0x81, 0x81, 0x61, 0x78], None).unwrap();
+    // ACCEPT [[1]]
+    validate_cbor_from_slice("a = [* ([tstr] / [int])]", &[0x81, 0x81, 0x01], None).unwrap();
+  }
+
+  // RFC 8610: Section 2.2.1. A type choice must reject an array when no
+  // alternative matches it, including alternatives that are not array-shaped
+  // (a non-array alternative failing against an array must count as a
+  // failure, not be skipped silently).
+  #[test]
+  fn type_choice_non_array_alternates() {
+    // REJECT [1]
+    validate_cbor_from_slice("a = tstr / bool", &[0x81, 0x01], None).unwrap_err();
+    // REJECT [1, "x"]
+    validate_cbor_from_slice("a = [int, int] / tstr", &[0x82, 0x01, 0x61, 0x78], None).unwrap_err();
+    // REJECT [[1]]
+    validate_cbor_from_slice("a = [* (tstr / bool)]", &[0x81, 0x81, 0x01], None).unwrap_err();
+    // ACCEPT "hi"
+    validate_cbor_from_slice("a = [int, int] / tstr", &[0x62, 0x68, 0x69], None).unwrap();
+    // ACCEPT [1]
+    validate_cbor_from_slice("a = tstr / [int]", &[0x81, 0x01], None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn range_1_2() {
+    // ACCEPT [1, "x"]
+    validate_cbor_from_slice("a = [1*2 (int, tstr)]", &[0x82, 0x01, 0x61, 0x78], None).unwrap();
+    // ACCEPT [1, "x", 2, "y"]
+    validate_cbor_from_slice(
+      "a = [1*2 (int, tstr)]",
+      &[0x84, 0x01, 0x61, 0x78, 0x02, 0x61, 0x79],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn sibling_after() {
+    // ACCEPT [1, "x", true]
+    validate_cbor_from_slice(
+      "a = [(int, tstr), bool]",
+      &[0x83, 0x01, 0x61, 0x78, 0xf5],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn sibling_before_no_occur() {
+    // ACCEPT [true, 1, "x"]
+    validate_cbor_from_slice(
+      "a = [bool, (int, tstr)]",
+      &[0x83, 0xf5, 0x01, 0x61, 0x78],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn sibling_before_occur() {
+    // ACCEPT [true, 1, "x"]
+    validate_cbor_from_slice(
+      "a = [bool, 1*1 (int, tstr)]",
+      &[0x83, 0xf5, 0x01, 0x61, 0x78],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn star_group_then_int() {
+    // ACCEPT [5]
+    validate_cbor_from_slice("a = [* (int, tstr), int]", &[0x81, 0x05], None).unwrap();
+    // ACCEPT [1, "x", 5]
+    validate_cbor_from_slice(
+      "a = [* (int, tstr), int]",
+      &[0x83, 0x01, 0x61, 0x78, 0x05],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn star_of_var_arity() {
+    // ACCEPT [1]
+    validate_cbor_from_slice("a = [* (int, * tstr)]", &[0x81, 0x01], None).unwrap();
+    // ACCEPT [1, "x", 2]
+    validate_cbor_from_slice(
+      "a = [* (int, * tstr)]",
+      &[0x83, 0x01, 0x61, 0x78, 0x02],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn star_then_tstr() {
+    // ACCEPT ["x"]
+    validate_cbor_from_slice("a = [* int, tstr]", &[0x81, 0x61, 0x78], None).unwrap();
+    // ACCEPT [1, "x"]
+    validate_cbor_from_slice("a = [* int, tstr]", &[0x82, 0x01, 0x61, 0x78], None).unwrap();
+    // ACCEPT [1, 2, "x"]
+    validate_cbor_from_slice("a = [* int, tstr]", &[0x83, 0x01, 0x02, 0x61, 0x78], None).unwrap();
+    // REJECT []
+    validate_cbor_from_slice("a = [* int, tstr]", &[0x80], None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn three_level_nesting() {
+    // ACCEPT [1, "x", true]
+    validate_cbor_from_slice(
+      "a = [1*1 (int, (tstr, (bool)))]",
+      &[0x83, 0x01, 0x61, 0x78, 0xf5],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.7.
+  #[test]
+  fn unwrap_after_sibling() {
+    // ACCEPT [true, 1, "x"]
+    validate_cbor_from_slice(
+      "a = [bool, ~b]\nb = [int, tstr]",
+      &[0x83, 0xf5, 0x01, 0x61, 0x78],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.7.
+  #[test]
+  fn unwrap_sole() {
+    // ACCEPT [1, "x"]
+    validate_cbor_from_slice("a = [~b]\nb = [int, tstr]", &[0x82, 0x01, 0x61, 0x78], None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.7.
+  #[test]
+  fn unwrap_with_occur() {
+    // ACCEPT [1, "x"]
+    validate_cbor_from_slice(
+      "a = [* ~b]\nb = [int, tstr]",
+      &[0x82, 0x01, 0x61, 0x78],
+      None,
+    )
+    .unwrap();
+    // ACCEPT [1, "x", 2, "y"]
+    validate_cbor_from_slice(
+      "a = [* ~b]\nb = [int, tstr]",
+      &[0x84, 0x01, 0x61, 0x78, 0x02, 0x61, 0x79],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn upper_only_group() {
+    // ACCEPT [1, "x"]
+    validate_cbor_from_slice("a = [*2 (int, tstr)]", &[0x82, 0x01, 0x61, 0x78], None).unwrap();
+    // ACCEPT [1, "x", 2, "y"]
+    validate_cbor_from_slice(
+      "a = [*2 (int, tstr)]",
+      &[0x84, 0x01, 0x61, 0x78, 0x02, 0x61, 0x79],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn var_arity_inside() {
+    // ACCEPT [1]
+    validate_cbor_from_slice("a = [1*1 (int, * tstr)]", &[0x81, 0x01], None).unwrap();
+    // ACCEPT [1, "x"]
+    validate_cbor_from_slice("a = [1*1 (int, * tstr)]", &[0x82, 0x01, 0x61, 0x78], None).unwrap();
+    // ACCEPT [1, "x", "y"]
+    validate_cbor_from_slice(
+      "a = [1*1 (int, * tstr)]",
+      &[0x83, 0x01, 0x61, 0x78, 0x61, 0x79],
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn zero_or_more() {
+    // ACCEPT [1, "x"]
+    validate_cbor_from_slice("a = [* (int, tstr)]", &[0x82, 0x01, 0x61, 0x78], None).unwrap();
+    // ACCEPT [1, "x", 2, "y"]
+    validate_cbor_from_slice(
+      "a = [* (int, tstr)]",
+      &[0x84, 0x01, 0x61, 0x78, 0x02, 0x61, 0x79],
+      None,
+    )
+    .unwrap();
+  }
+}

--- a/tests/json_array_sequence.rs
+++ b/tests/json_array_sequence.rs
@@ -1,0 +1,933 @@
+//! Array group/occurrence sequence-matching tests (JSON validator).
+//!
+//! Port of tests/cbor_array_sequence.rs to the JSON validator: same vector
+//! set minus CBOR-only shapes (tags, byte strings, .cbor). Vectors were
+//! cross-checked against the Ruby reference implementation (cddl gem
+//! 0.12.14)
+//!
+//! - `regression`: behavior that was already correct before the sequence
+//!   matcher landed and must not change.
+//! - `post_fix`: spec-correct behavior (confirmed by the Ruby reference
+//!   implementation) that the old positional array validator got wrong.
+//!   Fixed by the array sequence matcher.
+//!
+//! A vector's regression/post_fix placement follows the JSON validator's own
+//! pre-matcher behavior, which differed from the CBOR validator's on a few
+//! vectors (choice_from_group's `[1, 2, 1]`, nested_array's `[1]`), so their
+//! placement differs between the two files. When syncing the files, keep
+//! each file's own placement rather than mirroring the other's.
+//!
+//! The normative basis (RFC 8610 Appendix A PEG semantics + Appendix C
+//! matching rules, and the known tension between them) is documented in the
+//! header of tests/cbor_array_sequence.rs.
+#![cfg(feature = "std")]
+#![cfg(feature = "json")]
+#![cfg(not(target_arch = "wasm32"))]
+
+use cddl::validate_json_from_str;
+
+mod regression {
+  use super::*;
+
+  // RFC 8610: Sections 2.1, 2.2.2, 3.2, 3.4, 3.11.
+  #[test]
+  fn choice_diff_lengths() {
+    validate_json_from_str("a = [(bool // int, tstr)]", r#"[true]"#, None).unwrap();
+    validate_json_from_str("a = [(bool // int, tstr)]", r#"[1, "x"]"#, None).unwrap();
+    validate_json_from_str("a = [(bool // int, tstr)]", r#"[1]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.2.2.2, 3.2, 3.4; Appendix B (& group choice).
+  #[test]
+  fn choice_from_group() {
+    validate_json_from_str("a = [* &(1, 2)]", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = [* &(1, 2)]", r#"[3]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.2.2.2, 3.2, 3.4; Appendix B (& groupname).
+  #[test]
+  fn choice_from_named_group() {
+    validate_json_from_str("a = [* e]\ne = &g\ng = (1, 2)", r#"[3]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.4.
+  #[test]
+  fn empty_array() {
+    validate_json_from_str("a = []", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = []", r#"[1]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix A (greedy PEG occurrence must terminate
+  // on zero-width repetitions); Appendix B (parenthesized group).
+  #[test]
+  fn empty_group_star() {
+    // NOTE: Ruby gem infinite-loops on zero-width group repetition; expected per RFC: () matches trivially, then int matches. Matcher must terminate.
+    validate_json_from_str("a = [* (), int]", r#"[1]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn exact_1_1() {
+    validate_json_from_str("a = [1*1 (int, tstr)]", r#"[]"#, None).unwrap_err();
+    validate_json_from_str("a = [1*1 (int, tstr)]", r#"[1]"#, None).unwrap_err();
+    validate_json_from_str("a = [1*1 (int, tstr)]", r#"[1, "x", 2, "y"]"#, None).unwrap_err();
+    validate_json_from_str("a = [1*1 (int, tstr)]", r#"["x", 1]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn exact_2_2() {
+    validate_json_from_str("a = [2*2 (int, tstr)]", r#"[1, "x"]"#, None).unwrap_err();
+    validate_json_from_str("a = [2*2 (int, tstr)]", r#"[1, "x", 2, "y", 3, "z"]"#, None)
+      .unwrap_err();
+    validate_json_from_str("a = [2*2 (int, tstr)]", r#"[1, "x", 2]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.10.
+  #[test]
+  fn generic_elem() {
+    validate_json_from_str("a = [* box<int>]\nbox<T> = [T]", r#"[["x"]]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.10; Appendix B (groupname entry).
+  #[test]
+  fn generic_group_elem() {
+    // REJECT [1] (Ruby-verified)
+    validate_json_from_str("a = [* g<int>]\ng<T> = (T, T)", r#"[1]"#, None).unwrap_err();
+    // REJECT [1, "x"] (Ruby-verified)
+    validate_json_from_str("a = [* g<int>]\ng<T> = (T, T)", r#"[1, "x"]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn group_between_siblings() {
+    validate_json_from_str(
+      "a = [bool, * (int, tstr), bool]",
+      r#"[true, 1, false]"#,
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 2.2.2, 3.2, 3.4.
+  #[test]
+  fn group_choice_inside() {
+    validate_json_from_str("a = [1*1 (int, tstr // tstr, int)]", r#"[1, 2]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (groupname entry).
+  #[test]
+  fn groupref_after_sibling() {
+    validate_json_from_str(
+      "a = [tstr, * pair]\npair = (int, tstr)",
+      r#"["h", 1]"#,
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (groupname entry).
+  #[test]
+  fn groupref_exact() {
+    validate_json_from_str("a = [1*1 b]\nb = (int, tstr)", r#"[1]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (groupname entry).
+  #[test]
+  fn groupref_star() {
+    validate_json_from_str("a = [* pair]\npair = (int, tstr)", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = [* pair]\npair = (int, tstr)", r#"[1, "x", 2]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn homogeneous_alias() {
+    validate_json_from_str("a = [* zip]\nzip = int", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = [* zip]\nzip = int", r#"[1, 2]"#, None).unwrap();
+    validate_json_from_str("a = [* zip]\nzip = int", r#"["x"]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn homogeneous_exact() {
+    validate_json_from_str("a = [3*3 int]", r#"[1, 2, 3]"#, None).unwrap();
+    validate_json_from_str("a = [3*3 int]", r#"[1, 2]"#, None).unwrap_err();
+    validate_json_from_str("a = [3*3 int]", r#"[1, 2, 3, 4]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn homogeneous_lower() {
+    validate_json_from_str("a = [3* int]", r#"[1, 2, 3]"#, None).unwrap();
+    validate_json_from_str("a = [3* int]", r#"[1, 2, 3, 4]"#, None).unwrap();
+    validate_json_from_str("a = [3* int]", r#"[1, 2]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn homogeneous_opt() {
+    validate_json_from_str("a = [? int]", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = [? int]", r#"[1]"#, None).unwrap();
+    validate_json_from_str("a = [? int]", r#"[1, 2]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn homogeneous_plus() {
+    validate_json_from_str("a = [+ int]", r#"[1]"#, None).unwrap();
+    validate_json_from_str("a = [+ int]", r#"[1, 2, 3]"#, None).unwrap();
+    validate_json_from_str("a = [+ int]", r#"[]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn homogeneous_range() {
+    validate_json_from_str("a = [1*3 int]", r#"[1]"#, None).unwrap();
+    validate_json_from_str("a = [1*3 int]", r#"[1, 2, 3]"#, None).unwrap();
+    validate_json_from_str("a = [1*3 int]", r#"[]"#, None).unwrap_err();
+    validate_json_from_str("a = [1*3 int]", r#"[1, 2, 3, 4]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn homogeneous_star() {
+    validate_json_from_str("a = [* int]", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = [* int]", r#"[1, 2, 3]"#, None).unwrap();
+    validate_json_from_str("a = [* int]", r#"[1, "x"]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 2.2.1, 3.4.
+  #[test]
+  fn literal_elements() {
+    validate_json_from_str("a = [1, 2, 3]", r#"[1, 2, 3]"#, None).unwrap();
+    validate_json_from_str("a = [1, 2, 3]", r#"[1, 2]"#, None).unwrap_err();
+    validate_json_from_str("a = [1, 2, 3]", r#"[1, 2, 4]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn lower_bound_only() {
+    validate_json_from_str("a = [2* (int, tstr)]", r#"[1, "x"]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.5, 3.5.1; Appendix B (groupname entry).
+  #[test]
+  fn map_group_ref() {
+    validate_json_from_str(
+      "a = {g}\ng = (x: int, y: tstr)",
+      r#"{"x": 1, "y": "h"}"#,
+      None,
+    )
+    .unwrap();
+    validate_json_from_str("a = {g}\ng = (x: int, y: tstr)", r#"{"x": 1}"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.5.1.
+  #[test]
+  fn map_in_array() {
+    validate_json_from_str("a = [* {k: int}]", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = [* {k: int}]", r#"[{"k": 1}]"#, None).unwrap();
+    validate_json_from_str("a = [* {k: int}]", r#"[{"k": "x"}]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.5.1; Appendix B (groupname entry).
+  #[test]
+  fn map_in_array_with_group() {
+    validate_json_from_str("a = [* {g}]\ng = (x: int)", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = [* {g}]\ng = (x: int)", r#"[{"x": 1}]"#, None).unwrap();
+    validate_json_from_str("a = [* {g}]\ng = (x: int)", r#"[{"x": "h"}]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.5.1; Appendix B (parenthesized group).
+  #[test]
+  fn map_inline_group() {
+    validate_json_from_str("a = {(x: int, y: tstr)}", r#"{"x": 1, "y": "h"}"#, None).unwrap();
+    validate_json_from_str("a = {(x: int, y: tstr)}", r#"{"x": 1}"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.5.1.
+  #[test]
+  fn map_optional_member() {
+    validate_json_from_str("a = {x: int, ? y: tstr}", r#"{"x": 1}"#, None).unwrap();
+    validate_json_from_str("a = {x: int, ? y: tstr}", r#"{"x": 1, "y": "h"}"#, None).unwrap();
+    validate_json_from_str("a = {x: int, ? y: tstr}", r#"{}"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.5.1.
+  #[test]
+  fn map_record() {
+    validate_json_from_str("a = {x: int, y: tstr}", r#"{"x": 1, "y": "h"}"#, None).unwrap();
+    validate_json_from_str("a = {x: int, y: tstr}", r#"{"x": 1}"#, None).unwrap_err();
+    validate_json_from_str("a = {x: int, y: tstr}", r#"{"x": "h", "y": "h"}"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.5.2.
+  #[test]
+  fn map_star_members() {
+    validate_json_from_str("a = {* tstr => int}", r#"{}"#, None).unwrap();
+    validate_json_from_str("a = {* tstr => int}", r#"{"a": 1, "b": 2}"#, None).unwrap();
+    validate_json_from_str("a = {* tstr => int}", r#"{"a": "x"}"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.2.2, 3.2, 3.4; Appendix B (choice extension).
+  #[test]
+  fn named_type_choice_elem() {
+    validate_json_from_str("a = [* elem]\nelem = int\nelem /= tstr", r#"[true]"#, None)
+      .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn nested_array() {
+    validate_json_from_str("a = [* [int]]", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = [* [int]]", r#"[[1], [2]]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.4.
+  #[test]
+  fn nested_array_literal() {
+    validate_json_from_str(
+      "a = [int, [int, int], [int, int]]",
+      r#"[1, [2, 3], [4, 5]]"#,
+      None,
+    )
+    .unwrap();
+    validate_json_from_str("a = [int, [int, int], [int, int]]", r#"[1, [2, 3]]"#, None)
+      .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn nested_parens() {
+    validate_json_from_str("a = [1*1 (int, (tstr))]", r#"[1]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn nested_star_of_star() {
+    validate_json_from_str("a = [* [* (int, tstr)]]", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = [* [* (int, tstr)]]", r#"[[]]"#, None).unwrap();
+    validate_json_from_str("a = [* [* (int, tstr)]]", r#"[[1]]"#, None).unwrap_err();
+    validate_json_from_str("a = [* [* (int, tstr)]]", r#"[1, "x"]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn occur_inside_occur() {
+    validate_json_from_str("a = [* (int, 2*2 tstr)]", r#"[1, "x"]"#, None).unwrap_err();
+    validate_json_from_str("a = [* (int, 2*2 tstr)]", r#"[1, "x", "y", "z"]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn occur_on_single_entry_group() {
+    validate_json_from_str("a = [2*2 (int, 1*1 (tstr))]", r#"[1, "x", 2]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn one_or_more() {
+    validate_json_from_str("a = [+ (int, tstr)]", r#"[]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn optional() {
+    validate_json_from_str("a = [? (int, tstr)]", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = [? (int, tstr)]", r#"[1, "x", 2, "y"]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn optional_middle() {
+    validate_json_from_str("a = [int, ? tstr, bool]", r#"[1, "x"]"#, None).unwrap_err();
+    validate_json_from_str("a = [int, ? tstr, bool]", r#"[1, "x", true, true]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn prefix_then_star() {
+    validate_json_from_str("a = [tstr, * int]", r#"[1]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 2.2.2, 3.2, 3.4; Appendix A (prioritized choice).
+  #[test]
+  fn prioritized_choice_locks() {
+    validate_json_from_str("a = [(int // int, tstr)]", r#"[1]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn range_1_2() {
+    validate_json_from_str("a = [1*2 (int, tstr)]", r#"[]"#, None).unwrap_err();
+    validate_json_from_str("a = [1*2 (int, tstr)]", r#"[1, "x", 2, "y", 3, "z"]"#, None)
+      .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.4, 3.5.1.
+  #[test]
+  fn record() {
+    validate_json_from_str("a = [x: int, y: int, z: int]", r#"[1, 2, 3]"#, None).unwrap();
+    validate_json_from_str("a = [x: int, y: int, z: int]", r#"[1, 2]"#, None).unwrap_err();
+    validate_json_from_str("a = [x: int, y: int, z: int]", r#"[1, 2, 3, 4]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.4, 3.5.1.
+  #[test]
+  fn record_mixed() {
+    validate_json_from_str("a = [x: tstr, y: int]", r#"["h", 1]"#, None).unwrap();
+    validate_json_from_str("a = [x: tstr, y: int]", r#"[1, "h"]"#, None).unwrap_err();
+    validate_json_from_str("a = [x: tstr, y: int]", r#"["h"]"#, None).unwrap_err();
+    validate_json_from_str("a = [x: tstr, y: int]", r#"["h", 1, 2]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn sibling_after() {
+    validate_json_from_str("a = [(int, tstr), bool]", r#"[1, "x"]"#, None).unwrap_err();
+    validate_json_from_str("a = [(int, tstr), bool]", r#"[1, true]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn sibling_before_no_occur() {
+    validate_json_from_str("a = [bool, (int, tstr)]", r#"[true, 1]"#, None).unwrap_err();
+    validate_json_from_str("a = [bool, (int, tstr)]", r#"[true, "x", 1]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn sibling_before_occur() {
+    validate_json_from_str("a = [bool, 1*1 (int, tstr)]", r#"[true]"#, None).unwrap_err();
+    validate_json_from_str(
+      "a = [bool, 1*1 (int, tstr)]",
+      r#"[true, 1, "x", 2, "y"]"#,
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.8, 3.8.1.
+  #[test]
+  fn size_control_elem() {
+    validate_json_from_str("a = [* tstr .size 2]", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = [* tstr .size 2]", r#"["ok"]"#, None).unwrap();
+    validate_json_from_str("a = [* tstr .size 2]", r#"["x"]"#, None).unwrap_err();
+    validate_json_from_str("a = [* tstr .size 2]", r#"["abc"]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn sole_group_no_occur_inline() {
+    validate_json_from_str("a = [(int, tstr)]", r#"[1, "x"]"#, None).unwrap();
+    validate_json_from_str("a = [(int, tstr)]", r#"[1]"#, None).unwrap_err();
+    validate_json_from_str("a = [(int, tstr)]", r#"[1, "x", 2]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (groupname entry).
+  #[test]
+  fn sole_group_no_occur_ref() {
+    validate_json_from_str("a = [b]\nb = (int, tstr)", r#"[1, "x"]"#, None).unwrap();
+    validate_json_from_str("a = [b]\nb = (int, tstr)", r#"[1]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn star_group_then_int() {
+    validate_json_from_str("a = [* (int, tstr), int]", r#"[1, "x"]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn star_of_var_arity() {
+    validate_json_from_str("a = [* (int, * tstr)]", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = [* (int, * tstr)]", r#"["x"]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn star_then_tstr() {
+    validate_json_from_str("a = [* int, tstr]", r#"[1]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn three_level_nesting() {
+    validate_json_from_str("a = [1*1 (int, (tstr, (bool)))]", r#"[1, "x"]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn tuple_elements() {
+    validate_json_from_str("a = [* [int, tstr]]", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = [* [int, tstr]]", r#"[[1, "x"]]"#, None).unwrap();
+    validate_json_from_str("a = [* [int, tstr]]", r#"[[1, "x"], [2, "y"]]"#, None).unwrap();
+    validate_json_from_str("a = [* [int, tstr]]", r#"[[1]]"#, None).unwrap_err();
+    validate_json_from_str("a = [* [int, tstr]]", r#"[[1, "x", 2]]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.2.2, 3.2, 3.4, 3.11.
+  #[test]
+  fn type_choice_element() {
+    validate_json_from_str("a = [* (int / tstr)]", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = [* (int / tstr)]", r#"[1, "x"]"#, None).unwrap();
+    validate_json_from_str("a = [* (int / tstr)]", r#"[true]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 2.2.1, 3.2, 3.4.
+  #[test]
+  fn type_choice_of_arrays_elem() {
+    validate_json_from_str("a = [* ([int] / [tstr])]", r#"[[1]]"#, None).unwrap();
+    validate_json_from_str("a = [* ([int] / [tstr])]", r#"[[true]]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.7.
+  #[test]
+  fn unwrap_after_sibling() {
+    validate_json_from_str("a = [bool, ~b]\nb = [int, tstr]", r#"[true, 1]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4 (member keys are annotation-only in an
+  // array context), 3.7.
+  #[test]
+  fn unwrap_labeled() {
+    validate_json_from_str("a = [x: ~b]\nb = [int, tstr]", r#"[1, "x"]"#, None).unwrap();
+    validate_json_from_str("a = [x: ~b]\nb = [int, tstr]", r#"[1]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.7.
+  #[test]
+  fn unwrap_sole() {
+    validate_json_from_str("a = [~b]\nb = [int, tstr]", r#"[1]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.7.
+  #[test]
+  fn unwrap_with_occur() {
+    validate_json_from_str("a = [* ~b]\nb = [int, tstr]", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = [* ~b]\nb = [int, tstr]", r#"[1]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn upper_only_group() {
+    validate_json_from_str("a = [*2 (int, tstr)]", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = [*2 (int, tstr)]", r#"[1, "x", 2, "y", 3, "z"]"#, None)
+      .unwrap_err();
+    validate_json_from_str("a = [*2 (int, tstr)]", r#"[1]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn upper_only_homogeneous() {
+    validate_json_from_str("a = [*2 int]", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = [*2 int]", r#"[1, 2]"#, None).unwrap();
+    validate_json_from_str("a = [*2 int]", r#"[1, 2, 3]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn upstream_ignored_case() {
+    validate_json_from_str("a = [int, (int, int)]", r#"[1, 2, 3]"#, None).unwrap();
+    validate_json_from_str("a = [int, (int, int)]", r#"[1, 2]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn var_arity_inside() {
+    validate_json_from_str("a = [1*1 (int, * tstr)]", r#"[]"#, None).unwrap_err();
+    validate_json_from_str("a = [1*1 (int, * tstr)]", r#"["x"]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn zero_or_more() {
+    validate_json_from_str("a = [* (int, tstr)]", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = [* (int, tstr)]", r#"[1]"#, None).unwrap_err();
+    validate_json_from_str("a = [* (int, tstr)]", r#"[1, "x", 2]"#, None).unwrap_err();
+    validate_json_from_str("a = [* (int, tstr)]", r#"["x", 1]"#, None).unwrap_err();
+  }
+}
+
+mod post_fix {
+  use super::*;
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.7, 3.10.
+  #[test]
+  fn generic_group_choice_no_arg_leak() {
+    // Generic args registered while a failing choice alternative was tried
+    // speculatively must not leak into the next alternative.
+    // ACCEPT ["x", "x"] (Ruby-verified)
+    validate_json_from_str(
+      "a = [(g<int> // g<tstr>)]\ng<T> = (T, T)",
+      r#"["x", "x"]"#,
+      None,
+    )
+    .unwrap();
+    // ACCEPT [1, 1] (Ruby-verified)
+    validate_json_from_str(
+      "a = [(g<int> // g<tstr>)]\ng<T> = (T, T)",
+      r#"[1, 1]"#,
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.7, 3.10.
+  #[test]
+  fn unwrap_generic_choice_no_arg_leak() {
+    // ACCEPT ["x"] (Ruby-verified)
+    validate_json_from_str(
+      "a = [~box<int> // ~box<tstr>]\nbox<T> = [T]",
+      r#"["x"]"#,
+      None,
+    )
+    .unwrap();
+    // ACCEPT [1] (Ruby-verified)
+    validate_json_from_str(
+      "a = [~box<int> // ~box<tstr>]\nbox<T> = [T]",
+      r#"[1]"#,
+      None,
+    )
+    .unwrap();
+    // REJECT [true] (Ruby-verified)
+    validate_json_from_str(
+      "a = [~box<int> // ~box<tstr>]\nbox<T> = [T]",
+      r#"[true]"#,
+      None,
+    )
+    .unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.7.
+  #[test]
+  fn unwrap_recursive() {
+    // Recursive unwrap references must terminate instead of overflowing the
+    // stack; the rule is unsatisfiable.
+    // REJECT [] (Ruby-verified)
+    validate_json_from_str("a = [~b]\nb = [~b]", r#"[]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.2.2.2, 3.2, 3.4; Appendix B (& group choice).
+  #[test]
+  fn choice_from_group() {
+    // ACCEPT [1, 2, 1] (Ruby-verified)
+    validate_json_from_str("a = [* &(1, 2)]", r#"[1, 2, 1]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn nested_array() {
+    // REJECT [1] (Ruby-verified)
+    validate_json_from_str("a = [* [int]]", r#"[1]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.2.2.2, 3.2, 3.4; Appendix B (& groupname).
+  #[test]
+  fn choice_from_named_group() {
+    validate_json_from_str("a = [* e]\ne = &g\ng = (1, 2)", r#"[1, 2]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix A (greedy PEG occurrence must terminate
+  // on zero-width repetitions); Appendix B (parenthesized group).
+  #[test]
+  fn empty_group_star() {
+    // NOTE: Ruby gem infinite-loops on zero-width group repetition; expected per RFC: trailing int unmatched in []. Matcher must terminate.
+    validate_json_from_str("a = [* (), int]", r#"[]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn exact_1_1() {
+    validate_json_from_str("a = [1*1 (int, tstr)]", r#"[1, "x"]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn exact_2_2() {
+    validate_json_from_str("a = [2*2 (int, tstr)]", r#"[1, "x", 2, "y"]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.10.
+  #[test]
+  fn generic_elem() {
+    validate_json_from_str("a = [* box<int>]\nbox<T> = [T]", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = [* box<int>]\nbox<T> = [T]", r#"[[1]]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.10; Appendix B (groupname entry).
+  #[test]
+  fn generic_group_elem() {
+    // ACCEPT [] (Ruby-verified)
+    validate_json_from_str("a = [* g<int>]\ng<T> = (T, T)", r#"[]"#, None).unwrap();
+    // ACCEPT [1, 2] (Ruby-verified)
+    validate_json_from_str("a = [* g<int>]\ng<T> = (T, T)", r#"[1, 2]"#, None).unwrap();
+    // ACCEPT [1, 2, 3, 4] (Ruby-verified)
+    validate_json_from_str("a = [* g<int>]\ng<T> = (T, T)", r#"[1, 2, 3, 4]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix A (greedy PEG occurrence behavior).
+  #[test]
+  fn greedy_star_then_int() {
+    validate_json_from_str("a = [* int, int]", r#"[1]"#, None).unwrap_err();
+    validate_json_from_str("a = [* int, int]", r#"[1, 2]"#, None).unwrap_err();
+    validate_json_from_str("a = [* int, int]", r#"[]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn group_between_siblings() {
+    validate_json_from_str("a = [bool, * (int, tstr), bool]", r#"[true, false]"#, None).unwrap();
+    validate_json_from_str(
+      "a = [bool, * (int, tstr), bool]",
+      r#"[true, 1, "x", false]"#,
+      None,
+    )
+    .unwrap();
+    validate_json_from_str(
+      "a = [bool, * (int, tstr), bool]",
+      r#"[true, 1, "x", 2, "y", false]"#,
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 2.2.2, 3.2, 3.4.
+  #[test]
+  fn group_choice_inside() {
+    validate_json_from_str("a = [1*1 (int, tstr // tstr, int)]", r#"[1, "x"]"#, None).unwrap();
+    validate_json_from_str("a = [1*1 (int, tstr // tstr, int)]", r#"["x", 1]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (groupname entry).
+  #[test]
+  fn groupref_after_sibling() {
+    validate_json_from_str("a = [tstr, * pair]\npair = (int, tstr)", r#"["h"]"#, None).unwrap();
+    validate_json_from_str(
+      "a = [tstr, * pair]\npair = (int, tstr)",
+      r#"["h", 1, "x"]"#,
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (groupname entry).
+  #[test]
+  fn groupref_exact() {
+    validate_json_from_str("a = [1*1 b]\nb = (int, tstr)", r#"[1, "x"]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (groupname entry).
+  #[test]
+  fn groupref_star() {
+    validate_json_from_str("a = [* pair]\npair = (int, tstr)", r#"[1, "x"]"#, None).unwrap();
+    validate_json_from_str(
+      "a = [* pair]\npair = (int, tstr)",
+      r#"[1, "x", 2, "y"]"#,
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn lower_bound_only() {
+    validate_json_from_str("a = [2* (int, tstr)]", r#"[1, "x", 2, "y"]"#, None).unwrap();
+    validate_json_from_str("a = [2* (int, tstr)]", r#"[1, "x", 2, "y", 3, "z"]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.2.2, 3.2, 3.4; Appendix B (choice extension).
+  #[test]
+  fn named_type_choice_elem() {
+    validate_json_from_str("a = [* elem]\nelem = int\nelem /= tstr", r#"[]"#, None).unwrap();
+    validate_json_from_str(
+      "a = [* elem]\nelem = int\nelem /= tstr",
+      r#"[1, "x"]"#,
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn nested_parens() {
+    validate_json_from_str("a = [1*1 (int, (tstr))]", r#"[1, "x"]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn nested_star_of_star() {
+    validate_json_from_str("a = [* [* (int, tstr)]]", r#"[[1, "x"]]"#, None).unwrap();
+    validate_json_from_str("a = [* [* (int, tstr)]]", r#"[[1, "x", 2, "y"], []]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn occur_inside_occur() {
+    validate_json_from_str("a = [* (int, 2*2 tstr)]", r#"[]"#, None).unwrap();
+    validate_json_from_str("a = [* (int, 2*2 tstr)]", r#"[1, "x", "y"]"#, None).unwrap();
+    validate_json_from_str(
+      "a = [* (int, 2*2 tstr)]",
+      r#"[1, "x", "y", 2, "p", "q"]"#,
+      None,
+    )
+    .unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn occur_on_single_entry_group() {
+    validate_json_from_str("a = [2*2 (int, 1*1 (tstr))]", r#"[1, "x", 2, "y"]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn one_or_more() {
+    validate_json_from_str("a = [+ (int, tstr)]", r#"[1, "x"]"#, None).unwrap();
+    validate_json_from_str("a = [+ (int, tstr)]", r#"[1, "x", 2, "y"]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn optional() {
+    validate_json_from_str("a = [? (int, tstr)]", r#"[1, "x"]"#, None).unwrap();
+    validate_json_from_str("a = [? (int, tstr)]", r#"[1]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn optional_middle() {
+    validate_json_from_str("a = [int, ? tstr, bool]", r#"[1, true]"#, None).unwrap();
+    validate_json_from_str("a = [int, ? tstr, bool]", r#"[1, "x", true]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn prefix_then_star() {
+    validate_json_from_str("a = [tstr, * int]", r#"["h"]"#, None).unwrap();
+    validate_json_from_str("a = [tstr, * int]", r#"["h", 1, 2]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 2.2.2, 3.2, 3.4; Appendix A (prioritized choice).
+  #[test]
+  fn prioritized_choice_locks() {
+    validate_json_from_str("a = [(int // int, tstr)]", r#"[1, "x"]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 2.2.1, 3.2, 3.4. Errors recorded while trying a
+  // failing type-choice alternative must not poison a successful one,
+  // regardless of the order the alternatives appear in.
+  #[test]
+  fn type_choice_alternative_order() {
+    validate_json_from_str("a = [* ([int] / [tstr])]", r#"[["x"]]"#, None).unwrap();
+    validate_json_from_str("a = [* ([tstr] / [int])]", r#"[[1]]"#, None).unwrap();
+  }
+
+  // RFC 8610: Section 2.2.1. A type choice must reject an array when no
+  // alternative matches it, including alternatives that are not array-shaped
+  // (a non-array alternative failing against an array must count as a
+  // failure, not be skipped silently).
+  #[test]
+  fn type_choice_non_array_alternates() {
+    validate_json_from_str("a = tstr / bool", r#"[1]"#, None).unwrap_err();
+    validate_json_from_str("a = [int, int] / tstr", r#"[1, "x"]"#, None).unwrap_err();
+    validate_json_from_str("a = [* (tstr / bool)]", r#"[[1]]"#, None).unwrap_err();
+    validate_json_from_str("a = [int, int] / tstr", r#""hi""#, None).unwrap();
+    validate_json_from_str("a = tstr / [int]", r#"[1]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn range_1_2() {
+    validate_json_from_str("a = [1*2 (int, tstr)]", r#"[1, "x"]"#, None).unwrap();
+    validate_json_from_str("a = [1*2 (int, tstr)]", r#"[1, "x", 2, "y"]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn sibling_after() {
+    validate_json_from_str("a = [(int, tstr), bool]", r#"[1, "x", true]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn sibling_before_no_occur() {
+    validate_json_from_str("a = [bool, (int, tstr)]", r#"[true, 1, "x"]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn sibling_before_occur() {
+    validate_json_from_str("a = [bool, 1*1 (int, tstr)]", r#"[true, 1, "x"]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn star_group_then_int() {
+    validate_json_from_str("a = [* (int, tstr), int]", r#"[5]"#, None).unwrap();
+    validate_json_from_str("a = [* (int, tstr), int]", r#"[1, "x", 5]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn star_of_var_arity() {
+    validate_json_from_str("a = [* (int, * tstr)]", r#"[1]"#, None).unwrap();
+    validate_json_from_str("a = [* (int, * tstr)]", r#"[1, "x", 2]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn star_then_tstr() {
+    validate_json_from_str("a = [* int, tstr]", r#"["x"]"#, None).unwrap();
+    validate_json_from_str("a = [* int, tstr]", r#"[1, "x"]"#, None).unwrap();
+    validate_json_from_str("a = [* int, tstr]", r#"[1, 2, "x"]"#, None).unwrap();
+    validate_json_from_str("a = [* int, tstr]", r#"[]"#, None).unwrap_err();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4; Appendix B (parenthesized group).
+  #[test]
+  fn three_level_nesting() {
+    validate_json_from_str("a = [1*1 (int, (tstr, (bool)))]", r#"[1, "x", true]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.7.
+  #[test]
+  fn unwrap_after_sibling() {
+    validate_json_from_str("a = [bool, ~b]\nb = [int, tstr]", r#"[true, 1, "x"]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.7.
+  #[test]
+  fn unwrap_sole() {
+    validate_json_from_str("a = [~b]\nb = [int, tstr]", r#"[1, "x"]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4, 3.7.
+  #[test]
+  fn unwrap_with_occur() {
+    validate_json_from_str("a = [* ~b]\nb = [int, tstr]", r#"[1, "x"]"#, None).unwrap();
+    validate_json_from_str("a = [* ~b]\nb = [int, tstr]", r#"[1, "x", 2, "y"]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn upper_only_group() {
+    validate_json_from_str("a = [*2 (int, tstr)]", r#"[1, "x"]"#, None).unwrap();
+    validate_json_from_str("a = [*2 (int, tstr)]", r#"[1, "x", 2, "y"]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn var_arity_inside() {
+    validate_json_from_str("a = [1*1 (int, * tstr)]", r#"[1]"#, None).unwrap();
+    validate_json_from_str("a = [1*1 (int, * tstr)]", r#"[1, "x"]"#, None).unwrap();
+    validate_json_from_str("a = [1*1 (int, * tstr)]", r#"[1, "x", "y"]"#, None).unwrap();
+  }
+
+  // RFC 8610: Sections 2.1, 3.2, 3.4.
+  #[test]
+  fn zero_or_more() {
+    validate_json_from_str("a = [* (int, tstr)]", r#"[1, "x"]"#, None).unwrap();
+    validate_json_from_str("a = [* (int, tstr)]", r#"[1, "x", 2, "y"]"#, None).unwrap();
+  }
+}


### PR DESCRIPTION
## Summary

Replaces the positional array-validation model (in both the CBOR and JSON validators) with a
sequence matcher (implementing the PEG semantics of RFC 8610's normative Appendix A).

This solves the [FIXME](https://github.com/anweiss/cddl/blob/main/src/validator/json.rs#L2932-L2936)/[TODOs](https://github.com/anweiss/cddl/blob/main/tests/cbor.rs#L197-L200) inlined into the tests to fix the validation cases (I machine-generated some test vectors with AI using the ruby gem as the source of truth)

<details>
<summary>Fable 5 summary of the issue and fix</summary>

## Summary
Per RFC 8610 §3.2, matching a group against an array is sequence matching: a parenthesized
group matches a subsequence of the array's elements, and an occurrence indicator quantifies
repetitions of that **whole subsequence**. `a = [1*1 (int, tstr)]` should match the 2-element
array `[1, "x"]` (one repetition of a two-entry sequence).

The validator instead uses a purely positional model with the occurrence indicator held in
shared mutable state, and as a result **any multi-entry group inside an array — parenthesized
or referenced by group-rule name, with or without an occurrence indicator — is validated
incorrectly**. A multi-entry group currently works in exactly one configuration: as the
array's sole entry, with no occurrence indicator. The occurrence-vs-length confusion in the
error messages below is one symptom of this.

The blast radius is not even limited to groups: the occurrence state is also lost across
*other* rule indirections, so a quantified element whose type resolves through a `/=`
type-choice chain or a generic rule breaks too — with no group anywhere in the spec (see the
last section of the table below; those specs reject even the empty array).

The Ruby reference implementation (`cddl` gem) accepts all instances below that this crate
rejects.

## Repro

```cddl
a = [1*1 (int, tstr)]
```

Instance `[1, "x"]` (CBOR `82 01 61 78`):

```
$ cddl validate --cddl once.cddl --cbor once.cbor
error validating group entry associated with rule "int" at cbor location : array must have exactly 1 items
error validating group entry associated with rule "int" at cbor location : array must have between 1 and 1 items
error validating group entry associated with rule "tstr" at cbor location : array must have exactly 1 items
error validating group entry associated with rule "tstr" at cbor location : array must have between 1 and 1 items
```

## Blast radius: it is not just explicit `m*n` bounds

All of the following spec-valid (and Ruby-accepted) instances are rejected:

| spec | instance | result |
|---|---|---|
| `a = [1*1 (int, tstr)]` | `[1, "x"]` | REJECT: "array must have exactly 1 items" (×2 per inner entry) |
| `a = [2*2 (int, tstr)]` | `[1, "x", 2, "y"]` | REJECT: "array must have exactly 2 items" (4 is correct: 2 reps × 2 entries) |
| `a = [* (int, tstr)]` | `[1, "x"]` | REJECT: every item is validated against every inner entry, so `"x"` fails `int` |
| `a = [? (int, tstr)]` | `[1, "x"]` | REJECT: "array must have 0 or 1 items" |
| `a = [bool, (int, tstr)]` | `[true, 1, "x"]` | REJECT (no occurrence at all): inner entries reuse group-local indices 0,1 as array indices instead of 1,2 |
| `a = [bool, 1*1 (int, tstr)]` | `[true, 1, "x"]` | REJECT: sibling entry plus occurrence |
| `a = [1*1 b]`, `b = (int, tstr)` | `[1, "x"]` | REJECT: same bug via a group-rule reference instead of an inline group |
| `a = [* pair]`, `pair = (int, tstr)` | `[1, "x"]` | REJECT: named-reference spelling with `*`; only the empty array passes |
| `a = [1*1 (int, (tstr))]` | `[1, "x"]` | REJECT: nested parenthesized group |
| `a = [1*1 (int, tstr // tstr, int)]` | `[1, "x"]` | REJECT: group choices inside the repeated group |
| `a = [1*1 (int, * tstr)]` | `[1, "x", "y"]` | REJECT: variable-arity repeated group |
| `a = [* ~b]`, `b = [int, tstr]` | `[1, "x"]` | REJECT: unwrap into an array (broken in every accept configuration: sole, after sibling, quantified) |
| `a = [* e]`, `e = &g`, `g = (1, 2)` | `[1, 2]` | REJECT: choice-from-group via a named reference (inline `&(1, 2)` works) |

And the no-group-at-all cases — the occurrence is lost across the rule indirection itself, so
these reject **even the empty array** ("array must have exactly one item"):

| spec | instance | result |
|---|---|---|
| `a = [* elem]`, `elem = int`, `elem /= tstr` | `[]`, `[1, "x"]` | REJECT: `/=` type-choice chain as a quantified element |
| `a = [* box<int>]`, `box<T> = [T]` | `[]`, `[[1]]` | REJECT: generic rule as a quantified element (`[[1]]` is checked against `int` instead of `[int]`) |

## Root cause

The array-validation path assumes one leaf group entry ↔ one array element at a static index.
Three layers of the design each break independently on multi-entry groups:

1. **No cursor/sequence semantics.** Each leaf entry is validated against
   `array[group_entry_idx]`, where `group_entry_idx` is the entry's index *within its own group
   choice* (`visit_group_choice` in `src/validator/cbor.rs`). When the walker descends into an
   inline group (`walk_inline_group_entry`, `src/visitor.rs`), the inner group choice restarts
   `group_entry_idx` at 0 — nothing tracks how many array elements earlier entries consumed.
   This is why `[bool, (int, tstr)]` fails with no occurrence indicator involved at all: the
   inner `int, tstr` are checked against array indices 0 and 1 instead of 1 and 2.

2. **Occurrence is conflated with total array length.** The CBOR validator does not override
   `visit_inline_group_entry`, so the default walker stashes the group's occurrence into
   `state.occurrence` — a single mutable slot on shared validator state — and walks the inner
   group. Each inner leaf then independently reaches `validate_array_items`
   (`src/validator/cbor.rs`), which calls `validate_array_occurrence` (`src/validator/mod.rs`)
   comparing the stale occurrence bounds against `array.len()` — the whole array. That is only
   correct when the quantified entry is a single element *and* is the array's sole entry. For
   `1*1 (int, tstr)` it becomes "array must have exactly 1 items", re-fired once per inner leaf
   (`int`, `tstr`) — hence the doubled errors in the repro. For `* (int, tstr)` the
   `ZeroOrMore` path iterates every array element against the group homogeneously, so each
   element is checked against *both* inner entries. Note that no tweak to
   `validate_array_occurrence`'s arithmetic can fix this: the function has no notion of how
   many entries one repetition spans. The same shared slot is what breaks the no-group cases:
   descending through `/=` type-choice alternates or a generic instantiation also loses the
   occurrence, so validation of `[* elem]` falls into the no-occurrence branch ("array must
   have exactly one item") regardless of the array's contents.

3. **`entry_counts_from_group` patches over the missing model, incorrectly.**
   `entry_counts_from_group` (`src/validator/mod.rs`) precomputes valid total lengths, but it
   ignores the occurrence multiplier on group entries (a `2*2` group of 2 entries should
   contribute a length of 4, not 2), and it only captures an entry's occurrence when the entry
   is at index 1 within the choice — a special case for `[a, * b]`-shaped arrays that doesn't
   generalize.

The JSON validator (`src/validator/json.rs`) duplicates this logic and has the same bug.

## Fix

Array validation needs to be sequence matching with a cursor — compile the group into a
matcher over the element sequence (leaf entry = match one element, group = subsequence,
occurrence = quantifier, `//` = prioritized choice) with the PEG semantics that RFC 8610's
normative Appendix A prescribes: occurrence indicators are greedy (no backtracking out of a
repetition — the appendix notes `"*a a" in CDDL syntax never can match anything`), and choice
locks in the first successful alternative. Each quantifier iteration speculatively matches
the whole subsequence and rewinds only that iteration on failure. (Appendix C's matching
rule for occurrence — "a (possibly infinite) group choice" of repetition counts — could be
read alone as permitting shorter-than-greedy matches, but Appendix A's explicit `*a a`
example resolves it as greedy, and the Ruby reference implementation behaves greedily.)

Importantly, PEG semantics make this cheaper than it sounds: with no backtracking engine and
no ambiguity search, the matcher is a cursor, greedy loops, and ordered alternatives —
linear-time in practice. Two design notes:

- The matcher owns *sequencing* only (positions, repetitions, choice); the leaf check
  "does this one element match this type" delegates to the existing single-value
  validation machinery, which is what resolves `/=` chains, generics, unwraps, and named
  references correctly. Drawing the boundary there fixes the no-group cases for free and
  removes the need to thread occurrence state through descents.
- Repetition of a zero-width group (`* ()`) needs an explicit termination guard (stop when an
  iteration consumes nothing). For what it's worth, the Ruby reference implementation
  currently hangs forever on `a = [* (), int]`.

This replaces the array-length half of `validate_array_occurrence`, the `entry_counts`
machinery for arrays (the map-equality caller of `entry_counts_from_group` stays), and the
`group_entry_idx`-as-array-index assumption with a single model.
</details>