### PR TITLE
fix(validator) support floats as numbers

### DIFF
--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -1016,27 +1016,22 @@ where
         }
         #[cfg(not(feature = "freezer"))]
         return Ok(());
-      } else if is_ident_integer_data_type(self.state.cddl, target_ident)
-        && is_ident_float_data_type(self.state.cddl, target_ident)
-      {
-        // e.g. number = int / float, which admits both
-        if !matches!(self.cbor, Value::Integer(_) | Value::Float(_)) {
-          self.add_error(format!(
-            "expected type {}, got {:?}",
-            target_ident, self.cbor
-          ));
+      } else if let Some(kind) = ident_numeric_kind(self.state.cddl, target_ident) {
+        let matches_kind = match kind {
+          NumericKind::Int => matches!(self.cbor, Value::Integer(_)),
+          NumericKind::Float => matches!(self.cbor, Value::Float(_)),
+          // e.g. number = int / float, which admits both
+          NumericKind::Both => matches!(self.cbor, Value::Integer(_) | Value::Float(_)),
+        };
+        if !matches_kind {
+          let expected = match kind {
+            NumericKind::Int => "int".to_string(),
+            NumericKind::Float => "float".to_string(),
+            NumericKind::Both => target_ident.to_string(),
+          };
+          self.add_error(format!("expected type {}, got {:?}", expected, self.cbor));
           return Ok(());
         }
-      } else if is_ident_integer_data_type(self.state.cddl, target_ident)
-        && !matches!(self.cbor, Value::Integer(_))
-      {
-        self.add_error(format!("expected type int, got {:?}", self.cbor));
-        return Ok(());
-      } else if is_ident_float_data_type(self.state.cddl, target_ident)
-        && !matches!(self.cbor, Value::Float(_))
-      {
-        self.add_error(format!("expected type float, got {:?}", self.cbor));
-        return Ok(());
       } else if is_ident_bool_data_type(self.state.cddl, target_ident)
         && !matches!(self.cbor, Value::Bool(_))
       {
@@ -3121,7 +3116,7 @@ where
           }
 
           Ok(())
-        } else if is_ident_integer_data_type(self.state.cddl, ident) {
+        } else if ident_numeric_kind(self.state.cddl, ident).is_some_and(NumericKind::admits_int) {
           Ok(())
         } else if is_ident_time_data_type(self.state.cddl, ident) {
           if let chrono::LocalResult::None =
@@ -3141,7 +3136,7 @@ where
         }
       }
       Value::Float(f) => {
-        if is_ident_float_data_type(self.state.cddl, ident) {
+        if ident_numeric_kind(self.state.cddl, ident).is_some_and(NumericKind::admits_float) {
           Ok(())
         } else if is_ident_time_data_type(self.state.cddl, ident) {
           if let chrono::LocalResult::None = Utc.timestamp_millis_opt((*f * 1000f64) as i64) {
@@ -3248,7 +3243,9 @@ where
               return Ok(());
             }
 
-            if is_ident_integer_data_type(self.state.cddl, ident) && !self.validating_value {
+            if ident_numeric_kind(self.state.cddl, ident).is_some_and(NumericKind::admits_int)
+              && !self.validating_value
+            {
               if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Integer(_))) {
                 self
                   .validated_keys
@@ -3304,7 +3301,11 @@ where
               return Ok(());
             }
 
-            if is_ident_float_data_type(self.state.cddl, ident) && !self.validating_value {
+            if matches!(
+              ident_numeric_kind(self.state.cddl, ident),
+              Some(NumericKind::Float)
+            ) && !self.validating_value
+            {
               if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Null)) {
                 self
                   .validated_keys
@@ -3348,7 +3349,9 @@ where
               return Ok(());
             }
 
-            if is_ident_integer_data_type(self.state.cddl, ident) && !self.validating_value {
+            if ident_numeric_kind(self.state.cddl, ident).is_some_and(NumericKind::admits_int)
+              && !self.validating_value
+            {
               if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Integer(_))) {
                 self
                   .validated_keys
@@ -3404,7 +3407,11 @@ where
               return Ok(());
             }
 
-            if is_ident_float_data_type(self.state.cddl, ident) && !self.validating_value {
+            if matches!(
+              ident_numeric_kind(self.state.cddl, ident),
+              Some(NumericKind::Float)
+            ) && !self.validating_value
+            {
               if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Null)) {
                 self
                   .validated_keys
@@ -3461,7 +3468,7 @@ where
               self.values_to_validate = Some(values_to_validate);
             }
 
-            if is_ident_integer_data_type(self.state.cddl, ident) {
+            if ident_numeric_kind(self.state.cddl, ident).is_some_and(NumericKind::admits_int) {
               let mut errors = Vec::new();
               let values_to_validate = m
                 .iter()
@@ -3573,11 +3580,12 @@ where
               self.values_to_validate = Some(values_to_validate);
             }
 
-            // number matches the integer block above; without this guard it
-            // would also match here and overwrite the collected values
-            if is_ident_float_data_type(self.state.cddl, ident)
-              && !is_ident_integer_data_type(self.state.cddl, ident)
-            {
+            // number matches the integer block above; a float-only match here
+            // keeps it from also firing and overwriting the collected values
+            if matches!(
+              ident_numeric_kind(self.state.cddl, ident),
+              Some(NumericKind::Float)
+            ) {
               let mut errors = Vec::new();
               let values_to_validate = m
                 .iter()
@@ -3745,7 +3753,9 @@ where
               return Ok(());
             }
 
-            if is_ident_integer_data_type(self.state.cddl, ident) && !self.validating_value {
+            if ident_numeric_kind(self.state.cddl, ident).is_some_and(NumericKind::admits_int)
+              && !self.validating_value
+            {
               if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Integer(_))) {
                 self
                   .validated_keys
@@ -3809,7 +3819,11 @@ where
               return Ok(());
             }
 
-            if is_ident_float_data_type(self.state.cddl, ident) && !self.validating_value {
+            if matches!(
+              ident_numeric_kind(self.state.cddl, ident),
+              Some(NumericKind::Float)
+            ) && !self.validating_value
+            {
               if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Null)) {
                 self
                   .validated_keys
@@ -5051,7 +5065,8 @@ mod tests {
   }
 
   #[test]
-  fn validate_number_accepts_float_and_int() -> std::result::Result<(), Box<dyn std::error::Error>> {
+  fn validate_number_accepts_float_and_int() -> std::result::Result<(), Box<dyn std::error::Error>>
+  {
     for (cddl, cbor) in [
       ("x = number", Value::Float(2.0)),
       ("x = number", Value::Integer(5.into())),
@@ -5063,12 +5078,7 @@ mod tests {
       let mut cv = CBORValidator::new(&cddl_ast, cbor.clone(), None);
       #[cfg(not(feature = "additional-controls"))]
       let mut cv = CBORValidator::new(&cddl_ast, cbor.clone());
-      assert!(
-        cv.validate().is_ok(),
-        "{} should accept {:?}",
-        cddl,
-        cbor
-      );
+      assert!(cv.validate().is_ok(), "{} should accept {:?}", cddl, cbor);
     }
 
     Ok(())

--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -1017,6 +1017,17 @@ where
         #[cfg(not(feature = "freezer"))]
         return Ok(());
       } else if is_ident_integer_data_type(self.state.cddl, target_ident)
+        && is_ident_float_data_type(self.state.cddl, target_ident)
+      {
+        // e.g. number = int / float, which admits both
+        if !matches!(self.cbor, Value::Integer(_) | Value::Float(_)) {
+          self.add_error(format!(
+            "expected type {}, got {:?}",
+            target_ident, self.cbor
+          ));
+          return Ok(());
+        }
+      } else if is_ident_integer_data_type(self.state.cddl, target_ident)
         && !matches!(self.cbor, Value::Integer(_))
       {
         self.add_error(format!("expected type int, got {:?}", self.cbor));
@@ -3562,7 +3573,11 @@ where
               self.values_to_validate = Some(values_to_validate);
             }
 
-            if is_ident_float_data_type(self.state.cddl, ident) {
+            // number matches the integer block above; without this guard it
+            // would also match here and overwrite the collected values
+            if is_ident_float_data_type(self.state.cddl, ident)
+              && !is_ident_integer_data_type(self.state.cddl, ident)
+            {
               let mut errors = Vec::new();
               let values_to_validate = m
                 .iter()
@@ -5033,6 +5048,30 @@ mod tests {
     let cddl = cddl_from_str("start = any", true).unwrap();
     let cv = CBORValidator::new(&cddl, cbor, None);
     assert_eq!(cv.extract_cbor(), Value::Float(1.23));
+  }
+
+  #[test]
+  fn validate_number_accepts_float_and_int() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    for (cddl, cbor) in [
+      ("x = number", Value::Float(2.0)),
+      ("x = number", Value::Integer(5.into())),
+      ("x = number .eq 5", Value::Integer(5.into())),
+      ("x = number .ge 1.0", Value::Float(2.5)),
+    ] {
+      let cddl_ast = cddl_from_str(cddl, true)?;
+      #[cfg(feature = "additional-controls")]
+      let mut cv = CBORValidator::new(&cddl_ast, cbor.clone(), None);
+      #[cfg(not(feature = "additional-controls"))]
+      let mut cv = CBORValidator::new(&cddl_ast, cbor.clone());
+      assert!(
+        cv.validate().is_ok(),
+        "{} should accept {:?}",
+        cddl,
+        cbor
+      );
+    }
+
+    Ok(())
   }
 
   #[test]

--- a/src/validator/json.rs
+++ b/src/validator/json.rs
@@ -2505,10 +2505,15 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
               ));
             }
           }
-        } else if (is_ident_integer_data_type(self.state.cddl, ident) && n.is_i64())
-          || (is_ident_float_data_type(self.state.cddl, ident) && n.is_f64())
-        {
-          return Ok(());
+        } else if let Some(kind) = ident_numeric_kind(self.state.cddl, ident) {
+          let matches_kind = match kind {
+            NumericKind::Int => n.is_i64(),
+            NumericKind::Float => n.is_f64(),
+            NumericKind::Both => n.is_i64() || n.is_f64(),
+          };
+          if matches_kind {
+            return Ok(());
+          }
         }
 
         self.add_error(format!("expected type {}, got {}", ident, self.json));
@@ -3233,7 +3238,8 @@ mod tests {
   use indoc::indoc;
 
   #[test]
-  fn validate_number_accepts_float_and_int() -> std::result::Result<(), Box<dyn std::error::Error>> {
+  fn validate_number_accepts_float_and_int() -> std::result::Result<(), Box<dyn std::error::Error>>
+  {
     let cddl = cddl_from_str("x = number", true).unwrap();
 
     for json in ["2.5", "5"] {
@@ -3242,11 +3248,7 @@ mod tests {
       let mut jv = JSONValidator::new(&cddl, json.clone(), None);
       #[cfg(not(feature = "additional-controls"))]
       let mut jv = JSONValidator::new(&cddl, json.clone());
-      assert!(
-        jv.validate().is_ok(),
-        "number should accept {}",
-        json
-      );
+      assert!(jv.validate().is_ok(), "number should accept {}", json);
     }
 
     Ok(())

--- a/src/validator/json.rs
+++ b/src/validator/json.rs
@@ -3232,6 +3232,26 @@ mod tests {
   use super::*;
   use indoc::indoc;
 
+  #[test]
+  fn validate_number_accepts_float_and_int() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let cddl = cddl_from_str("x = number", true).unwrap();
+
+    for json in ["2.5", "5"] {
+      let json = serde_json::from_str::<serde_json::Value>(json)?;
+      #[cfg(feature = "additional-controls")]
+      let mut jv = JSONValidator::new(&cddl, json.clone(), None);
+      #[cfg(not(feature = "additional-controls"))]
+      let mut jv = JSONValidator::new(&cddl, json.clone());
+      assert!(
+        jv.validate().is_ok(),
+        "number should accept {}",
+        json
+      );
+    }
+
+    Ok(())
+  }
+
   #[cfg(feature = "additional-controls")]
   #[test]
   fn validate_plus() -> std::result::Result<(), Box<dyn std::error::Error>> {

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -1007,7 +1007,49 @@ pub fn is_ident_nint_data_type(cddl: &CDDL, ident: &Identifier) -> bool {
   })
 }
 
+/// Numbers are defined as `number = int / float`
+/// Therefore, this enum represents which type (or both) is allowed in a given position
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum NumericKind {
+  /// Only integer values (e.g. `int`, `uint`, `nint`)
+  Int,
+  /// Only float values (e.g. `float`, `float16` .. `float64`)
+  Float,
+  /// Both integer and float values (e.g. `number = int / float`)
+  Both,
+}
+
+impl NumericKind {
+  /// Does this kind admit integer values?
+  pub fn admits_int(self) -> bool {
+    matches!(self, NumericKind::Int | NumericKind::Both)
+  }
+
+  /// Does this kind admit float values?
+  pub fn admits_float(self) -> bool {
+    matches!(self, NumericKind::Float | NumericKind::Both)
+  }
+}
+
+/// Classify the given identifier's numeric kind
+/// or `None` if it is not associated with an int/float numeric data type
+pub fn ident_numeric_kind(cddl: &CDDL, ident: &Identifier) -> Option<NumericKind> {
+  #[allow(deprecated)]
+  match (
+    is_ident_integer_data_type(cddl, ident),
+    is_ident_float_data_type(cddl, ident),
+  ) {
+    (true, true) => Some(NumericKind::Both),
+    (true, false) => Some(NumericKind::Int),
+    (false, true) => Some(NumericKind::Float),
+    (false, false) => None,
+  }
+}
+
 /// Is the given identifier associated with an integer data type
+#[deprecated(
+  note = "not mutually exclusive with is_ident_float_data_type (`number` matches both); use ident_numeric_kind and handle NumericKind::Both"
+)]
 pub fn is_ident_integer_data_type(cddl: &CDDL, ident: &Identifier) -> bool {
   if let Token::INT | Token::INTEGER | Token::NINT | Token::UINT | Token::NUMBER | Token::UNSIGNED =
     lookup_ident(ident.ident)
@@ -1028,6 +1070,9 @@ pub fn is_ident_integer_data_type(cddl: &CDDL, ident: &Identifier) -> bool {
 }
 
 /// Is the given identifier associated with a float data type
+#[deprecated(
+  note = "not mutually exclusive with is_ident_integer_data_type (`number` matches both); use ident_numeric_kind and handle NumericKind::Both"
+)]
 pub fn is_ident_float_data_type(cddl: &CDDL, ident: &Identifier) -> bool {
   if let Token::FLOAT
   | Token::FLOAT16
@@ -1489,5 +1534,40 @@ mod tests {
     documents
       .iter()
       .all(|doc| cddl_schema.validate_json(doc.as_bytes(), None).is_ok());
+  }
+
+  #[test]
+  fn numeric_kind_classification() {
+    let cddl = cddl_from_str(
+      r#"
+  a = int
+  b = float32
+  c = number
+  d = int / float
+  e = a / b
+  f = tstr
+  "#,
+      true,
+    )
+    .unwrap();
+
+    let kind_of = |name: &str| {
+      let rule_ident = cddl
+        .rules
+        .iter()
+        .find_map(|r| match r {
+          Rule::Type { rule, .. } if rule.name.ident == name => Some(&rule.name),
+          _ => None,
+        })
+        .unwrap();
+      ident_numeric_kind(&cddl, rule_ident)
+    };
+
+    assert_eq!(kind_of("a"), Some(NumericKind::Int));
+    assert_eq!(kind_of("b"), Some(NumericKind::Float));
+    assert_eq!(kind_of("c"), Some(NumericKind::Both));
+    assert_eq!(kind_of("d"), Some(NumericKind::Both));
+    assert_eq!(kind_of("e"), Some(NumericKind::Both));
+    assert_eq!(kind_of("f"), None);
   }
 }

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -1034,7 +1034,8 @@ pub fn is_ident_float_data_type(cddl: &CDDL, ident: &Identifier) -> bool {
   | Token::FLOAT1632
   | Token::FLOAT32
   | Token::FLOAT3264
-  | Token::FLOAT64 = lookup_ident(ident.ident)
+  | Token::FLOAT64
+  | Token::NUMBER = lookup_ident(ident.ident)
   {
     return true;
   }


### PR DESCRIPTION
CDDL defines a `number` type in its prelude as `number = int / float`

However, this crate doesn't actually treat `number` as the sum of two parts, and instead treats it as a special case. However, in a lot of places, the `float` case wasn't handled properly leading to some errors

| spec | value | ruby | before | after |
|------|-------|------|--------|-------|
| `x = number` | f16 / f32 / f64 float (CBOR) | ✅ | ❌ rejected | ✅ |
| `x = number` | `2.5` (JSON) | ✅ | ❌ rejected | ✅ |
| `x = number` | int | ✅ | ✅ | ✅ |
| `x = number .ge 1.0` | float | ✅ | ❌ "expected type int" | ✅ |
| `x = number .eq 5` | int | ✅ | ✅ | ✅ |
| `x = int / float` | float | ✅ | ✅ | ✅ |

The first commit in this PR is the "simple" fix, but I felt it was too foot-gun-y so I made an enum to represent whether or not a float or an int is allowed in a given position (or both). This is a bit more of a breaking change (so I marked the older API as deprecated since it can be misleading), so feel free to merge/cherry-pick just the simpler solution if you want