### PR TITLE
fix(pest_bridge) support radix literals

### DIFF
--- a/cddl.pest
+++ b/cddl.pest
@@ -263,10 +263,43 @@ value = { number | text_value | bytes_value }
 // Examples: 42, -10, 3.14, 1.5e10, 0x1.5p10
 number = { hexfloat | float_value | int_value | uint_value }
 
-uint_value = @{ DIGIT+ }
-int_value = @{ "-" ~ DIGIT+ }
-float_value = @{ "-"? ~ DIGIT+ ~ "." ~ DIGIT+ ~ (^"e" ~ ("+" | "-")? ~ DIGIT+)? }
-hexfloat = @{ "-"? ~ "0x" ~ ASCII_HEX_DIGIT+ ~ ("." ~ ASCII_HEX_DIGIT+)? ~ ("p" ~ ("+" | "-")? ~ DIGIT+)? }
+// RFC 8610 Appendix B: uint = DIGIT1 *DIGIT / "0x" 1*HEXDIG / "0b" 1*BINDIG / "0"
+// (unchanged in RFC 9682 Appendix A, whose head-number = uint also makes these
+// radix forms valid in #6.<n>/#7.<n> tag and simple-value head positions).
+// Radix alternatives must come first: a decimal alternative would otherwise
+// consume the "0" of "0x10" and leave "x10" behind. Decimal literals must not
+// have leading zeros (DIGIT1 *DIGIT / "0"). Prefixes and digits are case
+// insensitive (RFC 8610 Section 3.1).
+//
+// Known re-tokenization quirk: because group entries need no separating
+// whitespace, an atomic number rule that stops early leaves the remainder to
+// parse as further entries. In group contexts "0x" parses as `0 x`, "042" as
+// `0 42`, and "01*02 t" as `0 (1*0) 2 t`. This is derivable under the RFC's own
+// ABNF, so it is accepted; at top level such inputs fail (nothing can consume
+// the remainder). Rejecting them would need a `"0" ~ !DIGIT`-style lookahead,
+// i.e. deliberately stricter than RFC 8610.
+uint_value = @{ ^"0x" ~ ASCII_HEX_DIGIT+ | ^"0b" ~ ASCII_BIN_DIGIT+ | ASCII_NONZERO_DIGIT ~ DIGIT* | "0" }
+int_value = @{ "-" ~ (^"0x" ~ ASCII_HEX_DIGIT+ | ^"0b" ~ ASCII_BIN_DIGIT+ | ASCII_NONZERO_DIGIT ~ DIGIT* | "0") }
+// RFC 8610 Appendix B: number = hexfloat / (int ["." fraction] ["e" exponent]),
+// so the fraction is optional when an exponent is present (e.g. 1e5). At least
+// one of fraction/exponent is required — a plain int must fall through to
+// int_value/uint_value. The mantissa is an int, so like uint_value it must not
+// have leading zeros; fraction and exponent are 1*DIGIT and may (e.g. 1.05e05).
+// The mantissa is deliberately decimal-only: the unordered ABNF (unchanged in
+// RFC 9682 Appendix A's collected grammar) literally also derives radix-int
+// mantissas (0b1e2, 0b1.5, 0x1.8 as 0x1 + ".8"), but that reading has no defined
+// semantics and makes hexfloat ambiguous. The only radix float form is hexfloat.
+// Spec question filed upstream: https://github.com/cbor-wg/cddl/issues/33
+float_value = @{
+  "-"? ~ (ASCII_NONZERO_DIGIT ~ DIGIT* | "0")
+    ~ (
+      "." ~ DIGIT+ ~ (^"e" ~ ("+" | "-")? ~ DIGIT+)?
+      | ^"e" ~ ("+" | "-")? ~ DIGIT+
+    )
+}
+// RFC 8610 Appendix B: hexfloat = ["-"] "0x" 1*HEXDIG ["." 1*HEXDIG] "p" exponent
+// The "p" exponent is REQUIRED — a plain hex integer must fall through to uint_value.
+hexfloat = @{ "-"? ~ ^"0x" ~ ASCII_HEX_DIGIT+ ~ ("." ~ ASCII_HEX_DIGIT+)? ~ ^"p" ~ ("+" | "-")? ~ DIGIT+ }
 
 // =============================================================================
 // TEXT VALUES (STRINGS)

--- a/src/pest_bridge.rs
+++ b/src/pest_bridge.rs
@@ -59,6 +59,35 @@ use std::collections::HashMap;
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, format, string::String, string::ToString, vec, vec::Vec};
 
+/// Parse a CDDL uint literal as u64, including the RFC 8610 radix forms
+/// ("0x" 1*HEXDIG / "0b" 1*BINDIG). Prefixes and digits are case insensitive
+/// (RFC 8610 Section 3.1); `from_str_radix` already accepts mixed-case hex
+/// digits, so only the prefix needs a case-insensitive match.
+fn parse_u64_lit(s: &str) -> Option<u64> {
+  match s.as_bytes() {
+    [b'0', b'x' | b'X', ..] => u64::from_str_radix(&s[2..], 16).ok(),
+    [b'0', b'b' | b'B', ..] => u64::from_str_radix(&s[2..], 2).ok(),
+    _ => s.parse().ok(),
+  }
+}
+
+/// Parse a CDDL uint literal into usize (the AST's uint representation).
+fn parse_uint_lit(s: &str) -> Option<usize> {
+  use core::convert::TryFrom;
+  parse_u64_lit(s).and_then(|v| usize::try_from(v).ok())
+}
+
+/// Parse a CDDL int literal (["-"] uint), radix forms included.
+fn parse_int_lit(s: &str) -> Option<isize> {
+  use core::convert::TryFrom;
+  if let Some(rest) = s.strip_prefix('-') {
+    let magnitude = i128::from(parse_u64_lit(rest)?);
+    isize::try_from(-magnitude).ok()
+  } else {
+    parse_u64_lit(s).and_then(|v| isize::try_from(v).ok())
+  }
+}
+
 /// Convert a Pest error to the existing parser error format with enhanced messages
 #[allow(unused_variables)]
 pub fn convert_pest_error(error: pest::error::Error<Rule>, input: &str) -> Error {
@@ -2230,7 +2259,7 @@ fn convert_number_to_type2<'a>(
   for inner in pair.into_inner() {
     match inner.as_rule() {
       Rule::uint_value => {
-        let val = inner.as_str().parse::<usize>().map_err(|_| Error::PARSER {
+        let val = parse_uint_lit(inner.as_str()).ok_or_else(|| Error::PARSER {
           position: pest_span_to_position(&inner.as_span(), input),
           msg: ErrorMsg {
             short: "Invalid unsigned integer".to_string(),
@@ -2240,7 +2269,7 @@ fn convert_number_to_type2<'a>(
         return Ok(ast::Type2::UintValue { value: val, span });
       }
       Rule::int_value => {
-        let val = inner.as_str().parse::<isize>().map_err(|_| Error::PARSER {
+        let val = parse_int_lit(inner.as_str()).ok_or_else(|| Error::PARSER {
           position: pest_span_to_position(&inner.as_span(), input),
           msg: ErrorMsg {
             short: "Invalid integer".to_string(),
@@ -2262,13 +2291,15 @@ fn convert_number_to_type2<'a>(
       Rule::hexfloat => {
         #[cfg(feature = "std")]
         {
-          let val = hexf_parse::parse_hexf64(inner.as_str(), false).map_err(|_| Error::PARSER {
-            position: pest_span_to_position(&inner.as_span(), input),
-            msg: ErrorMsg {
-              short: "Invalid hexfloat".to_string(),
-              extended: None,
+          let val = hexf_parse::parse_hexf64(&inner.as_str().to_ascii_lowercase(), false).map_err(
+            |_| Error::PARSER {
+              position: pest_span_to_position(&inner.as_span(), input),
+              msg: ErrorMsg {
+                short: "Invalid hexfloat".to_string(),
+                extended: None,
+              },
             },
-          })?;
+          )?;
           return Ok(ast::Type2::FloatValue { value: val, span });
         }
         #[cfg(not(feature = "std"))]
@@ -2300,7 +2331,7 @@ fn convert_number_to_type2<'a>(
   for inner in pair.into_inner() {
     match inner.as_rule() {
       Rule::uint_value => {
-        let val = inner.as_str().parse::<usize>().map_err(|_| Error::PARSER {
+        let val = parse_uint_lit(inner.as_str()).ok_or_else(|| Error::PARSER {
           msg: ErrorMsg {
             short: "Invalid unsigned integer".to_string(),
             extended: None,
@@ -2309,7 +2340,7 @@ fn convert_number_to_type2<'a>(
         return Ok(ast::Type2::UintValue { value: val });
       }
       Rule::int_value => {
-        let val = inner.as_str().parse::<isize>().map_err(|_| Error::PARSER {
+        let val = parse_int_lit(inner.as_str()).ok_or_else(|| Error::PARSER {
           msg: ErrorMsg {
             short: "Invalid integer".to_string(),
             extended: None,
@@ -2329,12 +2360,14 @@ fn convert_number_to_type2<'a>(
       Rule::hexfloat => {
         #[cfg(feature = "std")]
         {
-          let val = hexf_parse::parse_hexf64(inner.as_str(), false).map_err(|_| Error::PARSER {
-            msg: ErrorMsg {
-              short: "Invalid hexfloat".to_string(),
-              extended: None,
+          let val = hexf_parse::parse_hexf64(&inner.as_str().to_ascii_lowercase(), false).map_err(
+            |_| Error::PARSER {
+              msg: ErrorMsg {
+                short: "Invalid hexfloat".to_string(),
+                extended: None,
+              },
             },
-          })?;
+          )?;
           return Ok(ast::Type2::FloatValue { value: val });
         }
         #[cfg(not(feature = "std"))]
@@ -2519,7 +2552,14 @@ fn convert_tag_expr<'a>(pair: Pair<'a, Rule>, input: &'a str) -> Result<ast::Typ
         for tv in inner.into_inner() {
           match tv.as_rule() {
             Rule::uint_value => {
-              let val = tv.as_str().parse::<u64>().unwrap_or(0);
+              let val = parse_u64_lit(tv.as_str()).ok_or_else(|| Error::PARSER {
+                #[cfg(feature = "ast-span")]
+                position: pest_span_to_position(&tv.as_span(), input),
+                msg: ErrorMsg {
+                  short: format!("Tag number out of range: {}", tv.as_str()),
+                  extended: None,
+                },
+              })?;
               tag_constraint = Some(TagConstraint::Literal(val));
             }
             Rule::type_expr => {
@@ -2824,12 +2864,23 @@ fn convert_occurrence<'a>(
         // Parse the occurrence range
         let occur_str = inner.as_str();
 
+        let parse_bound = |bound: &str| -> Result<usize, Error> {
+          parse_uint_lit(bound).ok_or_else(|| Error::PARSER {
+            #[cfg(feature = "ast-span")]
+            position: pest_span_to_position(&inner.as_span(), input),
+            msg: ErrorMsg {
+              short: format!("Occurrence bound out of range: {}", bound),
+              extended: None,
+            },
+          })
+        };
+
         // Check if this is a simple "n*" pattern (n or more)
         if occur_str.ends_with('*') && !occur_str.contains("**") {
           let trimmed = occur_str.trim_end_matches('*').trim();
-          if !trimmed.is_empty() && trimmed.parse::<usize>().is_ok() {
+          if !trimmed.is_empty() {
             // This is "n*" meaning "n or more"
-            let lower = Some(trimmed.parse::<usize>().unwrap());
+            let lower = Some(parse_bound(trimmed)?);
             return Ok(ast::Occurrence {
               occur: ast::Occur::Exact {
                 lower,
@@ -2847,14 +2898,14 @@ fn convert_occurrence<'a>(
         // Handle range patterns "n*m" or "*m" or "n*"
         let parts: Vec<&str> = occur_str.split('*').collect();
 
-        let lower = if !parts[0].is_empty() {
-          Some(parts[0].trim().parse::<usize>().unwrap_or(0))
+        let lower = if !parts[0].trim().is_empty() {
+          Some(parse_bound(parts[0].trim())?)
         } else {
           None
         };
 
         let upper = if parts.len() > 1 && !parts[1].trim().is_empty() {
-          Some(parts[1].trim().parse::<usize>().unwrap_or(0))
+          Some(parse_bound(parts[1].trim())?)
         } else {
           None
         };

--- a/src/token.rs
+++ b/src/token.rs
@@ -450,7 +450,6 @@ impl fmt::Display for RangeValue<'_> {
 }
 
 /// Literal value
-// TODO: support hexfloat and exponent
 #[cfg_attr(target_arch = "wasm32", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Clone)]
 pub enum Value<'a> {

--- a/tests/radix_literals.rs
+++ b/tests/radix_literals.rs
@@ -1,0 +1,283 @@
+#![cfg(feature = "std")]
+#![cfg(feature = "cbor")]
+#![cfg(not(target_arch = "wasm32"))]
+
+use cddl::{ast, parser, validator::validate_cbor_from_slice};
+
+fn cbor(hex: &str) -> Vec<u8> {
+  assert!(hex.len() % 2 == 0, "hex input must have an even length");
+  (0..hex.len())
+    .step_by(2)
+    .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).unwrap())
+    .collect()
+}
+
+fn assert_valid_claim(cddl_input: &str, cbor_hex: &str) {
+  parser::cddl_from_str(cddl_input, false)
+    .unwrap_or_else(|e| panic!("unchecked parser rejected {:?}: {}", cddl_input, e));
+  ast::CDDL::from_slice(cddl_input.as_bytes())
+    .unwrap_or_else(|e| panic!("checked parser rejected {:?}: {}", cddl_input, e));
+  validate_cbor_from_slice(cddl_input, &cbor(cbor_hex), None)
+    .unwrap_or_else(|e| panic!("validator rejected {:?}: {}", cddl_input, e));
+}
+
+fn assert_parse_error_claim(cddl_input: &str) {
+  assert!(
+    parser::cddl_from_str(cddl_input, false).is_err(),
+    "unchecked parser accepted invalid CDDL: {:?}",
+    cddl_input
+  );
+  assert!(
+    ast::CDDL::from_slice(cddl_input.as_bytes()).is_err(),
+    "checked parser accepted invalid CDDL: {:?}",
+    cddl_input
+  );
+}
+
+#[test]
+fn radix_hex_uint_value() {
+  // Claim radix_hex_uint_value. RFC 8610 Appendix B: uint = ... / "0x" 1*HEXDIG.
+  assert_valid_claim("thing = 0x10", "10");
+}
+
+#[test]
+fn radix_bin_uint_value() {
+  // Claim radix_bin_uint_value. RFC 8610 Appendix B: uint = ... / "0b" 1*BINDIG.
+  assert_valid_claim("thing = 0b1010", "0a");
+}
+
+#[test]
+fn radix_hex_upper_prefix() {
+  // Claim radix_hex_upper_prefix. RFC 8610 Section 3.1: hex numbers are case insensitive,
+  // including the "0x" prefix (App. B: quote-delimited ABNF strings are case-insensitive).
+  assert_valid_claim("thing = 0X10", "10");
+}
+
+#[test]
+fn radix_bin_upper_prefix() {
+  // Claim radix_bin_upper_prefix. RFC 8610 Section 3.1: binary numbers are case insensitive,
+  // including the "0b" prefix (App. B: quote-delimited ABNF strings are case-insensitive).
+  assert_valid_claim("thing = 0B1010", "0a");
+}
+
+#[test]
+fn radix_hex_lowercase_digit() {
+  // Claim radix_hex_lowercase_digit. RFC 8610 Section 3.1: hex numbers are case insensitive, so
+  // lowercase a-f are valid HEXDIG matches (ABNF quoted literals are case-insensitive per RFC 5234).
+  // No spec-vs-oracle deviation here: ruby agrees.
+  assert_valid_claim("thing = 0x0f", "0f");
+}
+
+#[test]
+fn radix_negative_hex_int() {
+  // Claim radix_negative_hex_int. RFC 8610 Appendix B: int = ["-"] uint.
+  assert_valid_claim("thing = -0x10", "2f");
+}
+
+#[test]
+fn radix_negative_bin_int() {
+  // Claim radix_negative_bin_int. RFC 8610 Appendix B: int = ["-"] uint.
+  assert_valid_claim("thing = -0b101", "24");
+}
+
+#[test]
+fn radix_hex_range_bounds() {
+  // Claim radix_hex_range_bounds. RFC 8610 Section 2.2.2.1 and Appendix B rangeop.
+  assert_valid_claim("thing = 0x00..0xff", "18ff");
+}
+
+#[test]
+fn radix_hex_memberkey_value() {
+  // Claim radix_hex_memberkey_value. RFC 8610 Appendix B: memberkey = value S ":".
+  assert_valid_claim("thing = {0x10: tstr}", "a1106161");
+}
+
+#[test]
+fn radix_bin_memberkey_value() {
+  // Claim radix_bin_memberkey_value. RFC 8610 Appendix B: memberkey = value S ":".
+  assert_valid_claim("thing = {0b1010: tstr}", "a10a6161");
+}
+
+#[test]
+fn radix_major_ai_uint() {
+  // Claim radix_major_ai_uint. RFC 8610 Section 2.2.3: "#" DIGIT ["." uint].
+  assert_valid_claim("thing = #0.0x18", "1818");
+}
+
+#[test]
+fn radix_tag_head_number() {
+  // Claim radix_tag_head_number_oracle_deviation. RFC 8610 App. B `"#" "6" ["." uint]` and
+  // RFC 9682 Section 3.2 `head-number = uint` permit radix tag numbers: #6.0x20 is tag 32.
+  // Ruby cddl 0.12.14 disagrees (base-10 String#to_i on "0x20" yields tag 0) — confirmed RUBY_BUG
+  assert_valid_claim("thing = #6.0x20(tstr)", "d8206161");
+}
+
+#[test]
+fn radix_simple_head_number() {
+  // Claim radix_simple_head_number_oracle_deviation. RFC 9682 Section 3.2: #7.<head-number> with
+  // head-number 32..255 stands for that simple value, so #7.0x20 is simple(32).
+  // Ruby cddl 0.12.14 disagrees (same base-10 to_i bug) — confirmed RUBY_BUG
+  assert_valid_claim("thing = #7.0x20", "f820");
+}
+
+#[test]
+fn radix_occurrence_bounds() {
+  // Claim radix_occurrence_bounds_oracle_deviation. RFC 8610 App. B `occur = [uint] "*" [uint]`
+  // with the same radix-capable uint production, so 0x2*0x4 means 2..4 occurrences. (App. B's
+  // generative ABNF doesn't itself prioritize this over other derivations — App. A's PEG rules
+  // govern data matching, not spec-text parsing — but the occurrence-indicator read is the only
+  // one with defined semantics and is the de-facto convention.)
+  // Ruby cddl 0.12.14 disagrees (decimal-only regex in `occur`, raises "huh") — confirmed RUBY_BUG,
+  assert_valid_claim("thing = [0x2*0x4 tstr]", "8261616162");
+}
+
+#[test]
+fn hexfloat_valid_with_p_exponent() {
+  // Claim hexfloat_valid_with_p_exponent. RFC 8610 Appendix B: hexfloat ends with "p" exponent.
+  assert_valid_claim("thing = 0x1.8p+1", "fb4008000000000000");
+}
+
+#[test]
+fn hexfloat_missing_p_exponent() {
+  // Claim hexfloat_missing_p_exponent. RFC 8610 Appendix B requires the "p" exponent.
+  assert_parse_error_claim("thing = 0x1.8");
+}
+
+#[test]
+fn radix_hex_upper_digits() {
+  // Claim radix_hex_upper_digits. RFC 8610 Section 3.1: hex numbers are case insensitive.
+  assert_valid_claim("thing = 0xFF", "18ff");
+}
+
+#[test]
+fn radix_hex_zero() {
+  // Claim radix_hex_zero. RFC 8610 Appendix B: uint = ... / "0x" 1*HEXDIG.
+  assert_valid_claim("thing = 0x0", "00");
+}
+
+#[test]
+fn radix_bin_zero() {
+  // Claim radix_bin_zero. RFC 8610 Appendix B: uint = ... / "0b" 1*BINDIG.
+  assert_valid_claim("thing = 0b0", "00");
+}
+
+#[test]
+fn radix_hex_u64_max() {
+  // Claim radix_hex_u64_max. RFC 8610 Appendix B uint has no size bound; the bridge conversion
+  // must at least cover the full u64 range without overflow.
+  assert_valid_claim("thing = 0xffffffffffffffff", "1bffffffffffffffff");
+}
+
+#[test]
+fn radix_control_arg() {
+  // Claim radix_control_arg. RFC 8610 Section 3.8.6: .lt controller is a type1; value = number.
+  assert_valid_claim("thing = uint .lt 0x10", "0f");
+}
+
+#[test]
+fn radix_hex_no_digits() {
+  // Claim radix_hex_no_digits. RFC 8610 Appendix B: "0x" requires 1*HEXDIG, so "0x" is not a
+  // uint literal. At top level the leftover "x" makes the whole document unparseable. (In group
+  // contexts "0x" still parses as uint 0 followed by typename x — RFC-derivable, since group
+  // entries need no separating whitespace.)
+  assert_parse_error_claim("thing = 0x");
+}
+
+#[test]
+fn radix_bin_bad_digit() {
+  // Claim radix_bin_bad_digit. RFC 8610 Appendix B: "0b" requires 1*BINDIG; "0b2" must not parse.
+  assert_parse_error_claim("thing = 0b2");
+}
+
+#[test]
+fn hexfloat_no_fraction() {
+  // Claim hexfloat_no_fraction. RFC 8610 Appendix B hexfloat: fraction optional, "p" required.
+  assert_valid_claim("thing = 0x1p3", "fb4020000000000000");
+}
+
+#[test]
+fn hexfloat_upper_p() {
+  // Claim hexfloat_upper_p_oracle_deviation. RFC 8610 App. B "p" is a case-insensitive ABNF
+  // literal, so 0x1P3 is a valid hexfloat (8.0). Ruby cddl 0.12.14 disagrees (lowercase-only
+  // hexfloat regex at cddl.rb:1579, then Ruby eval SyntaxError) — confirmed RUBY_BUG
+  assert_valid_claim("thing = 0x1P3", "fb4020000000000000");
+}
+
+#[test]
+fn hexfloat_negative() {
+  // Claim hexfloat_negative. RFC 8610 Appendix B: hexfloat = ["-"] "0x" ....
+  assert_valid_claim("thing = -0x1.8p+1", "fbc008000000000000");
+}
+
+#[test]
+fn radix_hex_tag_head_overflow() {
+  // A head-number (RFC 9682 Section 3.2: head-number = uint) above u64::MAX must be a parse
+  // error, not silently tag 0.
+  assert_parse_error_claim("thing = #6.0x10000000000000000(bstr)");
+}
+
+#[test]
+fn radix_hex_tag_head_u64_max() {
+  // Tag numbers (RFC 8610 Section 3.6; RFC 9682 Section 3.2 head-number) cover the full u64
+  // range; CBOR: tag(2^64-1) around tstr "a".
+  assert_valid_claim(
+    "thing = #6.0xffffffffffffffff(tstr)",
+    "dbffffffffffffffff6161",
+  );
+}
+
+#[test]
+fn radix_occurrence_bound_overflow() {
+  // An occurrence bound that overflows must be a parse error, not silently 0 (which would
+  // invert the constraint from "at least 2^64 elements" to "any number of elements").
+  assert_parse_error_claim("thing = [0x10000000000000000* tstr]");
+}
+
+#[test]
+fn float_exponent_without_fraction() {
+  // RFC 8610 Appendix B: number = hexfloat / (int ["." fraction] ["e" exponent]) — the
+  // fraction is optional, so 1e5 is a valid float literal (100000.0).
+  assert_valid_claim("thing = 1e5", "fb40f86a0000000000");
+}
+
+#[test]
+fn decimal_leading_zero_rejected() {
+  // RFC 8610 Appendix B: uint = DIGIT1 *DIGIT / ... / "0" — leading-zero decimals like 042
+  // are not valid CDDL.
+  assert_parse_error_claim("thing = 042");
+}
+
+#[test]
+fn float_leading_zero_rejected() {
+  // The float mantissa is an int (RFC 8610 App. B: int ["." fraction] ["e" exponent]), so it
+  // must not have leading zeros either — 042e5 was a parse error before the exponent branch
+  // existed and must stay one. Zero itself and zero-led fractions/exponents remain valid.
+  assert_parse_error_claim("thing = 042e5");
+  assert_parse_error_claim("thing = 01.5");
+  assert_valid_claim("thing = 0.5", "fb3fe0000000000000");
+  assert_valid_claim("thing = 1.05e05", "fb40f9a28000000000");
+}
+
+#[test]
+fn decimal_leading_zero_regroups_in_arrays() {
+  // Pins the re-tokenization quirk documented at uint_value in cddl.pest: "042" is not a
+  // uint literal, but in group contexts (where no separating whitespace is required) it is
+  // RFC-derivable as the two entries `0 42`, so [042] accepts CBOR [0, 42] — and only that.
+  assert_valid_claim("thing = [042]", "8200182a");
+  assert!(
+    validate_cbor_from_slice("thing = [042]", &cbor("81182a"), None).is_err(),
+    "[042] must not validate CBOR [42]"
+  );
+}
+
+#[test]
+fn guardrail_decimal_uint_value() {
+  // Expected-green guardrail. RFC 8610 Appendix B: uint = DIGIT1 *DIGIT / "0".
+  assert_valid_claim("thing = 16", "10");
+}
+
+#[test]
+fn guardrail_decimal_occurrence_bounds() {
+  // Expected-green guardrail. RFC 8610 Appendix B: occur = [uint] "*" [uint].
+  assert_valid_claim("thing = [2*4 tstr]", "8261616162");
+}


### PR DESCRIPTION
RFC 8610 Appendix B defines the integer radix alternatives as part of `uint`:

```
uint = DIGIT1 *DIGIT
     / "0x" 1*HEXDIG
     / "0b" 1*BINDIG
     / "0"
hexfloat = ["-"] "0x" 1*HEXDIG ["." 1*HEXDIG] "p" exponent
```

However, `cddl.pest` handles neither:

```
number     = { hexfloat | float_value | int_value | uint_value }
uint_value = @{ DIGIT+ }                                          ; no 0x / 0b alternatives
hexfloat   = @{ "-"? ~ "0x" ~ ASCII_HEX_DIGIT+ ~ ("." ~ ASCII_HEX_DIGIT+)? ~ ("p" ~ ("+" | "-")? ~ DIGIT+)? }
```

This PR looks big, but actually it's 99% comments and tests. The only real diff is just expanding the rules to allow for the different cases. For example, a `uint` now has a `hex | binary | decimal` expansion

```diff
- uint_value = @{ DIGIT+ }
+ uint_value = @{ ^"0x" ~ ASCII_HEX_DIGIT+ | ^"0b" ~ ASCII_BIN_DIGIT+ | ASCII_NONZERO_DIGIT ~ DIGIT* | "0" }
```