### PR TITLE
fix(validation) non-uint range support

### DIFF
--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -417,23 +417,27 @@ impl<'a> CBORValidator<'a> {
   }
 
   // Helper function to resolve a Type2 bound to a usize value
-  fn resolve_bound_to_uint(&self, bound: &Type2<'a>) -> std::result::Result<usize, String> {
+  fn resolve_range_bound(&self, bound: &Type2<'a>) -> std::result::Result<RangeBound, String> {
     match bound {
-      Type2::UintValue { value, .. } => Ok(*value),
+      Type2::UintValue { value, .. } => Ok(RangeBound::Uint(*value)),
+      Type2::IntValue { value, .. } => Ok(RangeBound::Int(*value)),
+      Type2::FloatValue { value, .. } => Ok(RangeBound::Float(*value)),
       Type2::Typename { ident, .. } => {
         // Look up the identifier in the CDDL rules
         for rule in self.state.cddl.rules.iter() {
           if let Rule::Type { rule, .. } = rule {
             if rule.name.ident == ident.ident {
-              // Found the rule, now check if it's a simple uint value
+              // Found the rule, now check if it's a simple numeric value
               if rule.value.type_choices.len() == 1 {
-                let type_choice = &rule.value.type_choices[0];
-                if let Type2::UintValue { value, .. } = &type_choice.type1.type2 {
-                  return Ok(*value);
+                match &rule.value.type_choices[0].type1.type2 {
+                  Type2::UintValue { value, .. } => return Ok(RangeBound::Uint(*value)),
+                  Type2::IntValue { value, .. } => return Ok(RangeBound::Int(*value)),
+                  Type2::FloatValue { value, .. } => return Ok(RangeBound::Float(*value)),
+                  _ => {}
                 }
               }
               return Err(format!(
-                "Type name '{}' does not resolve to a simple uint value",
+                "Type name '{}' does not resolve to a simple numeric value",
                 ident.ident
               ));
             }
@@ -444,9 +448,21 @@ impl<'a> CBORValidator<'a> {
           ident.ident
         ))
       }
-      _ => Err(format!("Expected uint value or type name, got {}", bound)),
+      _ => Err(format!(
+        "Expected numeric value or type name, got {}",
+        bound
+      )),
     }
   }
+}
+
+// Resolved range endpoint. RFC 8610 §2.2.2.1: ranges are defined between two
+// integer values or between two floating-point values; mixing is not defined.
+#[derive(Copy, Clone)]
+enum RangeBound {
+  Uint(usize),
+  Int(isize),
+  Float(f64),
 }
 
 impl<'a, T: std::fmt::Debug + 'static> Validator<'a, '_, cbor::Error<T>> for CBORValidator<'a>
@@ -828,99 +844,146 @@ where
       return self.validate_array_items(&ArrayItemToken::Range(lower, upper, is_inclusive));
     }
 
-    // Resolve the bounds to uint values
-    let l_result = self.resolve_bound_to_uint(lower);
-    let u_result = self.resolve_bound_to_uint(upper);
+    // Resolve the bounds to numeric values
+    let (l_bound, u_bound) = match (
+      self.resolve_range_bound(lower),
+      self.resolve_range_bound(upper),
+    ) {
+      (Ok(l), Ok(u)) => (l, u),
+      (Ok(_), Err(u_err)) => {
+        self.add_error(format!(
+          "invalid cddl range. upper value must be a numeric type. got {}. Error: {}",
+          upper, u_err
+        ));
+        return Ok(());
+      }
+      (Err(l_err), Ok(_)) => {
+        self.add_error(format!(
+          "invalid cddl range. lower value must be a numeric type. got {}. Error: {}",
+          lower, l_err
+        ));
+        return Ok(());
+      }
+      (Err(l_err), Err(u_err)) => {
+        self.add_error(format!(
+          "invalid cddl range. upper and lower values must be numeric types. got {} and {}. Error: {} and {}",
+          lower, upper, l_err, u_err
+        ));
+        return Ok(());
+      }
+    };
 
-    match (l_result, u_result) {
-      (Ok(l), Ok(u)) => {
+    // RFC 8610 §2.2.2.1: ranges are between two integers (matching integer
+    // values) or two floats (matching floating-point values)
+    let (l, u) = match (l_bound, u_bound) {
+      (RangeBound::Float(l), RangeBound::Float(u)) => {
         match &self.cbor {
-          Value::Bytes(b) => {
-            let len = b.len();
-            if is_inclusive {
-              if len < l || len > u {
-                self.add_error(format!(
-                  "expected uint to be in range {} <= value <= {}, got Bytes({:?})",
-                  l, u, b
-                ));
-              }
-            } else if len < l || len >= u {
+          Value::Float(f) => {
+            // accept-form check so NaN (unordered) never matches
+            let in_window = l <= *f && if is_inclusive { *f <= u } else { *f < u };
+            if !in_window {
               self.add_error(format!(
-                "expected uint to be in range {} <= value < {}, got Bytes({:?})",
-                l, u, b
-              ));
-            }
-          }
-          Value::Text(s) => match self.state.ctrl {
-            Some(ControlOperator::SIZE) => {
-              let len = s.len();
-              let s = s.clone();
-              if is_inclusive {
-                if s.len() < l || s.len() > u {
-                  self.add_error(format!(
-                    "expected \"{}\" string length to be in the range {} <= value <= {}, got {}",
-                    s, l, u, len
-                  ));
-                }
-
-                return Ok(());
-              } else if s.len() < l || s.len() >= u {
-                self.add_error(format!(
-                  "expected \"{}\" string length to be in the range {} <= value < {}, got {}",
-                  s, l, u, len
-                ));
-                return Ok(());
-              }
-            }
-            _ => {
-              self.add_error("string value cannot be validated against a range without the .size control operator".to_string());
-              return Ok(());
-            }
-          },
-          Value::Integer(i) => {
-            if is_inclusive {
-              if i128::from(*i) < l as i128 || i128::from(*i) > u as i128 {
-                self.add_error(format!(
-                  "expected integer to be in range {} <= value <= {}, got {:?}",
-                  l, u, i
-                ));
-              }
-            } else if i128::from(*i) < l as i128 || i128::from(*i) >= u as i128 {
-              self.add_error(format!(
-                "expected integer to be in range {} <= value < {}, got {:?}",
-                l, u, i
+                "expected float to be in range {} <= value {} {}, got {:?}",
+                l,
+                if is_inclusive { "<=" } else { "<" },
+                u,
+                self.cbor
               ));
             }
           }
           _ => {
             self.add_error(format!(
-              "expected value to be in range {} {} value {} {}, got {:?}",
+              "expected float to be in range {} <= value {} {}, got {:?}",
               l,
-              if is_inclusive { "<=" } else { "<" },
               if is_inclusive { "<=" } else { "<" },
               u,
               self.cbor
             ));
           }
         }
+        return Ok(());
       }
-      (Ok(_), Err(u_err)) => {
+      (RangeBound::Float(_), _) | (_, RangeBound::Float(_)) => {
         self.add_error(format!(
-          "invalid cddl range. upper value must be a uint type. got {}. Error: {}",
-          upper, u_err
+          "invalid cddl range. mixed integer and floating-point endpoints are not defined. got {} and {}",
+          lower, upper
         ));
+        return Ok(());
       }
-      (Err(l_err), Ok(_)) => {
-        self.add_error(format!(
-          "invalid cddl range. lower value must be a uint type. got {}. Error: {}",
-          lower, l_err
-        ));
+      (RangeBound::Uint(l), RangeBound::Uint(u)) => (l as i128, u as i128),
+      (RangeBound::Uint(l), RangeBound::Int(u)) => (l as i128, u as i128),
+      (RangeBound::Int(l), RangeBound::Uint(u)) => (l as i128, u as i128),
+      (RangeBound::Int(l), RangeBound::Int(u)) => (l as i128, u as i128),
+    };
+
+    match &self.cbor {
+      Value::Bytes(b) => {
+        let len = b.len() as i128;
+        if is_inclusive {
+          if len < l || len > u {
+            self.add_error(format!(
+              "expected uint to be in range {} <= value <= {}, got Bytes({:?})",
+              l, u, b
+            ));
+          }
+        } else if len < l || len >= u {
+          self.add_error(format!(
+            "expected uint to be in range {} <= value < {}, got Bytes({:?})",
+            l, u, b
+          ));
+        }
       }
-      (Err(l_err), Err(u_err)) => {
-        let err_msg = format!("{} and {}", l_err, u_err);
+      Value::Text(s) => match self.state.ctrl {
+        Some(ControlOperator::SIZE) => {
+          let len = s.len() as i128;
+          if is_inclusive {
+            if len < l || len > u {
+              self.add_error(format!(
+                "expected \"{}\" string length to be in the range {} <= value <= {}, got {}",
+                s, l, u, len
+              ));
+            }
+
+            return Ok(());
+          } else if len < l || len >= u {
+            self.add_error(format!(
+              "expected \"{}\" string length to be in the range {} <= value < {}, got {}",
+              s, l, u, len
+            ));
+            return Ok(());
+          }
+        }
+        _ => {
+          self.add_error(
+            "string value cannot be validated against a range without the .size control operator"
+              .to_string(),
+          );
+          return Ok(());
+        }
+      },
+      Value::Integer(i) => {
+        if is_inclusive {
+          if i128::from(*i) < l || i128::from(*i) > u {
+            self.add_error(format!(
+              "expected integer to be in range {} <= value <= {}, got {:?}",
+              l, u, i
+            ));
+          }
+        } else if i128::from(*i) < l || i128::from(*i) >= u {
+          self.add_error(format!(
+            "expected integer to be in range {} <= value < {}, got {:?}",
+            l, u, i
+          ));
+        }
+      }
+      _ => {
         self.add_error(format!(
-          "invalid cddl range. upper and lower values must be uint types. got {} and {}. Error: {}",
-          lower, upper, err_msg
+          "expected value to be in range {} {} value {} {}, got {:?}",
+          l,
+          if is_inclusive { "<=" } else { "<" },
+          if is_inclusive { "<=" } else { "<" },
+          u,
+          self.cbor
         ));
       }
     }

--- a/tests/range_endpoints.rs
+++ b/tests/range_endpoints.rs
@@ -1,0 +1,348 @@
+#![cfg(feature = "std")]
+#![cfg(feature = "cbor")]
+#![cfg(not(target_arch = "wasm32"))]
+
+// Range endpoint semantics per RFC 8610 Section 2.2.2.1: ".." includes both
+// endpoints; "..." includes the lower endpoint and excludes only the upper.
+// Ranges are defined between two integer values (matching integers) or
+// between two floating-point values (matching floats) only.
+//
+// Every expected verdict below was cross-checked against the reference
+// implementation (ruby cddl gem 0.12.14) before being committed.
+
+use cddl::validator::validate_cbor_from_slice;
+
+struct Claim {
+  cddl: &'static str,
+  cbor: &'static [u8],
+  accept: bool,
+  rationale: &'static str,
+}
+
+fn check(claims: &[Claim]) {
+  for claim in claims {
+    let result = validate_cbor_from_slice(claim.cddl, claim.cbor, None);
+    assert_eq!(
+      result.is_ok(),
+      claim.accept,
+      "{} with CBOR {:02x?} should {}: {} (got {:?})",
+      claim.cddl,
+      claim.cbor,
+      if claim.accept { "accept" } else { "reject" },
+      claim.rationale,
+      result
+    );
+  }
+}
+
+#[test]
+fn range_endpoints_nint_to_nint_inclusive() {
+  // RFC 8610 Section 2.2.2.1: ".." includes both endpoints for integer ranges.
+  check(&[
+    Claim {
+      cddl: "t = -10..-3",
+      cbor: b"\x2a",
+      accept: false,
+      rationale: "-11 is below lower endpoint -10",
+    },
+    Claim {
+      cddl: "t = -10..-3",
+      cbor: b"\x29",
+      accept: true,
+      rationale: "lower endpoint -10 is included",
+    },
+    Claim {
+      cddl: "t = -10..-3",
+      cbor: b"\x26",
+      accept: true,
+      rationale: "-7 is mid-window",
+    },
+    Claim {
+      cddl: "t = -10..-3",
+      cbor: b"\x22",
+      accept: true,
+      rationale: "upper endpoint -3 is included",
+    },
+    Claim {
+      cddl: "t = -10..-3",
+      cbor: b"\x21",
+      accept: false,
+      rationale: "-2 is above upper endpoint -3",
+    },
+  ]);
+}
+
+#[test]
+fn range_endpoints_nint_to_nint_exclusive_upper() {
+  // RFC 8610 Section 2.2.2.1: "..." includes the lower endpoint and excludes
+  // only the upper endpoint.
+  check(&[
+    Claim {
+      cddl: "t = -10...-3",
+      cbor: b"\x2a",
+      accept: false,
+      rationale: "-11 is below lower endpoint -10",
+    },
+    Claim {
+      cddl: "t = -10...-3",
+      cbor: b"\x29",
+      accept: true,
+      rationale: "lower endpoint -10 is included",
+    },
+    Claim {
+      cddl: "t = -10...-3",
+      cbor: b"\x26",
+      accept: true,
+      rationale: "-7 is mid-window",
+    },
+    Claim {
+      cddl: "t = -10...-3",
+      cbor: b"\x22",
+      accept: false,
+      rationale: "upper endpoint -3 is excluded",
+    },
+    Claim {
+      cddl: "t = -10...-3",
+      cbor: b"\x21",
+      accept: false,
+      rationale: "-2 is above upper endpoint -3",
+    },
+  ]);
+}
+
+#[test]
+fn range_endpoints_nint_to_uint_inclusive() {
+  // RFC 8610 Section 2.2.2.1: integer ranges match integer values, including
+  // sign-spanning ranges.
+  check(&[
+    Claim {
+      cddl: "t = -10..10",
+      cbor: b"\x2a",
+      accept: false,
+      rationale: "-11 is below lower endpoint -10",
+    },
+    Claim {
+      cddl: "t = -10..10",
+      cbor: b"\x29",
+      accept: true,
+      rationale: "lower endpoint -10 is included",
+    },
+    Claim {
+      cddl: "t = -10..10",
+      cbor: b"\x00",
+      accept: true,
+      rationale: "0 is mid-window",
+    },
+    Claim {
+      cddl: "t = -10..10",
+      cbor: b"\x0a",
+      accept: true,
+      rationale: "upper endpoint 10 is included",
+    },
+    Claim {
+      cddl: "t = -10..10",
+      cbor: b"\x0b",
+      accept: false,
+      rationale: "11 is above upper endpoint 10",
+    },
+  ]);
+}
+
+#[test]
+fn range_endpoints_nint_to_uint_exclusive_upper() {
+  // RFC 8610 Section 2.2.2.1: sign-spanning "..." ranges include the lower
+  // endpoint and exclude only the upper endpoint.
+  check(&[
+    Claim {
+      cddl: "t = -10...10",
+      cbor: b"\x2a",
+      accept: false,
+      rationale: "-11 is below lower endpoint -10",
+    },
+    Claim {
+      cddl: "t = -10...10",
+      cbor: b"\x29",
+      accept: true,
+      rationale: "lower endpoint -10 is included",
+    },
+    Claim {
+      cddl: "t = -10...10",
+      cbor: b"\x00",
+      accept: true,
+      rationale: "0 is mid-window",
+    },
+    Claim {
+      cddl: "t = -10...10",
+      cbor: b"\x0a",
+      accept: false,
+      rationale: "upper endpoint 10 is excluded",
+    },
+    Claim {
+      cddl: "t = -10...10",
+      cbor: b"\x0b",
+      accept: false,
+      rationale: "11 is above upper endpoint 10",
+    },
+  ]);
+}
+
+#[test]
+fn range_endpoints_float_to_float_inclusive() {
+  // RFC 8610 Section 2.2.2.1: float ranges match floating-point values only.
+  check(&[
+    Claim {
+      cddl: "t = 0.5..10.5",
+      cbor: b"\xfb\xbf\xe0\x00\x00\x00\x00\x00\x00",
+      accept: false,
+      rationale: "-0.5 is below lower endpoint 0.5",
+    },
+    Claim {
+      cddl: "t = 0.5..10.5",
+      cbor: b"\xfb\x3f\xe0\x00\x00\x00\x00\x00\x00",
+      accept: true,
+      rationale: "lower endpoint 0.5 is included",
+    },
+    Claim {
+      cddl: "t = 0.5..10.5",
+      cbor: b"\xfb\x40\x16\x00\x00\x00\x00\x00\x00",
+      accept: true,
+      rationale: "5.5 is mid-window",
+    },
+    Claim {
+      cddl: "t = 0.5..10.5",
+      cbor: b"\xfb\x40\x25\x00\x00\x00\x00\x00\x00",
+      accept: true,
+      rationale: "upper endpoint 10.5 is included",
+    },
+    Claim {
+      cddl: "t = 0.5..10.5",
+      cbor: b"\xfb\x40\x27\x00\x00\x00\x00\x00\x00",
+      accept: false,
+      rationale: "11.5 is above upper endpoint 10.5",
+    },
+    Claim {
+      cddl: "t = 0.5..10.5",
+      cbor: b"\xf9\x7e\x00",
+      accept: false,
+      rationale: "NaN is unordered and must not match a bounded range",
+    },
+    Claim {
+      cddl: "t = 0.5..10.5",
+      cbor: b"\x05",
+      accept: false,
+      rationale: "float ranges match floating-point values, not integer encodings",
+    },
+  ]);
+}
+
+#[test]
+fn range_endpoints_float_to_float_exclusive_upper() {
+  // RFC 8610 Section 2.2.2.1: float "..." ranges include the lower endpoint
+  // and exclude only the upper endpoint.
+  check(&[
+    Claim {
+      cddl: "t = 0.5...10.5",
+      cbor: b"\xfb\xbf\xe0\x00\x00\x00\x00\x00\x00",
+      accept: false,
+      rationale: "-0.5 is below lower endpoint 0.5",
+    },
+    Claim {
+      cddl: "t = 0.5...10.5",
+      cbor: b"\xfb\x3f\xe0\x00\x00\x00\x00\x00\x00",
+      accept: true,
+      rationale: "lower endpoint 0.5 is included",
+    },
+    Claim {
+      cddl: "t = 0.5...10.5",
+      cbor: b"\xfb\x40\x16\x00\x00\x00\x00\x00\x00",
+      accept: true,
+      rationale: "5.5 is mid-window",
+    },
+    Claim {
+      cddl: "t = 0.5...10.5",
+      cbor: b"\xfb\x40\x25\x00\x00\x00\x00\x00\x00",
+      accept: false,
+      rationale: "upper endpoint 10.5 is excluded",
+    },
+    Claim {
+      cddl: "t = 0.5...10.5",
+      cbor: b"\xfb\x40\x27\x00\x00\x00\x00\x00\x00",
+      accept: false,
+      rationale: "11.5 is above upper endpoint 10.5",
+    },
+    Claim {
+      cddl: "t = 0.5...10.5",
+      cbor: b"\xf9\x7e\x00",
+      accept: false,
+      rationale: "NaN is unordered and must not match a bounded range",
+    },
+  ]);
+}
+
+#[test]
+fn range_endpoints_uint_to_uint_controls() {
+  // RFC 8610 Section 2.2.2.1: uint..uint ranges (already supported) keep
+  // working, with half-open semantics on "...".
+  check(&[
+    Claim {
+      cddl: "t = 5..10",
+      cbor: b"\x04",
+      accept: false,
+      rationale: "4 is below lower endpoint 5",
+    },
+    Claim {
+      cddl: "t = 5..10",
+      cbor: b"\x05",
+      accept: true,
+      rationale: "lower endpoint 5 is included",
+    },
+    Claim {
+      cddl: "t = 5..10",
+      cbor: b"\x07",
+      accept: true,
+      rationale: "7 is mid-window",
+    },
+    Claim {
+      cddl: "t = 5..10",
+      cbor: b"\x0a",
+      accept: true,
+      rationale: "upper endpoint 10 is included",
+    },
+    Claim {
+      cddl: "t = 5..10",
+      cbor: b"\x0b",
+      accept: false,
+      rationale: "11 is above upper endpoint 10",
+    },
+    Claim {
+      cddl: "t = 5...10",
+      cbor: b"\x04",
+      accept: false,
+      rationale: "4 is below lower endpoint 5",
+    },
+    Claim {
+      cddl: "t = 5...10",
+      cbor: b"\x05",
+      accept: true,
+      rationale: "lower endpoint 5 is included",
+    },
+    Claim {
+      cddl: "t = 5...10",
+      cbor: b"\x07",
+      accept: true,
+      rationale: "7 is mid-window",
+    },
+    Claim {
+      cddl: "t = 5...10",
+      cbor: b"\x0a",
+      accept: false,
+      rationale: "upper endpoint 10 is excluded",
+    },
+    Claim {
+      cddl: "t = 5...10",
+      cbor: b"\x0b",
+      accept: false,
+      rationale: "11 is above upper endpoint 10",
+    },
+  ]);
+}


### PR DESCRIPTION
Since v0.10.0, `validate_cbor_from_slice` / `cddl validate` stopped supporting non-uint types in ranges. Notably, this is a regression from #237

ex: negative values (`t = -10..-3`) and float ranges (`t = 0.5..10.5`)

This PR restores support and includes test vectors seeded from the spec, validated with the ruby gem as the source of truth