### PR TITLE
fix(validator) optional keys support empty maps and reject invalid keys

### DIFF
--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -2384,13 +2384,16 @@ where
 
           self.visit_group(group)?;
 
-          // If extra map entries are detected, return validation error
+          // A key is unexpected unless some group entry consumed it
+          // (validated_keys of None is an empty consumed set)
           if self.values_to_validate.is_none() {
             for k in m.into_iter() {
-              if let Some(keys) = &self.validated_keys {
-                if !keys.contains(&k) {
-                  self.add_error(format!("unexpected key {:?}", k));
-                }
+              if !self
+                .validated_keys
+                .as_ref()
+                .is_some_and(|keys| keys.contains(&k))
+              {
+                self.add_error(format!("unexpected key {:?}", k));
               }
             }
           }
@@ -3220,6 +3223,9 @@ where
       }
       Value::Array(_) => self.validate_array_items(&ArrayItemToken::Identifier(ident)),
       Value::Map(m) => {
+        // `?` permits the entry to be absent (RFC 8610 §3.2), so a failure to
+        // find a matching entry key is not an error for an optional entry
+        let entry_optional = matches!(&self.state.occurrence, Some(Occur::Optional { .. }));
         match &self.state.occurrence {
           #[cfg(feature = "ast-span")]
           Some(Occur::Optional { .. }) | None => {
@@ -3231,7 +3237,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 let _ = write!(self.state.data_location, "/{:?}", v);
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -3245,7 +3251,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 let _ = write!(self.state.data_location, "/{:?}", v);
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -3259,7 +3265,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 let _ = write!(self.state.data_location, "/{:?}", v);
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -3273,7 +3279,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 let _ = write!(self.state.data_location, "/{:?}", v);
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -3287,7 +3293,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 let _ = write!(self.state.data_location, "/{:?}", v);
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -3301,7 +3307,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 let _ = write!(self.state.data_location, "/{:?}", v);
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -3330,7 +3336,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 self.state.data_location.push_str(&format!("/{}", value));
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
 
@@ -3345,7 +3351,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 self.state.data_location.push_str(&format!("/{}", value));
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -3359,7 +3365,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 self.state.data_location.push_str(&format!("/{}", value));
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -3373,7 +3379,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 self.state.data_location.push_str(&format!("/{}", value));
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -3387,7 +3393,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 self.state.data_location.push_str(&format!("/{}", value));
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -3401,7 +3407,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 self.state.data_location.push_str(&format!("/{}", value));
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -4090,6 +4096,15 @@ where
         cv.visit_rule(rule)?;
 
         self.errors.append(&mut cv.errors);
+
+        // The child validated the same map in the same group context, so keys
+        // it consumed count toward this validator's unexpected-key check
+        if let Some(keys) = cv.validated_keys {
+          self
+            .validated_keys
+            .get_or_insert_with(Vec::new)
+            .extend(keys);
+        }
 
         return Ok(());
       }

--- a/src/validator/json.rs
+++ b/src/validator/json.rs
@@ -2010,12 +2010,16 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
 
           self.visit_group(group)?;
 
+          // A key is unexpected unless some group entry consumed it
+          // (validated_keys of None is an empty consumed set)
           if self.values_to_validate.is_none() {
             for k in o.into_iter() {
-              if let Some(keys) = &self.validated_keys {
-                if !keys.contains(&k) {
-                  self.add_error(format!("unexpected key {:?}", k));
-                }
+              if !self
+                .validated_keys
+                .as_ref()
+                .is_some_and(|keys| keys.contains(&k))
+              {
+                self.add_error(format!("unexpected key {:?}", k));
               }
             }
           }
@@ -2557,6 +2561,28 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
       Value::Object(o) => match &self.state.occurrence {
         #[cfg(feature = "ast-span")]
         Some(Occur::Optional { .. }) | None => {
+          // A type-domain string key (e.g. `tstr => v`) matches any object
+          // entry, since JSON object keys are always strings. `?` permits the
+          // entry to be absent (RFC 8610 §3.2), so a find-miss is only an
+          // error for an occurrence-less entry
+          if self.state.is_member_key && is_ident_string_data_type(self.state.cddl, ident) {
+            if let Some((k, v)) = o.iter().next() {
+              self
+                .validated_keys
+                .get_or_insert(vec![k.clone()])
+                .push(k.clone());
+              self.object_value = Some(v.clone());
+              let _ = write!(self.state.data_location, "/{}", k);
+            } else if let Some(Occur::Optional { .. }) = self.state.occurrence.take() {
+              // absent optional entry: skip value validation for this entry
+              self.state.advance_to_next_entry = true;
+            } else {
+              self.add_error(format!("object requires entry key of type {}", ident));
+            }
+
+            return Ok(());
+          }
+
           if token::lookup_ident(ident.ident)
             .in_standard_prelude()
             .is_some()
@@ -2572,6 +2598,24 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
         }
         #[cfg(not(feature = "ast-span"))]
         Some(Occur::Optional {}) | None => {
+          if self.state.is_member_key && is_ident_string_data_type(self.state.cddl, ident) {
+            if let Some((k, v)) = o.iter().next() {
+              self
+                .validated_keys
+                .get_or_insert(vec![k.clone()])
+                .push(k.clone());
+              self.object_value = Some(v.clone());
+              self.state.data_location.push_str(&format!("/{}", k));
+            } else if let Some(Occur::Optional { .. }) = self.state.occurrence.take() {
+              // absent optional entry: skip value validation for this entry
+              self.state.advance_to_next_entry = true;
+            } else {
+              self.add_error(format!("object requires entry key of type {}", ident));
+            }
+
+            return Ok(());
+          }
+
           if token::lookup_ident(ident.ident)
             .in_standard_prelude()
             .is_some()
@@ -2863,6 +2907,15 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
         jv.visit_rule(rule)?;
 
         self.errors.append(&mut jv.errors);
+
+        // The child validated the same object in the same group context, so
+        // keys it consumed count toward this validator's unexpected-key check
+        if let Some(keys) = jv.validated_keys {
+          self
+            .validated_keys
+            .get_or_insert_with(Vec::new)
+            .extend(keys);
+        }
 
         return Ok(());
       }

--- a/tests/cbor.rs
+++ b/tests/cbor.rs
@@ -639,3 +639,56 @@ fn validate_decfrac_and_bigfloat() -> Result<(), Box<dyn Error>> {
 
   Ok(())
 }
+
+#[test]
+fn validate_optional_type_domain_map_entry_absent() -> Result<(), Box<dyn Error>> {
+  // `?` permits the entry to be absent (RFC 8610 §3.2), so the empty map is
+  // valid against a map whose sole entry is a `?`-marked type-domain entry
+  let empty_map = b"\xa0";
+  let one_entry = b"\xa1\x61\x61\x01"; // {"a": 1}
+
+  validate_cbor_from_slice(r#"m = { ? tstr => uint }"#, empty_map, None)?;
+  // present entry still validates
+  validate_cbor_from_slice(r#"m = { ? tstr => uint }"#, one_entry, None)?;
+  // present entry with a bad value type still fails
+  let bad_value = b"\xa1\x61\x61\x61\x62"; // {"a": "b"}
+  assert!(validate_cbor_from_slice(r#"m = { ? tstr => uint }"#, bad_value, None).is_err());
+
+  // other key types take the same code path
+  validate_cbor_from_slice(r#"m = { ? int => uint }"#, empty_map, None)?;
+  validate_cbor_from_slice(r#"m = { ? bool => uint }"#, empty_map, None)?;
+  validate_cbor_from_slice(r#"m = { ? bytes => uint }"#, empty_map, None)?;
+
+  // an occurrence-less entry must still require a match
+  assert!(validate_cbor_from_slice(r#"m = { tstr => uint }"#, empty_map, None).is_err());
+
+  // absent optional entry alongside other entries that do consume the keys
+  let int_entry = b"\xa1\x01\x02"; // {1: 2}
+  let text_and_int = b"\xa2\x61\x61\x01\x01\x02"; // {"a": 1, 1: 2}
+  validate_cbor_from_slice(r#"m = { ? tstr => uint, int => int }"#, int_entry, None)?;
+  validate_cbor_from_slice(r#"m = { ? tstr => uint, ? int => int }"#, int_entry, None)?;
+  validate_cbor_from_slice(r#"m = { ? tstr => uint, int => int }"#, text_and_int, None)?;
+  validate_cbor_from_slice(r#"m = { ? tstr => uint, ? int => int }"#, empty_map, None)?;
+
+  Ok(())
+}
+
+#[test]
+fn validate_map_unexpected_entries_rejected() -> Result<(), Box<dyn Error>> {
+  // A map entry unmatched by any group member is an unexpected key, including
+  // when the group's only member is `?`-marked and absent
+  let empty_map = b"\xa0";
+  let k1 = b"\xa1\x61\x6b\x01"; // {"k": 1}
+  let a1 = b"\xa1\x61\x61\x01"; // {"a": 1}
+  let k1_a2 = b"\xa2\x61\x6b\x01\x61\x61\x02"; // {"k": 1, "a": 2}
+  let int_entry = b"\xa1\x01\x02"; // {1: 2}
+
+  validate_cbor_from_slice(r#"m = { ? k: uint }"#, empty_map, None)?;
+  validate_cbor_from_slice(r#"m = { ? k: uint }"#, k1, None)?;
+  assert!(validate_cbor_from_slice(r#"m = { ? k: uint }"#, a1, None).is_err());
+  assert!(validate_cbor_from_slice(r#"m = { ? k: uint }"#, k1_a2, None).is_err());
+  // absent optional type-domain entry does not excuse a key of another domain
+  assert!(validate_cbor_from_slice(r#"m = { ? tstr => uint }"#, int_entry, None).is_err());
+
+  Ok(())
+}

--- a/tests/cddl.rs
+++ b/tests/cddl.rs
@@ -116,3 +116,30 @@ hex_test = bstr .hex "test"
     );
   }
 }
+
+/// Regression: type-domain string keys (`tstr => v`) in objects were rejected
+/// even when present, and `?`-marked ones rejected the spec-valid empty object
+#[test]
+fn validate_json_optional_type_domain_object_key() {
+  // `?` permits the entry to be absent (RFC 8610 §3.2)
+  validate_json_from_str(r#"m = { ? tstr => uint }"#, r#"{}"#, None).unwrap();
+  // present entry validates
+  validate_json_from_str(r#"m = { ? tstr => uint }"#, r#"{"a": 1}"#, None).unwrap();
+  validate_json_from_str(r#"m = { tstr => uint }"#, r#"{"a": 1}"#, None).unwrap();
+  // present entry with a bad value type still fails
+  validate_json_from_str(r#"m = { ? tstr => uint }"#, r#"{"a": "b"}"#, None).unwrap_err();
+  // an occurrence-less entry still requires a match
+  validate_json_from_str(r#"m = { tstr => uint }"#, r#"{}"#, None).unwrap_err();
+  // a bare string type against an object still fails (not treated as a key)
+  validate_json_from_str(r#"m = tstr"#, r#"{"a": 1}"#, None).unwrap_err();
+}
+
+/// Regression: an object entry unmatched by any group member must be rejected
+/// as an unexpected key, even when no group member consumed any key at all
+#[test]
+fn validate_json_unexpected_entries_rejected() {
+  validate_json_from_str(r#"m = { ? k: uint }"#, r#"{}"#, None).unwrap();
+  validate_json_from_str(r#"m = { ? k: uint }"#, r#"{"k": 1}"#, None).unwrap();
+  validate_json_from_str(r#"m = { ? k: uint }"#, r#"{"a": 1}"#, None).unwrap_err();
+  validate_json_from_str(r#"m = { ? k: uint }"#, r#"{"k": 1, "a": 2}"#, None).unwrap_err();
+}


### PR DESCRIPTION
This PR does three things:

1. `{ ? tstr => uint }` rejected empty maps (even though it should allow them). This was caused by `Value::Map` missing a check for whether something was optional
2. Support for type domain `tstr => v` was missing in JSON in general, but it was easy to add since JSON keys are always strings anyway
3. Fixed maps allowing invalid keys if none of the optional keys are included. ex: `{ ? k: uint }` allowed `{"a": 1}` because `k` doesn't it appear. This happened because `None` was conflated between "skip the check entirely" and "no keys consumed". I fixed this in the same PR, because fixing (1) without fixing this would introduce new bugs

Note: this is a separate issue from #643