### PR TITLE
fix(validator): support bignum types (`bigint` / `biguint` / `bignint`) as CBOR map keys + values

### DIFF
--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -3172,6 +3172,15 @@ where
         Ok(())
       }
       Value::Tag(tag, value) => {
+        if is_ident_bignum_data_type(self.state.cddl, ident) {
+          if !(ident_accepts_bignum_tag(self.state.cddl, ident, *tag)
+            && matches!(value.as_ref(), Value::Bytes(_)))
+          {
+            self.add_error(format!("expected type {}, got {:?}", ident, self.cbor));
+          }
+          return Ok(());
+        }
+
         match *tag {
           0 => {
             if is_ident_tdate_data_type(self.state.cddl, ident) {
@@ -3307,6 +3316,23 @@ where
               return Ok(());
             }
 
+            if is_ident_bignum_data_type(self.state.cddl, ident) && !self.validating_value {
+              if let Some((k, v)) = m
+                .iter()
+                .find(|(k, _)| is_bignum_value(self.state.cddl, ident, k))
+              {
+                self
+                  .validated_keys
+                  .get_or_insert(vec![k.clone()])
+                  .push(k.clone());
+                self.object_value = Some(v.clone());
+                let _ = write!(self.state.data_location, "/{:?}", v);
+              } else {
+                self.add_error(format!("map requires entry key of type {}", ident));
+              }
+              return Ok(());
+            }
+
             if token::lookup_ident(ident.ident)
               .in_standard_prelude()
               .is_some()
@@ -3395,6 +3421,23 @@ where
 
             if is_ident_float_data_type(self.state.cddl, ident) && !self.validating_value {
               if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Null)) {
+                self
+                  .validated_keys
+                  .get_or_insert(vec![k.clone()])
+                  .push(k.clone());
+                self.object_value = Some(v.clone());
+                self.state.data_location.push_str(&format!("/{}", value));
+              } else {
+                self.add_error(format!("map requires entry key of type {}", ident));
+              }
+              return Ok(());
+            }
+
+            if is_ident_bignum_data_type(self.state.cddl, ident) && !self.validating_value {
+              if let Some((k, v)) = m
+                .iter()
+                .find(|(k, _)| is_bignum_value(self.state.cddl, ident, k))
+              {
                 self
                   .validated_keys
                   .get_or_insert(vec![k.clone()])
@@ -3579,6 +3622,34 @@ where
                       None
                     }
                   } else if matches!(k, Value::Float(_)) {
+                    Some(v.clone())
+                  } else {
+                    errors.push(format!("key of type {} required, got {:?}", ident, k));
+                    None
+                  }
+                })
+                .collect::<Vec<_>>();
+
+              self.values_to_validate = Some(values_to_validate);
+            }
+
+            if is_ident_bignum_data_type(self.state.cddl, ident) {
+              let mut errors = Vec::new();
+              let values_to_validate = m
+                .iter()
+                .filter_map(|(k, v)| {
+                  if let Some(keys) = &self.validated_keys {
+                    if !keys.contains(k) {
+                      if is_bignum_value(self.state.cddl, ident, k) {
+                        Some(v.clone())
+                      } else {
+                        errors.push(format!("key of type {} required, got {:?}", ident, k));
+                        None
+                      }
+                    } else {
+                      None
+                    }
+                  } else if is_bignum_value(self.state.cddl, ident, k) {
                     Some(v.clone())
                   } else {
                     errors.push(format!("key of type {} required, got {:?}", ident, k));
@@ -3796,6 +3867,25 @@ where
 
             if is_ident_float_data_type(self.state.cddl, ident) && !self.validating_value {
               if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Null)) {
+                self
+                  .validated_keys
+                  .get_or_insert(vec![k.clone()])
+                  .push(k.clone());
+                self.object_value = Some(v.clone());
+                let _ = write!(self.state.data_location, "/{:?}", v);
+              } else if (!matches!(occur, Occur::ZeroOrMore { .. }) && m.is_empty())
+                || (matches!(occur, Occur::ZeroOrMore { .. }) && !m.is_empty())
+              {
+                self.add_error(format!("map requires entry key of type {}", ident));
+              }
+              return Ok(());
+            }
+
+            if is_ident_bignum_data_type(self.state.cddl, ident) && !self.validating_value {
+              if let Some((k, v)) = m
+                .iter()
+                .find(|(k, _)| is_bignum_value(self.state.cddl, ident, k))
+              {
                 self
                   .validated_keys
                   .get_or_insert(vec![k.clone()])
@@ -4628,6 +4718,12 @@ where
 
     Ok(())
   }
+}
+
+/// Is `v` a tagged byte string accepted by the bignum type `ident`?
+fn is_bignum_value(cddl: &CDDL, ident: &Identifier, v: &Value) -> bool {
+  matches!(v, Value::Tag(tag, inner)
+    if ident_accepts_bignum_tag(cddl, ident, *tag) && matches!(inner.as_ref(), Value::Bytes(_)))
 }
 
 /// Converts a CDDL value type to our custom CBOR Value

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -1027,6 +1027,34 @@ pub fn is_ident_integer_data_type(cddl: &CDDL, ident: &Identifier) -> bool {
   })
 }
 
+/// Does the given identifier denote a bignum data type that accepts CBOR tag
+/// `tag`? Per the RFC 8610 prelude: `biguint = #6.2(bstr)`,
+/// `bignint = #6.3(bstr)` and `bigint = biguint / bignint`.
+pub fn ident_accepts_bignum_tag(cddl: &CDDL, ident: &Identifier, tag: u64) -> bool {
+  match lookup_ident(ident.ident) {
+    Token::BIGUINT => return tag == 2,
+    Token::BIGNINT => return tag == 3,
+    Token::BIGINT => return tag == 2 || tag == 3,
+    _ => (),
+  }
+
+  cddl.rules.iter().any(|r| match r {
+    Rule::Type { rule, .. } if rule.name == *ident => rule.value.type_choices.iter().any(|tc| {
+      if let Type2::Typename { ident, .. } = &tc.type1.type2 {
+        ident_accepts_bignum_tag(cddl, ident, tag)
+      } else {
+        false
+      }
+    }),
+    _ => false,
+  })
+}
+
+/// Is the given identifier associated with a bignum data type
+pub fn is_ident_bignum_data_type(cddl: &CDDL, ident: &Identifier) -> bool {
+  ident_accepts_bignum_tag(cddl, ident, 2) || ident_accepts_bignum_tag(cddl, ident, 3)
+}
+
 /// Is the given identifier associated with a float data type
 pub fn is_ident_float_data_type(cddl: &CDDL, ident: &Identifier) -> bool {
   if let Token::FLOAT

--- a/tests/bignum.rs
+++ b/tests/bignum.rs
@@ -1,0 +1,177 @@
+#![cfg(feature = "std")]
+#![cfg(feature = "cbor")]
+#![cfg(not(target_arch = "wasm32"))]
+
+use cddl::validate_cbor_from_slice;
+
+fn assert_valid(name: &str, cddl: &str, cbor: &[u8]) {
+  if let Err(e) = validate_cbor_from_slice(cddl, cbor, None) {
+    panic!("{}: expected valid, got error: {:?}", name, e);
+  }
+}
+
+fn assert_invalid(name: &str, cddl: &str, cbor: &[u8]) {
+  assert!(
+    validate_cbor_from_slice(cddl, cbor, None).is_err(),
+    "{}: expected invalid, but it validated",
+    name
+  );
+}
+
+/// `biguint = #6.2(bstr)`, `bignint = #6.3(bstr)`, `bigint = biguint / bignint`
+#[test]
+fn bignum_as_map_key() {
+  assert_valid(
+    "bignint key",
+    "start = { bignint => int }",
+    &[0xa1, 0xc3, 0x41, 0x01, 0x01],
+  );
+  assert_valid(
+    "biguint key",
+    "start = { biguint => int }",
+    &[0xa1, 0xc2, 0x41, 0x01, 0x01],
+  );
+  assert_valid(
+    "bigint key, tag 2",
+    "start = { bigint => int }",
+    &[0xa1, 0xc2, 0x41, 0x01, 0x01],
+  );
+  assert_valid(
+    "bigint key, tag 3",
+    "start = { bigint => int }",
+    &[0xa1, 0xc3, 0x41, 0x01, 0x01],
+  );
+  assert_valid(
+    "typename alias as key",
+    "k = bignint\nstart = { k => int }",
+    &[0xa1, 0xc3, 0x41, 0x01, 0x01],
+  );
+
+  assert_invalid(
+    "bignint key given tag 2",
+    "start = { bignint => int }",
+    &[0xa1, 0xc2, 0x41, 0x01, 0x01],
+  );
+  assert_invalid(
+    "biguint key given tag 3",
+    "start = { biguint => int }",
+    &[0xa1, 0xc3, 0x41, 0x01, 0x01],
+  );
+  assert_invalid(
+    "bignum tag wrapping a non-bstr",
+    "start = { bignint => int }",
+    &[0xa1, 0xc3, 0x01, 0x01],
+  );
+  assert_invalid(
+    "plain int key is not a bignum",
+    "start = { bignint => int }",
+    &[0xa1, 0x01, 0x01],
+  );
+  assert_invalid(
+    "unknown tag as key",
+    "start = { bignint => int }",
+    &[0xa1, 0xc5, 0x41, 0x01, 0x01],
+  );
+  assert_invalid(
+    "map value is still validated",
+    "start = { bignint => tstr }",
+    &[0xa1, 0xc3, 0x41, 0x01, 0x01],
+  );
+}
+
+/// Occurrence indicators route through a different arm of `visit_identifier`
+/// (the `Some(occur)` filter path), so cover them separately.
+#[test]
+fn bignum_as_map_key_with_occurrence() {
+  assert_valid("* with empty map", "start = { * bignint => int }", &[0xa0]);
+  assert_valid(
+    "* with one entry",
+    "start = { * bignint => int }",
+    &[0xa1, 0xc3, 0x41, 0x01, 0x01],
+  );
+  assert_valid(
+    "* with two entries",
+    "start = { * bignint => int }",
+    &[0xa2, 0xc3, 0x41, 0x01, 0x01, 0xc3, 0x41, 0x02, 0x02],
+  );
+  assert_valid(
+    "+ with one entry",
+    "start = { + bignint => int }",
+    &[0xa1, 0xc3, 0x41, 0x01, 0x01],
+  );
+  assert_valid(
+    "* behind .cbor, empty map",
+    "start = [payload: x]\nx = bytes .cbor { * bignint => uint }",
+    &[0x81, 0x41, 0xa0],
+  );
+  assert_valid(
+    "* behind .cbor, one entry",
+    "start = [payload: x]\nx = bytes .cbor { * bignint => uint }",
+    &[0x81, 0x45, 0xa1, 0xc3, 0x41, 0x01, 0x01],
+  );
+
+  assert_invalid(
+    "* with second value of wrong type",
+    "start = { * bignint => int }",
+    &[0xa2, 0xc3, 0x41, 0x01, 0x01, 0xc3, 0x41, 0x02, 0x61, 0x78],
+  );
+  assert_invalid(
+    "* with foreign key",
+    "start = { * bignint => int }",
+    &[0xa1, 0x01, 0x01],
+  );
+  assert_invalid(
+    "* with wrong-tag key",
+    "start = { * bignint => int }",
+    &[0xa1, 0xc2, 0x41, 0x01, 0x01],
+  );
+  assert_invalid("+ with empty map", "start = { + bignint => int }", &[0xa0]);
+}
+
+#[test]
+fn bignum_as_value() {
+  assert_valid(
+    "[bignint] tag 3",
+    "start = [bignint]",
+    &[0x81, 0xc3, 0x41, 0x01],
+  );
+  assert_valid(
+    "[biguint] tag 2",
+    "start = [biguint]",
+    &[0x81, 0xc2, 0x41, 0x01],
+  );
+  assert_valid(
+    "[bigint] tag 2",
+    "start = [bigint]",
+    &[0x81, 0xc2, 0x41, 0x01],
+  );
+  assert_valid(
+    "[bigint] tag 3",
+    "start = [bigint]",
+    &[0x81, 0xc3, 0x41, 0x01],
+  );
+
+  assert_invalid(
+    "[bignint] tag 2",
+    "start = [bignint]",
+    &[0x81, 0xc2, 0x41, 0x01],
+  );
+  assert_invalid(
+    "[biguint] tag 3",
+    "start = [biguint]",
+    &[0x81, 0xc3, 0x41, 0x01],
+  );
+  assert_invalid("[bignint] tag 1", "start = [bignint]", &[0x81, 0xc1, 0x01]);
+  // Tag 5 has no dedicated `match *tag` arm — this is why the bignum check
+  // sits before the tag dispatch, which can only reject tags it knows about.
+  assert_invalid(
+    "[bignint] unknown tag 5",
+    "start = [bignint]",
+    &[0x81, 0xc5, 0x41, 0x01],
+  );
+  assert_invalid(
+    "[bignint] tag 3(1)",
+    "start = [bignint]",
+    &[0x81, 0xc3, 0x01],
+  );
+}


### PR DESCRIPTION
Two bugs in relation to bignum types (`bigint` / `biguint` / `bignint`)
- Key position error: `validate_cbor_from_slice` was missing an bignum case for the arm matches
- Value position error: `Value::Tag` only checked the correctness of contents of `tdate`  and `time`, not whether or not bignum tags contents are correct

## Examples

```cddl
start = { bignint => int }
```

and the CBOR `{ 3(h'01') : 1 }` (`a1 c3 41 01 01`), validation errors with:

```
expected object value of type bignint, got object
```

Here is a test on a variety of cases got fixed (using the ruby gem as the source of truth beyond the obviously checking the spec)
   | CDDL | CBOR (diag) | before | ruby gem | this fix |
  | --- | --- | --- | --- | --- |
  | `{ bignint => int }` | `{3(h'01'): 1}` | **invalid** | valid | valid |
  | `{ bignint => int }` | `{2(h'01'): 1}` | invalid¹ | invalid | invalid |
  | `{ biguint => int }` | `{2(h'01'): 1}` | **invalid** | valid | valid |
  | `{ biguint => int }` | `{3(h'01'): 1}` | invalid¹ | invalid | invalid |
  | `{ bigint => int }` | `{2(h'01'): 1}` | **invalid** | valid | valid |
  | `{ bigint => int }` | `{3(h'01'): 1}` | **invalid** | valid | valid |
  | `{ * bignint => int }` | `{}` | **invalid** | valid | valid |
  | `{ * bignint => int }` | `{3(h'01'): 1, 3(h'02'): 2}` | **invalid** | valid | valid |
  | `{ * bignint => int }` | `{2(h'01'): 1}` | invalid¹ | invalid | invalid |
  | `[bignint]` | `[3(h'01')]` | valid | valid | valid |
  | `[bignint]` | `[2(h'01')]` | **valid** | invalid | invalid |
  | `[bignint]` | `[3(1)]` | **valid** | invalid | invalid |