### PR TITLE
Enforce primitive integer value domains

### DIFF
--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -1230,6 +1230,21 @@ where
       ..
     } = target
     {
+      if matches!(
+        &self.cbor,
+        Value::Integer(i)
+          if ident_numeric_kind(self.state.cddl, target_ident)
+            .is_some_and(NumericKind::admits_int)
+            && ident_matches_integer_value(self.state.cddl, target_ident, i128::from(*i))
+              == Some(false)
+      ) {
+        self.add_error(format!(
+          "expected type {}, got {:?}",
+          target_ident, self.cbor
+        ));
+        return Ok(());
+      }
+
       if let Type2::Typename {
         ident: controller_ident,
         ..
@@ -1289,16 +1304,13 @@ where
       {
         self.add_error(format!("expected type bstr, got {:?}", self.cbor));
         return Ok(());
-      } else if is_ident_uint_data_type(self.state.cddl, target_ident) {
-        // For uint, we need to check that it's an integer and it's non-negative,
-        // then fall through so the control operator is enforced
-        match &self.cbor {
-          Value::Integer(i) if i128::from(*i) >= 0 => {}
-          _ => {
-            self.add_error(format!("expected type uint, got {:?}", self.cbor));
-            return Ok(());
-          }
-        }
+      } else if matches!(
+        ident_numeric_kind(self.state.cddl, target_ident),
+        Some(NumericKind::Int)
+      ) && !matches!(self.cbor, Value::Integer(_))
+      {
+        self.add_error(format!("expected type int, got {:?}", self.cbor));
+        return Ok(());
       } else if let Some(kind) = ident_numeric_kind(self.state.cddl, target_ident) {
         let matches_kind = match kind {
           NumericKind::Int => matches!(self.cbor, Value::Integer(_)),
@@ -3405,13 +3417,9 @@ where
         Ok(())
       }
       Value::Integer(i) => {
-        if is_ident_uint_data_type(self.state.cddl, ident) {
-          if i128::from(*i).is_negative() {
-            self.add_error(format!("expected type {}, got {:?}", ident, self.cbor));
-          }
-
-          Ok(())
-        } else if ident_numeric_kind(self.state.cddl, ident).is_some_and(NumericKind::admits_int) {
+        if ident_numeric_kind(self.state.cddl, ident).is_some_and(NumericKind::admits_int)
+          && ident_matches_integer_value(self.state.cddl, ident, i128::from(*i)) == Some(true)
+        {
           Ok(())
         } else if is_ident_time_data_type(self.state.cddl, ident) {
           if let chrono::LocalResult::None =

--- a/src/validator/json.rs
+++ b/src/validator/json.rs
@@ -1380,6 +1380,21 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
       ..
     } = target
     {
+      if let Value::Number(number) = &self.json {
+        let integer = number
+          .as_i64()
+          .map(i128::from)
+          .or_else(|| number.as_u64().map(i128::from));
+        if let Some(integer) = integer {
+          if ident_numeric_kind(self.state.cddl, target_ident).is_some_and(NumericKind::admits_int)
+            && ident_matches_integer_value(self.state.cddl, target_ident, integer) == Some(false)
+          {
+            self.add_error(format!("expected type {}, got {}", target_ident, self.json));
+            return Ok(());
+          }
+        }
+      }
+
       if let Type2::Typename {
         ident: controller_ident,
         ..
@@ -2708,15 +2723,22 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
         Ok(())
       }
       Value::Number(n) => {
-        if is_ident_uint_data_type(self.state.cddl, ident) && n.is_u64() {
-          return Ok(());
-        } else if is_ident_nint_data_type(self.state.cddl, ident) {
-          if let Some(n) = n.as_i64() {
-            if n.is_negative() {
+        let integer = n
+          .as_i64()
+          .map(i128::from)
+          .or_else(|| n.as_u64().map(i128::from));
+        if let Some(integer) = integer {
+          if ident_numeric_kind(self.state.cddl, ident).is_some_and(NumericKind::admits_int) {
+            if ident_matches_integer_value(self.state.cddl, ident, integer) == Some(true) {
               return Ok(());
             }
+
+            self.add_error(format!("expected type {}, got {}", ident, self.json));
+            return Ok(());
           }
-        } else if is_ident_time_data_type(self.state.cddl, ident) {
+        }
+
+        if is_ident_time_data_type(self.state.cddl, ident) {
           if let Some(n) = n.as_i64() {
             if let chrono::LocalResult::None = Utc.timestamp_millis_opt(n * 1000) {
               self.add_error(format!(

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -1013,6 +1013,87 @@ impl NumericKind {
   }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum IntegerDomain {
+  Unsigned,
+  Negative,
+  EitherSign,
+}
+
+impl IntegerDomain {
+  fn union(self, other: Self) -> Self {
+    match (self, other) {
+      (Self::Unsigned, Self::Unsigned) => Self::Unsigned,
+      (Self::Negative, Self::Negative) => Self::Negative,
+      _ => Self::EitherSign,
+    }
+  }
+
+  fn matches(self, value: i128) -> bool {
+    match self {
+      Self::Unsigned => !value.is_negative(),
+      Self::Negative => value.is_negative(),
+      Self::EitherSign => true,
+    }
+  }
+}
+
+/// Whether an untagged integer belongs to the value domain denoted by an
+/// identifier.
+///
+/// RFC 8610 normative Appendix D defines `uint = #0`, `nint = #1`,
+/// `int = uint / nint`, and `unsigned = uint / biguint`. Aliases and choices
+/// combine the untagged integer arms of their referenced types. Returns
+/// `None` when a rule contains `any`, literals, ranges, or other forms that
+/// cannot be represented by a sign-only domain.
+pub(crate) fn ident_matches_integer_value(
+  cddl: &CDDL,
+  ident: &Identifier,
+  value: i128,
+) -> Option<bool> {
+  fn domain(cddl: &CDDL, ident: &Identifier) -> Option<IntegerDomain> {
+    let primitive = match lookup_ident(ident.ident) {
+      Token::UINT | Token::UNSIGNED => Some(IntegerDomain::Unsigned),
+      Token::NINT => Some(IntegerDomain::Negative),
+      Token::INT | Token::INTEGER | Token::NUMBER => Some(IntegerDomain::EitherSign),
+      _ => None,
+    };
+
+    if primitive.is_some() {
+      return primitive;
+    }
+
+    let mut combined: Option<IntegerDomain> = None;
+    for type_choice in cddl.rules.iter().filter_map(|r| match r {
+      Rule::Type { rule, .. } if rule.name == *ident => Some(&rule.value),
+      _ => None,
+    }) {
+      for choice in type_choice.type_choices.iter() {
+        let Type2::Typename { ident, .. } = &choice.type1.type2 else {
+          // A sign-only predicate cannot faithfully classify literals,
+          // ranges, or other composite forms. Their existing full type-choice
+          // validation remains authoritative.
+          return None;
+        };
+        if let Some(choice_domain) = domain(cddl, ident) {
+          combined = Some(match combined {
+            Some(domain) => domain.union(choice_domain),
+            None => choice_domain,
+          });
+        } else if is_ident_any_type(cddl, ident) {
+          // `any` includes integers of either sign, but treating it as merely
+          // an integer domain would overstate what this predicate validates.
+          return None;
+        }
+      }
+    }
+
+    combined
+  }
+
+  domain(cddl, ident).map(|domain| domain.matches(value))
+}
+
 /// Classify the given identifier's numeric kind
 /// or `None` if it is not associated with an int/float numeric data type
 pub fn ident_numeric_kind(cddl: &CDDL, ident: &Identifier) -> Option<NumericKind> {

--- a/tests/primitive_integer_value_domains.rs
+++ b/tests/primitive_integer_value_domains.rs
@@ -1,0 +1,186 @@
+//! RFC 8610 primitive integer value-domain regressions.
+//!
+//! Normative Appendix D defines `uint = #0`, `nint = #1`,
+//! `int = uint / nint`, and `unsigned = uint / biguint`. The tests below
+//! exercise the untagged integer arms in ordinary values and control targets.
+#![cfg(feature = "std")]
+#![cfg(not(target_arch = "wasm32"))]
+
+#[cfg(feature = "cbor")]
+fn validate_cbor(schema: &str, data: &[u8]) -> bool {
+  #[cfg(feature = "additional-controls")]
+  let result = cddl::validate_cbor_from_slice(schema, data, None);
+  #[cfg(not(feature = "additional-controls"))]
+  let result = cddl::validate_cbor_from_slice(schema, data);
+
+  result.is_ok()
+}
+
+#[cfg(feature = "json")]
+fn validate_json(schema: &str, data: &str) -> bool {
+  #[cfg(feature = "additional-controls")]
+  let result = cddl::validate_json_from_str(schema, data, None);
+  #[cfg(not(feature = "additional-controls"))]
+  let result = cddl::validate_json_from_str(schema, data);
+
+  result.is_ok()
+}
+
+#[cfg(feature = "cbor")]
+mod cbor {
+  use super::validate_cbor;
+
+  const NEGATIVE_ONE: &[u8] = b"\x20";
+  const ZERO: &[u8] = b"\x00";
+  const ONE: &[u8] = b"\x01";
+  const FLOAT_ONE: &[u8] = b"\xf9\x3c\x00";
+
+  #[test]
+  fn enforces_direct_primitive_integer_domains() {
+    for schema in ["x = uint", "x = unsigned"] {
+      assert!(!validate_cbor(schema, NEGATIVE_ONE), "{}: -1", schema);
+      assert!(validate_cbor(schema, ZERO), "{}: 0", schema);
+      assert!(validate_cbor(schema, ONE), "{}: 1", schema);
+      assert!(!validate_cbor(schema, FLOAT_ONE), "{}: float", schema);
+    }
+
+    assert!(validate_cbor("x = nint", NEGATIVE_ONE));
+    assert!(!validate_cbor("x = nint", ZERO));
+    assert!(!validate_cbor("x = nint", ONE));
+    assert!(!validate_cbor("x = nint", FLOAT_ONE));
+
+    for schema in ["x = int", "x = integer"] {
+      assert!(validate_cbor(schema, NEGATIVE_ONE), "{}: -1", schema);
+      assert!(validate_cbor(schema, ZERO), "{}: 0", schema);
+      assert!(validate_cbor(schema, ONE), "{}: 1", schema);
+      assert!(!validate_cbor(schema, FLOAT_ONE), "{}: float", schema);
+    }
+
+    for data in [NEGATIVE_ONE, ZERO, ONE, FLOAT_ONE] {
+      assert!(validate_cbor("x = number", data));
+    }
+  }
+
+  #[test]
+  fn preserves_integer_domains_through_value_aliases_and_choices() {
+    let unsigned_alias = "x = small\nsmall = unsigned";
+    assert!(!validate_cbor(unsigned_alias, NEGATIVE_ONE));
+    assert!(validate_cbor(unsigned_alias, ZERO));
+
+    let either_sign = "x = integer-choice\ninteger-choice = uint / nint";
+    assert!(validate_cbor(either_sign, NEGATIVE_ONE));
+    assert!(validate_cbor(either_sign, ZERO));
+
+    let unsigned_or_float = "x = numeric-choice\nnumeric-choice = unsigned / float";
+    assert!(!validate_cbor(unsigned_or_float, NEGATIVE_ONE));
+    assert!(validate_cbor(unsigned_or_float, ZERO));
+    assert!(validate_cbor(unsigned_or_float, FLOAT_ONE));
+  }
+
+  #[test]
+  fn gates_control_targets_by_integer_domain() {
+    assert!(!validate_cbor("x = unsigned .eq -1", NEGATIVE_ONE));
+    assert!(!validate_cbor("x = nint .eq 0", ZERO));
+
+    assert!(validate_cbor("x = unsigned .eq 0", ZERO));
+    assert!(validate_cbor("x = nint .eq -1", NEGATIVE_ONE));
+
+    // The target matches, but the controller does not.
+    assert!(!validate_cbor("x = unsigned .eq 1", ZERO));
+    assert!(!validate_cbor("x = nint .eq -2", NEGATIVE_ONE));
+  }
+
+  #[test]
+  fn gates_aliased_and_choice_control_targets_semantically() {
+    let unsigned_alias = "x = small .eq -1\nsmall = unsigned";
+    assert!(!validate_cbor(unsigned_alias, NEGATIVE_ONE));
+
+    let either_sign = "x = integer-choice .eq -1\ninteger-choice = uint / nint";
+    assert!(validate_cbor(either_sign, NEGATIVE_ONE));
+
+    // Literal/composite target validation is not reducible to a sign domain.
+    let literal_choice = "x = integer-choice .eq 1\ninteger-choice = 1 / nint";
+    assert!(validate_cbor(literal_choice, ONE));
+
+    // `any` can admit integers but has no sign-only domain of its own.
+    let unbounded_choice = "x = integer-choice .eq -1\ninteger-choice = unsigned / any";
+    assert!(validate_cbor(unbounded_choice, NEGATIVE_ONE));
+  }
+}
+
+#[cfg(feature = "json")]
+mod json {
+  use super::validate_json;
+
+  #[test]
+  fn enforces_direct_primitive_integer_domains() {
+    for schema in ["x = uint", "x = unsigned"] {
+      assert!(!validate_json(schema, "-1"), "{}: -1", schema);
+      assert!(validate_json(schema, "0"), "{}: 0", schema);
+      assert!(validate_json(schema, "1"), "{}: 1", schema);
+      assert!(!validate_json(schema, "1.0"), "{}: float", schema);
+    }
+
+    assert!(validate_json("x = nint", "-1"));
+    assert!(!validate_json("x = nint", "0"));
+    assert!(!validate_json("x = nint", "1"));
+    assert!(!validate_json("x = nint", "1.0"));
+
+    for schema in ["x = int", "x = integer"] {
+      assert!(validate_json(schema, "-1"), "{}: -1", schema);
+      assert!(validate_json(schema, "0"), "{}: 0", schema);
+      assert!(validate_json(schema, "1"), "{}: 1", schema);
+      assert!(!validate_json(schema, "1.0"), "{}: float", schema);
+    }
+
+    for data in ["-1", "0", "1", "1.0"] {
+      assert!(validate_json("x = number", data), "number: {}", data);
+    }
+  }
+
+  #[test]
+  fn preserves_integer_domains_through_value_aliases_and_choices() {
+    let unsigned_alias = "x = small\nsmall = unsigned";
+    assert!(!validate_json(unsigned_alias, "-1"));
+    assert!(validate_json(unsigned_alias, "0"));
+
+    let either_sign = "x = integer-choice\ninteger-choice = uint / nint";
+    assert!(validate_json(either_sign, "-1"));
+    assert!(validate_json(either_sign, "0"));
+
+    let unsigned_or_float = "x = numeric-choice\nnumeric-choice = unsigned / float";
+    assert!(!validate_json(unsigned_or_float, "-1"));
+    assert!(validate_json(unsigned_or_float, "0"));
+    assert!(validate_json(unsigned_or_float, "1.0"));
+  }
+
+  #[test]
+  fn gates_control_targets_by_integer_domain() {
+    assert!(!validate_json("x = unsigned .eq -1", "-1"));
+    assert!(!validate_json("x = nint .eq 0", "0"));
+
+    assert!(validate_json("x = unsigned .eq 0", "0"));
+    assert!(validate_json("x = nint .eq -1", "-1"));
+
+    // The target matches, but the controller does not.
+    assert!(!validate_json("x = unsigned .eq 1", "0"));
+    assert!(!validate_json("x = nint .eq -2", "-1"));
+  }
+
+  #[test]
+  fn gates_aliased_and_choice_control_targets_semantically() {
+    let unsigned_alias = "x = small .eq -1\nsmall = unsigned";
+    assert!(!validate_json(unsigned_alias, "-1"));
+
+    let either_sign = "x = integer-choice .eq -1\ninteger-choice = uint / nint";
+    assert!(validate_json(either_sign, "-1"));
+
+    // Literal/composite target validation is not reducible to a sign domain.
+    let literal_choice = "x = integer-choice .eq 1\ninteger-choice = 1 / nint";
+    assert!(validate_json(literal_choice, "1"));
+
+    // `any` can admit integers but has no sign-only domain of its own.
+    let unbounded_choice = "x = integer-choice .eq -1\ninteger-choice = unsigned / any";
+    assert!(validate_json(unbounded_choice, "-1"));
+  }
+}


### PR DESCRIPTION
# Enforce primitive integer value domains

This PR fixes primitive integer sign validation in ordinary CBOR and JSON
values and in numeric control-operator targets:

- Reject negative untagged integers for `uint` and `unsigned`.
- Reject zero and positive integers for `nint`.
- Preserve either-sign integer acceptance for `int`, `integer`, and `number`.
- Apply the same sign predicate before a control operator can mask an invalid
  target.
- Combine direct typename aliases and choices without treating literals,
  ranges, or composite forms as sign-only domains.
- Keep CBOR map candidate selection, tagged bignum validation, and float
  representability in their existing PR boundaries.

## Relevant RFC 8610 rules

<summary>section list</summary>
<details>

- Normative Appendix D defines `uint = #0` and `nint = #1`.
- Normative Appendix D defines `int = uint / nint`.
- Normative Appendix D defines `unsigned = uint / biguint`; its untagged
  integer arm is consequently non-negative.
- Section 4.2 applies the CDDL data model when validating JSON representations;
  the primitive sign domains are not CBOR encoding preferences.

</details>

## Key implementation insight

Integer kind and integer sign are separate properties.

The existing `NumericKind::Int` classification correctly distinguished
integers from floats, but it could not say which integer signs a type admits.
After a specific sign check failed, both validators could fall through to the
broad integer-kind branch and accept the value anyway. CBOR also lacked a
negative-only check for `nint`.

`IntegerDomain` adds the missing semantic classification:

```text
uint, unsigned  -> unsigned only
nint            -> negative only
int, integer    -> either sign
number          -> either sign for its integer arm
```

`ident_matches_integer_value` applies that classification to untagged
integers. It unions direct typename aliases and choices, so `uint / nint`
admits both signs while `unsigned / float` still rejects a negative integer.
It returns no sign classification for `any`, literal, range, or composite
choices: a sign-only predicate cannot validate those complete value sets, so
their existing full type evaluation remains authoritative.

CBOR and JSON ordinary values now require both numeric-kind and sign-domain
membership. Their control-target gates reject a known sign mismatch before
visiting the controller. A schema such as

```cddl
x = unsigned .eq -1
```

therefore rejects `-1` because the target is invalid, even though the
controller itself equals the instance.

## Rust and Ruby evidence

The comparison used Rust `cddl` and Ruby `cddl` gem 0.12.14, invoked with
`ruby -rset`. Appendix D is the conformance basis; the gem is supporting
interoperability evidence.

| Schema and instance | Rust `main` | Ruby 0.12.14 | This PR | Basis |
| --- | ---: | ---: | ---: | --- |
| `x = uint`, JSON `-1` | **accept** | reject | reject | Appendix D `uint = #0` |
| `x = unsigned`, CBOR/JSON `-1` | **accept** | reject | reject | Appendix D `unsigned = uint / biguint` |
| `x = nint`, CBOR `0` | **accept** | reject | reject | Appendix D `nint = #1` |
| `x = nint`, JSON `0` | reject | reject | reject | Same domain, existing JSON control |
| `x = unsigned`, CBOR/JSON `0` | accept | accept | accept | Unsigned lower boundary |
| `x = nint`, CBOR/JSON `-1` | accept | accept | accept | Negative upper boundary |
| `x = unsigned .eq -1`, CBOR/JSON `-1` | **accept** | reject | reject | Target membership precedes controller |
| `x = nint .eq 0`, CBOR/JSON `0` | **accept** | reject | reject | Target membership precedes controller |

The JSON `uint` failure was found while completing the direct primitive
matrix. It is the same fallback defect as `unsigned`, so it is fixed here
rather than split into another issue.

## Scope and coordination

This branch is based directly on
`main@db4ea5509976b1cf0f88c7c0408f80aa79665275`. It does not contain S01 or
any CBOR map-stack commit.

S01's float precision predicate remains separate. A no-commit merge of S01
and this commit resolved automatically; the combined nine float regressions
and eight integer regressions passed before the merge was aborted.

A05 still owns primitive numeric CBOR member-key candidate selection. A08
owns general member-key aliases, choices, controls, tags, and composites. I05
owns exact tagged primitive validation, including the bignum arms of
`unsigned` and `integer`.

## Verification

The focused tests were first observed failing on the exact recorded base.
Verification on `3789b14bdca44aaa5da1babaaa9728ec1c14c35b`:

```text
cargo test --test primitive_integer_value_domains --quiet                 pass (8)
cargo test --all --quiet                                                   pass
cargo test --no-default-features \
  --features std,ast-span,json,cbor,additional-controls \
  --test primitive_integer_value_domains --quiet                          pass (8)
cargo check -p cddl --lib --target wasm32-unknown-unknown                 pass
cargo +1.88 check --locked --all --bins --examples --tests                pass
cargo +1.88 check --locked -p cddl --lib --no-default-features \
  --features _build-parser --target thumbv7em-none-eabihf                 pass
cargo clippy --all                                                         pass (one pre-existing warning)
cargo clippy -p cddl --lib --target wasm32-unknown-unknown                pass (same warning)
cargo fmt --all -- --check                                                 pass
git diff --check                                                           pass
GitHub Actions for PR #671                                                  pass (all checks)
```

The retained tests cover direct primitive names, aliases, choices, all three
sign boundaries, float controls, masked target failures, controller failures,
and deferred literal/`any` choice controls. No new out-of-scope proposal was
needed.
