### PR TITLE
Fix `* any => any` support in maps

### DIFF
--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -3068,7 +3068,13 @@ where
     }
 
     if is_ident_any_type(self.state.cddl, ident) {
-      return Ok(());
+      // As a member key, `any` must consume map entries rather than
+      // short-circuit, otherwise `* any => any` leaves the remaining keys
+      // unvalidated and the closed-map check rejects them. Fall through to
+      // the map handling below
+      if !(self.state.is_member_key && matches!(&self.cbor, Value::Map(_))) {
+        return Ok(());
+      }
     }
 
     // Special case for array values - check if we're in an array context and this
@@ -3229,6 +3235,27 @@ where
         match &self.state.occurrence {
           #[cfg(feature = "ast-span")]
           Some(Occur::Optional { .. }) | None => {
+            // An `any`-keyed entry matches any map entry; consume the first
+            // not-yet-validated one
+            if is_ident_any_type(self.state.cddl, ident) && !self.validating_value {
+              if let Some((k, v)) = m.iter().find(|(k, _)| {
+                !self
+                  .validated_keys
+                  .as_ref()
+                  .is_some_and(|keys| keys.contains(k))
+              }) {
+                self
+                  .validated_keys
+                  .get_or_insert(vec![k.clone()])
+                  .push(k.clone());
+                self.object_value = Some(v.clone());
+                let _ = write!(self.state.data_location, "/{:?}", v);
+              } else if !entry_optional {
+                self.add_error(format!("map requires entry key of type {}", ident));
+              }
+              return Ok(());
+            }
+
             if is_ident_string_data_type(self.state.cddl, ident) && !self.validating_value {
               if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Text(_))) {
                 self
@@ -3328,6 +3355,27 @@ where
           }
           #[cfg(not(feature = "ast-span"))]
           Some(Occur::Optional {}) | None => {
+            // An `any`-keyed entry matches any map entry; consume the first
+            // not-yet-validated one
+            if is_ident_any_type(self.state.cddl, ident) && !self.validating_value {
+              if let Some((k, v)) = m.iter().find(|(k, _)| {
+                !self
+                  .validated_keys
+                  .as_ref()
+                  .is_some_and(|keys| keys.contains(k))
+              }) {
+                self
+                  .validated_keys
+                  .get_or_insert(vec![k.clone()])
+                  .push(k.clone());
+                self.object_value = Some(v.clone());
+                self.state.data_location.push_str(&format!("/{:?}", v));
+              } else if !entry_optional {
+                self.add_error(format!("map requires entry key of type {}", ident));
+              }
+              return Ok(());
+            }
+
             if is_ident_string_data_type(self.state.cddl, ident) && !self.validating_value {
               if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Text(_))) {
                 self
@@ -3428,6 +3476,20 @@ where
           }
           Some(occur) => {
             let mut errors = Vec::new();
+
+            // An `any`-keyed table (e.g. `* any => v`) matches entries of any
+            // key type, so all not-yet-validated values are candidates
+            if is_ident_any_type(self.state.cddl, ident) {
+              let values_to_validate = m
+                .iter()
+                .filter_map(|(k, v)| match &self.validated_keys {
+                  Some(keys) if keys.contains(k) => None,
+                  _ => Some(v.clone()),
+                })
+                .collect::<Vec<_>>();
+
+              self.values_to_validate = Some(values_to_validate);
+            }
 
             if is_ident_string_data_type(self.state.cddl, ident) {
               let values_to_validate = m
@@ -3717,6 +3779,13 @@ where
 
                 return Ok(());
               }
+            }
+
+            // `any` keys have already collected their values above; nothing
+            // further to match, and the prelude fall-through below must not
+            // reject them
+            if is_ident_any_type(self.state.cddl, ident) {
+              return Ok(());
             }
 
             if is_ident_string_data_type(self.state.cddl, ident) && !self.validating_value {

--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -2384,13 +2384,16 @@ where
 
           self.visit_group(group)?;
 
-          // If extra map entries are detected, return validation error
+          // A key is unexpected unless some group entry consumed it
+          // (validated_keys of None is an empty consumed set)
           if self.values_to_validate.is_none() {
             for k in m.into_iter() {
-              if let Some(keys) = &self.validated_keys {
-                if !keys.contains(&k) {
-                  self.add_error(format!("unexpected key {:?}", k));
-                }
+              if !self
+                .validated_keys
+                .as_ref()
+                .is_some_and(|keys| keys.contains(&k))
+              {
+                self.add_error(format!("unexpected key {:?}", k));
               }
             }
           }
@@ -3220,6 +3223,9 @@ where
       }
       Value::Array(_) => self.validate_array_items(&ArrayItemToken::Identifier(ident)),
       Value::Map(m) => {
+        // `?` permits the entry to be absent (RFC 8610 §3.2), so a failure to
+        // find a matching entry key is not an error for an optional entry
+        let entry_optional = matches!(&self.state.occurrence, Some(Occur::Optional { .. }));
         match &self.state.occurrence {
           #[cfg(feature = "ast-span")]
           Some(Occur::Optional { .. }) | None => {
@@ -3231,7 +3237,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 let _ = write!(self.state.data_location, "/{:?}", v);
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -3245,7 +3251,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 let _ = write!(self.state.data_location, "/{:?}", v);
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -3259,7 +3265,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 let _ = write!(self.state.data_location, "/{:?}", v);
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -3273,7 +3279,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 let _ = write!(self.state.data_location, "/{:?}", v);
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -3287,7 +3293,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 let _ = write!(self.state.data_location, "/{:?}", v);
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -3301,7 +3307,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 let _ = write!(self.state.data_location, "/{:?}", v);
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -3330,7 +3336,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 self.state.data_location.push_str(&format!("/{}", value));
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
 
@@ -3345,7 +3351,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 self.state.data_location.push_str(&format!("/{}", value));
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -3359,7 +3365,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 self.state.data_location.push_str(&format!("/{}", value));
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -3373,7 +3379,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 self.state.data_location.push_str(&format!("/{}", value));
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -3387,7 +3393,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 self.state.data_location.push_str(&format!("/{}", value));
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -3401,7 +3407,7 @@ where
                   .push(k.clone());
                 self.object_value = Some(v.clone());
                 self.state.data_location.push_str(&format!("/{}", value));
-              } else {
+              } else if !entry_optional {
                 self.add_error(format!("map requires entry key of type {}", ident));
               }
               return Ok(());
@@ -4090,6 +4096,15 @@ where
         cv.visit_rule(rule)?;
 
         self.errors.append(&mut cv.errors);
+
+        // The child validated the same map in the same group context, so keys
+        // it consumed count toward this validator's unexpected-key check
+        if let Some(keys) = cv.validated_keys {
+          self
+            .validated_keys
+            .get_or_insert_with(Vec::new)
+            .extend(keys);
+        }
 
         return Ok(());
       }

--- a/src/validator/json.rs
+++ b/src/validator/json.rs
@@ -2010,12 +2010,16 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
 
           self.visit_group(group)?;
 
+          // A key is unexpected unless some group entry consumed it
+          // (validated_keys of None is an empty consumed set)
           if self.values_to_validate.is_none() {
             for k in o.into_iter() {
-              if let Some(keys) = &self.validated_keys {
-                if !keys.contains(&k) {
-                  self.add_error(format!("unexpected key {:?}", k));
-                }
+              if !self
+                .validated_keys
+                .as_ref()
+                .is_some_and(|keys| keys.contains(&k))
+              {
+                self.add_error(format!("unexpected key {:?}", k));
               }
             }
           }
@@ -2557,6 +2561,28 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
       Value::Object(o) => match &self.state.occurrence {
         #[cfg(feature = "ast-span")]
         Some(Occur::Optional { .. }) | None => {
+          // A type-domain string key (e.g. `tstr => v`) matches any object
+          // entry, since JSON object keys are always strings. `?` permits the
+          // entry to be absent (RFC 8610 §3.2), so a find-miss is only an
+          // error for an occurrence-less entry
+          if self.state.is_member_key && is_ident_string_data_type(self.state.cddl, ident) {
+            if let Some((k, v)) = o.iter().next() {
+              self
+                .validated_keys
+                .get_or_insert(vec![k.clone()])
+                .push(k.clone());
+              self.object_value = Some(v.clone());
+              let _ = write!(self.state.data_location, "/{}", k);
+            } else if let Some(Occur::Optional { .. }) = self.state.occurrence.take() {
+              // absent optional entry: skip value validation for this entry
+              self.state.advance_to_next_entry = true;
+            } else {
+              self.add_error(format!("object requires entry key of type {}", ident));
+            }
+
+            return Ok(());
+          }
+
           if token::lookup_ident(ident.ident)
             .in_standard_prelude()
             .is_some()
@@ -2572,6 +2598,24 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
         }
         #[cfg(not(feature = "ast-span"))]
         Some(Occur::Optional {}) | None => {
+          if self.state.is_member_key && is_ident_string_data_type(self.state.cddl, ident) {
+            if let Some((k, v)) = o.iter().next() {
+              self
+                .validated_keys
+                .get_or_insert(vec![k.clone()])
+                .push(k.clone());
+              self.object_value = Some(v.clone());
+              self.state.data_location.push_str(&format!("/{}", k));
+            } else if let Some(Occur::Optional { .. }) = self.state.occurrence.take() {
+              // absent optional entry: skip value validation for this entry
+              self.state.advance_to_next_entry = true;
+            } else {
+              self.add_error(format!("object requires entry key of type {}", ident));
+            }
+
+            return Ok(());
+          }
+
           if token::lookup_ident(ident.ident)
             .in_standard_prelude()
             .is_some()
@@ -2863,6 +2907,15 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
         jv.visit_rule(rule)?;
 
         self.errors.append(&mut jv.errors);
+
+        // The child validated the same object in the same group context, so
+        // keys it consumed count toward this validator's unexpected-key check
+        if let Some(keys) = jv.validated_keys {
+          self
+            .validated_keys
+            .get_or_insert_with(Vec::new)
+            .extend(keys);
+        }
 
         return Ok(());
       }

--- a/src/validator/json.rs
+++ b/src/validator/json.rs
@@ -2447,7 +2447,13 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
     }
 
     if is_ident_any_type(self.state.cddl, ident) {
-      return Ok(());
+      // As a member key, `any` must consume object entries rather than
+      // short-circuit, otherwise `* any => any` leaves the remaining keys
+      // unvalidated and the closed-map check rejects them. Fall through to
+      // the object handling below
+      if !(self.state.is_member_key && matches!(&self.json, Value::Object(_))) {
+        return Ok(());
+      }
     }
 
     // Special case for array values - check if we're in an array context and this
@@ -2562,11 +2568,21 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
         #[cfg(feature = "ast-span")]
         Some(Occur::Optional { .. }) | None => {
           // A type-domain string key (e.g. `tstr => v`) matches any object
-          // entry, since JSON object keys are always strings. `?` permits the
-          // entry to be absent (RFC 8610 §3.2), so a find-miss is only an
-          // error for an occurrence-less entry
-          if self.state.is_member_key && is_ident_string_data_type(self.state.cddl, ident) {
-            if let Some((k, v)) = o.iter().next() {
+          // entry, since JSON object keys are always strings. An `any` key
+          // likewise matches any entry; it consumes the first
+          // not-yet-validated one. `?` permits the entry to be absent
+          // (RFC 8610 §3.2), so a find-miss is only an error for an
+          // occurrence-less entry
+          if self.state.is_member_key
+            && (is_ident_string_data_type(self.state.cddl, ident)
+              || is_ident_any_type(self.state.cddl, ident))
+          {
+            if let Some((k, v)) = o.iter().find(|(k, _)| {
+              !self
+                .validated_keys
+                .as_ref()
+                .is_some_and(|keys| keys.contains(*k))
+            }) {
               self
                 .validated_keys
                 .get_or_insert(vec![k.clone()])
@@ -2598,8 +2614,16 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
         }
         #[cfg(not(feature = "ast-span"))]
         Some(Occur::Optional {}) | None => {
-          if self.state.is_member_key && is_ident_string_data_type(self.state.cddl, ident) {
-            if let Some((k, v)) = o.iter().next() {
+          if self.state.is_member_key
+            && (is_ident_string_data_type(self.state.cddl, ident)
+              || is_ident_any_type(self.state.cddl, ident))
+          {
+            if let Some((k, v)) = o.iter().find(|(k, _)| {
+              !self
+                .validated_keys
+                .as_ref()
+                .is_some_and(|keys| keys.contains(*k))
+            }) {
               self
                 .validated_keys
                 .get_or_insert(vec![k.clone()])
@@ -2630,7 +2654,9 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
           self.visit_value(&token::Value::TEXT(ident.ident.into()))
         }
         Some(occur) => {
-          if is_ident_string_data_type(self.state.cddl, ident) {
+          if is_ident_string_data_type(self.state.cddl, ident)
+            || is_ident_any_type(self.state.cddl, ident)
+          {
             let values_to_validate = o
               .iter()
               .filter_map(|(k, v)| match &self.validated_keys {

--- a/tests/cbor.rs
+++ b/tests/cbor.rs
@@ -692,3 +692,54 @@ fn validate_map_unexpected_entries_rejected() -> Result<(), Box<dyn Error>> {
 
   Ok(())
 }
+
+/// Regression: `* any => any` (the RFC 8610 extension-point idiom) must
+/// permit unknown extra entries instead of rejecting them as unexpected keys
+#[test]
+fn validate_map_any_key_permits_extra_entries() -> Result<(), Box<dyn Error>> {
+  let empty_map = b"\xa0";
+  let k1 = b"\xa1\x61\x6b\x01"; // {"k": 1}
+  let k1_z9 = b"\xa2\x61\x6b\x01\x61\x7a\x09"; // {"k": 1, "z": 9}
+  let k1_ztext = b"\xa2\x61\x6b\x01\x61\x7a\x61\x61"; // {"k": 1, "z": "a"}
+  let int_keyed = b"\xa2\x01\x02\x03\x04"; // {1: 2, 3: 4}
+
+  // the openness idiom, with and without other members, in both member orders
+  validate_cbor_from_slice(r#"m = { k: uint, * any => any }"#, k1, None)?;
+  validate_cbor_from_slice(r#"m = { k: uint, * any => any }"#, k1_z9, None)?;
+  validate_cbor_from_slice(r#"m = { * any => any, k: uint }"#, k1_z9, None)?;
+  // colon shortcut form
+  validate_cbor_from_slice(r#"m = { k: uint, * any: any }"#, k1_z9, None)?;
+  validate_cbor_from_slice(r#"m = { * any => any }"#, empty_map, None)?;
+  // `any` keys are not limited to text keys
+  validate_cbor_from_slice(r#"m = { * any => any }"#, int_keyed, None)?;
+  // `+` still requires at least one entry
+  assert!(validate_cbor_from_slice(r#"m = { + any => any }"#, empty_map, None).is_err());
+  validate_cbor_from_slice(r#"m = { + any => any }"#, k1, None)?;
+  // an `any` key does not excuse a value-type mismatch
+  assert!(validate_cbor_from_slice(r#"m = { k: uint, * any => uint }"#, k1_ztext, None).is_err());
+  // a map without the extension member stays closed
+  assert!(validate_cbor_from_slice(r#"m = { k: uint }"#, k1_z9, None).is_err());
+
+  Ok(())
+}
+
+/// A wrong value type under a cut-carrying key (`k: uint` — the colon
+/// shortcut implies a cut, RFC 8610 §3.5.4) must NOT be rescued by a
+/// `* any => any` extension member, and the error must name the value-type
+/// mismatch rather than anything about the `any` branch
+#[test]
+fn validate_map_any_key_does_not_rescue_cut_value_mismatch() {
+  let k_wrong_z = b"\xa2\x61\x6b\x61\x73\x61\x7a\x09"; // {"k": "s", "z": 9}
+  for schema in [
+    r#"m = { k: uint, * any => any }"#,
+    r#"m = { k: uint, any => any }"#,
+  ] {
+    let err = validate_cbor_from_slice(schema, k_wrong_z, None)
+      .unwrap_err()
+      .to_string();
+    assert!(
+      err.contains(r#"expected type uint, got Text("s")"#),
+      "schema {schema}: expected a value-type error for k, got: {err}"
+    );
+  }
+}

--- a/tests/cbor.rs
+++ b/tests/cbor.rs
@@ -639,3 +639,56 @@ fn validate_decfrac_and_bigfloat() -> Result<(), Box<dyn Error>> {
 
   Ok(())
 }
+
+#[test]
+fn validate_optional_type_domain_map_entry_absent() -> Result<(), Box<dyn Error>> {
+  // `?` permits the entry to be absent (RFC 8610 §3.2), so the empty map is
+  // valid against a map whose sole entry is a `?`-marked type-domain entry
+  let empty_map = b"\xa0";
+  let one_entry = b"\xa1\x61\x61\x01"; // {"a": 1}
+
+  validate_cbor_from_slice(r#"m = { ? tstr => uint }"#, empty_map, None)?;
+  // present entry still validates
+  validate_cbor_from_slice(r#"m = { ? tstr => uint }"#, one_entry, None)?;
+  // present entry with a bad value type still fails
+  let bad_value = b"\xa1\x61\x61\x61\x62"; // {"a": "b"}
+  assert!(validate_cbor_from_slice(r#"m = { ? tstr => uint }"#, bad_value, None).is_err());
+
+  // other key types take the same code path
+  validate_cbor_from_slice(r#"m = { ? int => uint }"#, empty_map, None)?;
+  validate_cbor_from_slice(r#"m = { ? bool => uint }"#, empty_map, None)?;
+  validate_cbor_from_slice(r#"m = { ? bytes => uint }"#, empty_map, None)?;
+
+  // an occurrence-less entry must still require a match
+  assert!(validate_cbor_from_slice(r#"m = { tstr => uint }"#, empty_map, None).is_err());
+
+  // absent optional entry alongside other entries that do consume the keys
+  let int_entry = b"\xa1\x01\x02"; // {1: 2}
+  let text_and_int = b"\xa2\x61\x61\x01\x01\x02"; // {"a": 1, 1: 2}
+  validate_cbor_from_slice(r#"m = { ? tstr => uint, int => int }"#, int_entry, None)?;
+  validate_cbor_from_slice(r#"m = { ? tstr => uint, ? int => int }"#, int_entry, None)?;
+  validate_cbor_from_slice(r#"m = { ? tstr => uint, int => int }"#, text_and_int, None)?;
+  validate_cbor_from_slice(r#"m = { ? tstr => uint, ? int => int }"#, empty_map, None)?;
+
+  Ok(())
+}
+
+#[test]
+fn validate_map_unexpected_entries_rejected() -> Result<(), Box<dyn Error>> {
+  // A map entry unmatched by any group member is an unexpected key, including
+  // when the group's only member is `?`-marked and absent
+  let empty_map = b"\xa0";
+  let k1 = b"\xa1\x61\x6b\x01"; // {"k": 1}
+  let a1 = b"\xa1\x61\x61\x01"; // {"a": 1}
+  let k1_a2 = b"\xa2\x61\x6b\x01\x61\x61\x02"; // {"k": 1, "a": 2}
+  let int_entry = b"\xa1\x01\x02"; // {1: 2}
+
+  validate_cbor_from_slice(r#"m = { ? k: uint }"#, empty_map, None)?;
+  validate_cbor_from_slice(r#"m = { ? k: uint }"#, k1, None)?;
+  assert!(validate_cbor_from_slice(r#"m = { ? k: uint }"#, a1, None).is_err());
+  assert!(validate_cbor_from_slice(r#"m = { ? k: uint }"#, k1_a2, None).is_err());
+  // absent optional type-domain entry does not excuse a key of another domain
+  assert!(validate_cbor_from_slice(r#"m = { ? tstr => uint }"#, int_entry, None).is_err());
+
+  Ok(())
+}

--- a/tests/cddl.rs
+++ b/tests/cddl.rs
@@ -116,3 +116,30 @@ hex_test = bstr .hex "test"
     );
   }
 }
+
+/// Regression: type-domain string keys (`tstr => v`) in objects were rejected
+/// even when present, and `?`-marked ones rejected the spec-valid empty object
+#[test]
+fn validate_json_optional_type_domain_object_key() {
+  // `?` permits the entry to be absent (RFC 8610 §3.2)
+  validate_json_from_str(r#"m = { ? tstr => uint }"#, r#"{}"#, None).unwrap();
+  // present entry validates
+  validate_json_from_str(r#"m = { ? tstr => uint }"#, r#"{"a": 1}"#, None).unwrap();
+  validate_json_from_str(r#"m = { tstr => uint }"#, r#"{"a": 1}"#, None).unwrap();
+  // present entry with a bad value type still fails
+  validate_json_from_str(r#"m = { ? tstr => uint }"#, r#"{"a": "b"}"#, None).unwrap_err();
+  // an occurrence-less entry still requires a match
+  validate_json_from_str(r#"m = { tstr => uint }"#, r#"{}"#, None).unwrap_err();
+  // a bare string type against an object still fails (not treated as a key)
+  validate_json_from_str(r#"m = tstr"#, r#"{"a": 1}"#, None).unwrap_err();
+}
+
+/// Regression: an object entry unmatched by any group member must be rejected
+/// as an unexpected key, even when no group member consumed any key at all
+#[test]
+fn validate_json_unexpected_entries_rejected() {
+  validate_json_from_str(r#"m = { ? k: uint }"#, r#"{}"#, None).unwrap();
+  validate_json_from_str(r#"m = { ? k: uint }"#, r#"{"k": 1}"#, None).unwrap();
+  validate_json_from_str(r#"m = { ? k: uint }"#, r#"{"a": 1}"#, None).unwrap_err();
+  validate_json_from_str(r#"m = { ? k: uint }"#, r#"{"k": 1, "a": 2}"#, None).unwrap_err();
+}

--- a/tests/cddl.rs
+++ b/tests/cddl.rs
@@ -143,3 +143,66 @@ fn validate_json_unexpected_entries_rejected() {
   validate_json_from_str(r#"m = { ? k: uint }"#, r#"{"a": 1}"#, None).unwrap_err();
   validate_json_from_str(r#"m = { ? k: uint }"#, r#"{"k": 1, "a": 2}"#, None).unwrap_err();
 }
+
+/// Regression: `* any => any` (the RFC 8610 extension-point idiom) must
+/// permit unknown extra entries instead of rejecting them as unexpected keys
+#[test]
+fn validate_json_any_key_permits_extra_entries() {
+  // the openness idiom, with and without other members, in both member orders
+  validate_json_from_str(r#"m = { k: uint, * any => any }"#, r#"{"k": 1}"#, None).unwrap();
+  validate_json_from_str(
+    r#"m = { k: uint, * any => any }"#,
+    r#"{"k": 1, "z": 9}"#,
+    None,
+  )
+  .unwrap();
+  validate_json_from_str(
+    r#"m = { * any => any, k: uint }"#,
+    r#"{"k": 1, "z": 9}"#,
+    None,
+  )
+  .unwrap();
+  // colon shortcut form
+  validate_json_from_str(
+    r#"m = { k: uint, * any: any }"#,
+    r#"{"k": 1, "z": 9}"#,
+    None,
+  )
+  .unwrap();
+  validate_json_from_str(r#"m = { * any => any }"#, r#"{}"#, None).unwrap();
+  validate_json_from_str(r#"m = { * any => any }"#, r#"{"z": 9}"#, None).unwrap();
+  // `+` still requires at least one entry
+  validate_json_from_str(r#"m = { + any => any }"#, r#"{}"#, None).unwrap_err();
+  validate_json_from_str(r#"m = { + any => any }"#, r#"{"z": 9}"#, None).unwrap();
+  // an occurrence-less `any` key consumes an entry
+  validate_json_from_str(r#"m = { any => any }"#, r#"{"z": 9}"#, None).unwrap();
+  // an `any` key does not excuse a value-type mismatch
+  validate_json_from_str(
+    r#"m = { k: uint, * any => uint }"#,
+    r#"{"k": 1, "z": "s"}"#,
+    None,
+  )
+  .unwrap_err();
+  // a map without the extension member stays closed
+  validate_json_from_str(r#"m = { k: uint }"#, r#"{"k": 1, "z": 9}"#, None).unwrap_err();
+}
+
+/// A wrong value type under a cut-carrying key (`k: uint` — the colon
+/// shortcut implies a cut, RFC 8610 §3.5.4) must NOT be rescued by a
+/// `* any => any` extension member, and the error must name the value-type
+/// mismatch rather than anything about the `any` branch
+#[test]
+fn validate_json_any_key_does_not_rescue_cut_value_mismatch() {
+  for schema in [
+    r#"m = { k: uint, * any => any }"#,
+    r#"m = { k: uint, any => any }"#,
+  ] {
+    let err = validate_json_from_str(schema, r#"{"k": "s", "z": 9}"#, None)
+      .unwrap_err()
+      .to_string();
+    assert!(
+      err.contains(r#"/k: expected type uint, got "s""#),
+      "schema {schema}: expected a value-type error for k, got: {err}"
+    );
+  }
+}


### PR DESCRIPTION
CDDL allows specifying maps that are "loose" like `{ k: uint, * any => any }`

However, currently the validator does not support this. This PR adds support

Note: I made this a draft PR because it depends on #644 being merged first