### PR TITLE
fix(validator) claim repeating map entries by complete pairs

### DIFF
--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -550,19 +550,17 @@ impl<'a> CBORValidator<'a> {
       self.find_single_map_entry_matching(entries, |_| true)
     } else if is_ident_string_data_type(self.state.cddl, ident) {
       self.find_single_map_entry_matching(entries, |key| matches!(key, Value::Text(_)))
-    } else if ident_numeric_kind(self.state.cddl, ident).is_some_and(NumericKind::admits_int) {
-      self.find_single_map_entry_matching(entries, |key| matches!(key, Value::Integer(_)))
+    } else if ident_numeric_kind(self.state.cddl, ident).is_some() {
+      let cddl = self.state.cddl;
+      self.find_single_map_entry_matching(entries, |key| {
+        numeric_ident_matches_cbor_value(cddl, ident, key)
+      })
     } else if is_ident_bool_data_type(self.state.cddl, ident) {
       self.find_single_map_entry_matching(entries, |key| matches!(key, Value::Bool(_)))
     } else if is_ident_null_data_type(self.state.cddl, ident) {
       self.find_single_map_entry_matching(entries, |key| matches!(key, Value::Null))
     } else if is_ident_byte_string_data_type(self.state.cddl, ident) {
       self.find_single_map_entry_matching(entries, |key| matches!(key, Value::Bytes(_)))
-    } else if matches!(
-      ident_numeric_kind(self.state.cddl, ident),
-      Some(NumericKind::Float)
-    ) {
-      self.find_single_map_entry_matching(entries, |key| matches!(key, Value::Float(_)))
     } else if is_ident_bignum_data_type(self.state.cddl, ident) {
       let cddl = self.state.cddl;
       self.find_single_map_entry_matching(entries, |key| is_bignum_value(cddl, ident, key))
@@ -3976,20 +3974,13 @@ where
                 max_matches,
                 |key| matches!(key, Value::Text(_)),
               ))
-            } else if let Some(kind) =
-              ident_numeric_kind(self.state.cddl, ident).filter(|k| k.admits_int())
-            {
-              // `number` admits both, so this block also claims float keys; the
-              // float-only branch below is reserved for float-only types.
-              let admits_float = kind.admits_float();
+            } else if ident_numeric_kind(self.state.cddl, ident).is_some() {
+              let cddl = self.state.cddl;
               Some(Self::collect_unconsumed_map_entries_matching(
                 m,
                 claimed_entries,
                 max_matches,
-                |key| {
-                  matches!(key, Value::Integer(_))
-                    || (admits_float && matches!(key, Value::Float(_)))
-                },
+                |key| numeric_ident_matches_cbor_value(cddl, ident, key),
               ))
             } else if is_ident_bool_data_type(self.state.cddl, ident) {
               Some(Self::collect_unconsumed_map_entries_matching(
@@ -4011,16 +4002,6 @@ where
                 claimed_entries,
                 max_matches,
                 |key| matches!(key, Value::Null),
-              ))
-            } else if matches!(
-              ident_numeric_kind(self.state.cddl, ident),
-              Some(NumericKind::Float)
-            ) {
-              Some(Self::collect_unconsumed_map_entries_matching(
-                m,
-                claimed_entries,
-                max_matches,
-                |key| matches!(key, Value::Float(_)),
               ))
             } else if is_ident_bignum_data_type(self.state.cddl, ident) {
               let cddl = self.state.cddl;
@@ -4860,6 +4841,35 @@ where
     self.state.occurrence = Some(o.occur);
 
     Ok(())
+  }
+}
+
+/// Whether `v` belongs to the primitive numeric domain denoted by `ident`.
+///
+/// RFC 8610 Appendix D defines `uint` as CBOR major type 0, `nint` as major
+/// type 1, `number` as `int / float`, and `unsigned` as `uint / biguint`.
+/// This predicate classifies the untagged integer/float arms only. Float
+/// precision and general tagged-union handling are separate concerns.
+fn numeric_ident_matches_cbor_value(cddl: &CDDL, ident: &Identifier, v: &Value) -> bool {
+  let Some(kind) = ident_numeric_kind(cddl, ident) else {
+    return false;
+  };
+
+  match v {
+    Value::Integer(i) if kind.admits_int() => {
+      let is_negative = i128::from(*i).is_negative();
+      if matches!(lookup_ident(ident.ident), Token::UINT | Token::UNSIGNED)
+        || is_ident_uint_data_type(cddl, ident)
+      {
+        !is_negative
+      } else if is_ident_nint_data_type(cddl, ident) {
+        is_negative
+      } else {
+        true
+      }
+    }
+    Value::Float(_) => kind.admits_float(),
+    _ => false,
   }
 }
 

--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -524,7 +524,6 @@ impl<'a> CBORValidator<'a> {
   fn collect_unconsumed_map_entries_matching(
     entries: &[(Value, Value)],
     claimed_entries: &[usize],
-    max_matches: Option<usize>,
     predicate: impl Fn(&Value) -> bool,
   ) -> Vec<(usize, Value)> {
     entries
@@ -534,8 +533,54 @@ impl<'a> CBORValidator<'a> {
         (predicate(key) && Self::is_unconsumed_map_entry(entry_index, claimed_entries))
           .then(|| (entry_index, value.clone()))
       })
-      .take(max_matches.unwrap_or(usize::MAX))
       .collect()
+  }
+
+  fn repeating_member_upper_bound(entry: &ValueMemberKeyEntry<'a>) -> Option<usize> {
+    entry.occur.as_ref().and_then(|occurrence| {
+      if let Occur::Exact { upper, .. } = occurrence.occur {
+        upper
+      } else {
+        None
+      }
+    })
+  }
+
+  fn validate_repeating_member_count(&mut self, entry: &ValueMemberKeyEntry<'a>, count: usize) {
+    let Some(occurrence) = &entry.occur else {
+      return;
+    };
+    let member_key = entry
+      .member_key
+      .as_ref()
+      .map(ToString::to_string)
+      .unwrap_or_else(|| "member".to_string());
+
+    match occurrence.occur {
+      Occur::OneOrMore { .. } if count == 0 => self.add_error(format!(
+        "object must contain at least one entry matching {}",
+        member_key
+      )),
+      Occur::Exact {
+        lower: Some(lower),
+        upper,
+        ..
+      } if count < lower => match upper {
+        Some(upper) if lower == upper => self.add_error(format!(
+          "object must contain exactly {} entries matching {}",
+          lower, member_key
+        )),
+        Some(upper) => self.add_error(format!(
+          "object must contain between {} and {} entries matching {}",
+          lower, upper, member_key
+        )),
+        None => self.add_error(format!(
+          "object must contain at least {} entries matching {}",
+          lower, member_key
+        )),
+      },
+      _ => {}
+    }
   }
 
   /// Find the first unconsumed map entry for a primitive identifier used as a
@@ -3951,27 +3996,21 @@ where
 
             self.visit_value(&token::Value::TEXT(ident.ident.into()))
           }
-          Some(occur) => {
-            // Repeating primitive-key entries greedily claim unconsumed pairs
-            // in their key domain, up to any upper bound. The occurrence
-            // bounds apply to those matches, not to the enclosing map's size.
+          Some(_) => {
+            // Relay every unconsumed key-domain candidate to the group entry.
+            // It applies the value type provisionally and commits only
+            // complete pair matches, up to any occurrence upper bound.
             let claimed_entries = &self.claimed_map_entries;
-            let max_matches = match occur {
-              Occur::Exact { upper, .. } => *upper,
-              _ => None,
-            };
             let matches = if is_ident_any_type(self.state.cddl, ident) {
               Some(Self::collect_unconsumed_map_entries_matching(
                 m,
                 claimed_entries,
-                max_matches,
                 |_| true,
               ))
             } else if is_ident_string_data_type(self.state.cddl, ident) {
               Some(Self::collect_unconsumed_map_entries_matching(
                 m,
                 claimed_entries,
-                max_matches,
                 |key| matches!(key, Value::Text(_)),
               ))
             } else if ident_numeric_kind(self.state.cddl, ident).is_some() {
@@ -3979,28 +4018,24 @@ where
               Some(Self::collect_unconsumed_map_entries_matching(
                 m,
                 claimed_entries,
-                max_matches,
                 |key| numeric_ident_matches_cbor_value(cddl, ident, key),
               ))
             } else if is_ident_bool_data_type(self.state.cddl, ident) {
               Some(Self::collect_unconsumed_map_entries_matching(
                 m,
                 claimed_entries,
-                max_matches,
                 |key| matches!(key, Value::Bool(_)),
               ))
             } else if is_ident_byte_string_data_type(self.state.cddl, ident) {
               Some(Self::collect_unconsumed_map_entries_matching(
                 m,
                 claimed_entries,
-                max_matches,
                 |key| matches!(key, Value::Bytes(_)),
               ))
             } else if is_ident_null_data_type(self.state.cddl, ident) {
               Some(Self::collect_unconsumed_map_entries_matching(
                 m,
                 claimed_entries,
-                max_matches,
                 |key| matches!(key, Value::Null),
               ))
             } else if is_ident_bignum_data_type(self.state.cddl, ident) {
@@ -4008,7 +4043,6 @@ where
               Some(Self::collect_unconsumed_map_entries_matching(
                 m,
                 claimed_entries,
-                max_matches,
                 |key| is_bignum_value(cddl, ident, key),
               ))
             } else {
@@ -4016,43 +4050,7 @@ where
             };
 
             if let Some(map_entry_candidates) = matches {
-              let count = map_entry_candidates.len();
               self.map_entry_candidates = Some(map_entry_candidates);
-              match occur {
-                Occur::ZeroOrMore { .. } => {}
-                Occur::OneOrMore { .. } if count == 0 => self.add_error(format!(
-                  "object must contain at least one entry with key type {}",
-                  ident
-                )),
-                Occur::OneOrMore { .. } => {}
-                Occur::Exact { lower, upper, .. } => {
-                  if lower.is_some_and(|lower| count < lower)
-                    || upper.is_some_and(|upper| count > upper)
-                  {
-                    match (lower, upper) {
-                      (Some(lower), Some(upper)) if lower == upper => self.add_error(format!(
-                        "object must contain exactly {} entries with key type {}",
-                        lower, ident,
-                      )),
-                      (Some(lower), Some(upper)) => self.add_error(format!(
-                        "object must contain between {} and {} entries with key type {}",
-                        lower, upper, ident,
-                      )),
-                      (Some(lower), None) => self.add_error(format!(
-                        "object must contain at least {} entries with key type {}",
-                        lower, ident,
-                      )),
-                      (None, Some(upper)) => self.add_error(format!(
-                        "object must contain no more than {} entries with key type {}",
-                        upper, ident,
-                      )),
-                      (None, None) => {}
-                    }
-                  }
-                }
-                Occur::Optional { .. } => {}
-              }
-
               return Ok(());
             }
 
@@ -4119,12 +4117,6 @@ where
         let object_value = self.object_value.take();
         member_key_result?;
 
-        if let Some(candidates) = &map_entry_candidates {
-          self
-            .claimed_map_entries
-            .extend(candidates.iter().map(|(entry_index, _)| *entry_index));
-        }
-
         // Move to next entry if member key validation fails
         if self.errors.len() != error_count {
           self.state.advance_to_next_entry = true;
@@ -4138,17 +4130,15 @@ where
 
     if let Some(candidates) = map_entry_candidates {
       debug_assert!(object_value.is_none());
-      for (_, value) in candidates {
-        #[cfg(all(feature = "additional-controls", target_arch = "wasm32"))]
-        let mut cv =
-          CBORValidator::new(self.state.cddl, value, self.state.enabled_features.clone());
-        #[cfg(all(feature = "additional-controls", not(target_arch = "wasm32")))]
-        let mut cv = CBORValidator::new(self.state.cddl, value, self.state.enabled_features);
-        #[cfg(not(feature = "additional-controls"))]
-        let mut cv = CBORValidator::new(self.state.cddl, value);
+      let max_matches = Self::repeating_member_upper_bound(entry).unwrap_or(usize::MAX);
+      let mut match_count = 0;
 
-        cv.state.generic_rules = self.state.generic_rules.clone();
-        cv.state.eval_generic_rule = self.state.eval_generic_rule;
+      for (entry_index, value) in candidates {
+        if match_count == max_matches {
+          break;
+        }
+
+        let mut cv = self.new_with_recursion_state(value);
         cv.state.is_multi_type_choice = self.state.is_multi_type_choice;
         cv.state.is_multi_group_choice = self.state.is_multi_group_choice;
         cv.state.data_location.push_str(&self.state.data_location);
@@ -4158,12 +4148,14 @@ where
 
         self.state.data_location = current_location.clone();
 
-        self.errors.append(&mut cv.errors);
-        if entry.occur.is_some() {
-          self.state.occurrence = None;
+        if cv.errors.is_empty() {
+          self.claimed_map_entries.push(entry_index);
+          match_count += 1;
         }
       }
 
+      self.validate_repeating_member_count(entry, match_count);
+      self.state.occurrence = None;
       return Ok(());
     }
 

--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -139,6 +139,20 @@ impl<T: std::fmt::Debug> Error<T> {
   }
 }
 
+#[derive(Clone)]
+struct GenericEvaluationContext<'a> {
+  rule_name: &'a str,
+  args: Vec<Type1<'a>>,
+}
+
+#[derive(Clone)]
+struct SingleMapEntryClaim<'a> {
+  entry_index: usize,
+  validated_key_index: usize,
+  entry: Option<ValueMemberKeyEntry<'a>>,
+  generic_context: Option<GenericEvaluationContext<'a>>,
+}
+
 /// cbor validator type
 #[derive(Clone)]
 pub struct CBORValidator<'a> {
@@ -153,6 +167,14 @@ pub struct CBORValidator<'a> {
   cut_value: Option<Type1<'a>>,
   // Collect map entry keys that have already been validated
   validated_keys: Option<Vec<Value>>,
+  // Direct non-repeating claims used by physical-pair allocation. Each claim
+  // retains the member context needed for transactional reassignment.
+  single_entry_claims: Vec<SingleMapEntryClaim<'a>>,
+  // Claim created by the member key currently being visited.
+  active_single_entry_claim: Option<usize>,
+  // Isolated compatibility probes must not recursively start another map
+  // assignment search when the tested pair does not match.
+  probing_single_entry_assignment: bool,
   // Collect map entry values that have yet to be validated
   values_to_validate: Option<Vec<Value>>,
   // Whether or not the validator is validating a map entry value
@@ -172,6 +194,9 @@ impl<'a> CBORValidator<'a> {
       object_value: None,
       cut_value: None,
       validated_keys: None,
+      single_entry_claims: Vec::new(),
+      active_single_entry_claim: None,
+      probing_single_entry_assignment: false,
       values_to_validate: None,
       validating_value: false,
       range_upper: None,
@@ -189,6 +214,9 @@ impl<'a> CBORValidator<'a> {
       object_value: None,
       cut_value: None,
       validated_keys: None,
+      single_entry_claims: Vec::new(),
+      active_single_entry_claim: None,
+      probing_single_entry_assignment: false,
       values_to_validate: None,
       validating_value: false,
       range_upper: None,
@@ -206,6 +234,9 @@ impl<'a> CBORValidator<'a> {
       object_value: None,
       cut_value: None,
       validated_keys: None,
+      single_entry_claims: Vec::new(),
+      active_single_entry_claim: None,
+      probing_single_entry_assignment: false,
       values_to_validate: None,
       validating_value: false,
       range_upper: None,
@@ -223,6 +254,9 @@ impl<'a> CBORValidator<'a> {
       object_value: None,
       cut_value: None,
       validated_keys: None,
+      single_entry_claims: Vec::new(),
+      active_single_entry_claim: None,
+      probing_single_entry_assignment: false,
       values_to_validate: None,
       validating_value: false,
       range_upper: None,
@@ -232,6 +266,330 @@ impl<'a> CBORValidator<'a> {
   /// Extract the underlying CBOR Value.
   pub fn extract_cbor(self) -> Value {
     self.cbor
+  }
+
+  /// Claim one map entry for a member-key type that has no repeating
+  /// occurrence. A missing optional entry skips its value type entirely.
+  fn claim_single_map_entry(
+    &mut self,
+    entry: Option<(usize, Value, Value)>,
+    entry_optional: bool,
+  ) -> bool {
+    if let Some((entry_index, key, value)) = entry {
+      self.claim_single_map_key(entry_index, key);
+      let _ = write!(self.state.data_location, "/{:?}", value);
+      self.object_value = Some(value);
+      true
+    } else {
+      if entry_optional {
+        self.state.occurrence = None;
+        self.state.advance_to_next_entry = true;
+      }
+      false
+    }
+  }
+
+  fn claim_single_map_key(&mut self, entry_index: usize, key: Value) {
+    let generic_context = self.current_generic_evaluation_context();
+    let validated_keys = self.validated_keys.get_or_insert_with(Vec::new);
+    let validated_key_index = validated_keys.len();
+    validated_keys.push(key.clone());
+    self.single_entry_claims.push(SingleMapEntryClaim {
+      entry_index,
+      validated_key_index,
+      entry: None,
+      generic_context,
+    });
+    self.active_single_entry_claim = Some(self.single_entry_claims.len() - 1);
+  }
+
+  fn remove_single_map_entry_claim(&mut self, claim_position: usize) {
+    let claim = self.single_entry_claims.remove(claim_position);
+
+    if let Some(keys) = &mut self.validated_keys {
+      if claim.validated_key_index < keys.len() {
+        keys.remove(claim.validated_key_index);
+        for remaining_claim in &mut self.single_entry_claims {
+          if remaining_claim.validated_key_index > claim.validated_key_index {
+            remaining_claim.validated_key_index -= 1;
+          }
+        }
+      }
+    }
+  }
+
+  fn member_key_has_cut(entry: &ValueMemberKeyEntry<'a>) -> bool {
+    matches!(
+      entry.member_key.as_ref(),
+      Some(MemberKey::Bareword { .. } | MemberKey::Value { .. })
+        | Some(MemberKey::Type1 { is_cut: true, .. })
+    )
+  }
+
+  fn current_generic_evaluation_context(&self) -> Option<GenericEvaluationContext<'a>> {
+    let rule_name = self.state.eval_generic_rule?;
+    let rule = self
+      .state
+      .generic_rules
+      .iter()
+      .find(|rule| rule.name == rule_name)?;
+    let current_args_start = rule.args.len().checked_sub(rule.params.len())?;
+
+    Some(GenericEvaluationContext {
+      rule_name,
+      args: rule.args[current_args_start..].to_vec(),
+    })
+  }
+
+  fn single_pair_validates_entry<T: std::fmt::Debug + 'static>(
+    &self,
+    entry: &ValueMemberKeyEntry<'a>,
+    generic_context: Option<&GenericEvaluationContext<'a>>,
+    key: Value,
+    value: Value,
+  ) -> std::result::Result<bool, Error<T>>
+  where
+    cbor::Error<T>: From<cbor::Error<std::io::Error>>,
+  {
+    let mut candidate = self.new_with_recursion_state(Value::Map(vec![(key, value)]));
+    candidate.state.eval_generic_rule = generic_context.map(|context| context.rule_name);
+    if let Some(context) = generic_context {
+      if let Some(rule) = candidate
+        .state
+        .generic_rules
+        .iter_mut()
+        .find(|rule| rule.name == context.rule_name)
+      {
+        rule.args = context.args.clone();
+      }
+    }
+    candidate.state.is_multi_type_choice = self.state.is_multi_type_choice;
+    candidate.state.is_multi_group_choice = self.state.is_multi_group_choice;
+    candidate.state.type_group_name_entry = self.state.type_group_name_entry;
+    candidate.probing_single_entry_assignment = true;
+
+    // A pair assigned to this member must satisfy it. Do not let an optional
+    // occurrence turn a failed key match into a successful absence.
+    let mut required_entry = entry.clone();
+    required_entry.occur = None;
+    candidate.visit_value_member_key_entry(&required_entry)?;
+
+    Ok(candidate.errors.is_empty() && candidate.single_entry_claims.len() == 1)
+  }
+
+  /// Finds an augmenting path in the member-to-map-pair compatibility graph.
+  ///
+  /// This is the DFS form of maximum bipartite matching, often called Kuhn's
+  /// algorithm:
+  /// <https://cp-algorithms.com/graph/kuhn_maximum_bipartite_matching.html>
+  fn augment_single_entry_assignment(
+    claim_slot: usize,
+    compatibility: &[Vec<bool>],
+    visited_entries: &mut [bool],
+    entry_owners: &mut [Option<usize>],
+  ) -> bool {
+    for entry_slot in 0..compatibility[claim_slot].len() {
+      if !compatibility[claim_slot][entry_slot] || visited_entries[entry_slot] {
+        continue;
+      }
+      visited_entries[entry_slot] = true;
+
+      if entry_owners[entry_slot].is_none_or(|owner| {
+        Self::augment_single_entry_assignment(owner, compatibility, visited_entries, entry_owners)
+      }) {
+        entry_owners[entry_slot] = Some(claim_slot);
+        return true;
+      }
+    }
+
+    false
+  }
+
+  /// Reassign the direct single-entry claims after the current member's
+  /// initially selected pair fails value validation. Pair compatibility is
+  /// evaluated from complete member schemas, and a new allocation is
+  /// committed only when every participating claim has a distinct pair.
+  fn try_reassign_failed_single_entries<T: std::fmt::Debug + 'static>(
+    &mut self,
+    current_claim_position: usize,
+    current_entry: &ValueMemberKeyEntry<'a>,
+    current_generic_context: Option<GenericEvaluationContext<'a>>,
+  ) -> std::result::Result<bool, Error<T>>
+  where
+    cbor::Error<T>: From<cbor::Error<std::io::Error>>,
+  {
+    let entries = match &self.cbor {
+      Value::Map(entries) => entries.clone(),
+      _ => return Ok(false),
+    };
+
+    let mut claim_positions = Vec::new();
+    let mut claim_entries = Vec::new();
+    let mut claim_generic_contexts = Vec::new();
+    let mut entry_indices = Vec::new();
+    for (claim_position, claim) in self.single_entry_claims.iter().enumerate() {
+      let entry = if claim_position == current_claim_position {
+        current_entry.clone()
+      } else if let Some(entry) = &claim.entry {
+        entry.clone()
+      } else {
+        continue;
+      };
+
+      if entries.get(claim.entry_index).is_none() || entry_indices.contains(&claim.entry_index) {
+        return Ok(false);
+      }
+      claim_positions.push(claim_position);
+      claim_entries.push(entry);
+      claim_generic_contexts.push(if claim_position == current_claim_position {
+        current_generic_context.clone()
+      } else {
+        claim.generic_context.clone()
+      });
+      entry_indices.push(claim.entry_index);
+    }
+
+    if !claim_positions.contains(&current_claim_position) || claim_positions.len() < 2 {
+      return Ok(false);
+    }
+
+    let mut compatibility = vec![vec![false; entry_indices.len()]; claim_positions.len()];
+    for (claim_slot, entry) in claim_entries.iter().enumerate() {
+      for (entry_slot, entry_index) in entry_indices.iter().enumerate() {
+        let (key, value) = entries[*entry_index].clone();
+        compatibility[claim_slot][entry_slot] = self.single_pair_validates_entry::<T>(
+          entry,
+          claim_generic_contexts[claim_slot].as_ref(),
+          key,
+          value,
+        )?;
+      }
+    }
+
+    let mut entry_owners = vec![None; entry_indices.len()];
+    for claim_slot in 0..claim_positions.len() {
+      let mut visited_entries = vec![false; entry_indices.len()];
+      if !Self::augment_single_entry_assignment(
+        claim_slot,
+        &compatibility,
+        &mut visited_entries,
+        &mut entry_owners,
+      ) {
+        return Ok(false);
+      }
+    }
+
+    let mut assigned_entry_slots = vec![None; claim_positions.len()];
+    for (entry_slot, claim_slot) in entry_owners.into_iter().enumerate() {
+      if let Some(claim_slot) = claim_slot {
+        assigned_entry_slots[claim_slot] = Some(entry_slot);
+      }
+    }
+
+    for (claim_slot, claim_position) in claim_positions.into_iter().enumerate() {
+      let entry_slot = match assigned_entry_slots[claim_slot] {
+        Some(entry_slot) => entry_slot,
+        None => return Ok(false),
+      };
+      let entry_index = entry_indices[entry_slot];
+      let key = entries[entry_index].0.clone();
+      let claim = &mut self.single_entry_claims[claim_position];
+      claim.entry_index = entry_index;
+      claim.entry = Some(claim_entries[claim_slot].clone());
+      claim.generic_context = claim_generic_contexts[claim_slot].clone();
+      if let Some(keys) = &mut self.validated_keys {
+        keys[claim.validated_key_index] = key;
+      }
+    }
+
+    Ok(true)
+  }
+
+  /// Whether the physical entry at `entry_index` is still available.
+  ///
+  /// Counting equivalent earlier entries keeps two physical pairs distinct
+  /// even when their decoded keys compare equal (for example duplicate text
+  /// keys or +0/-0 float keys).
+  fn is_unconsumed_map_entry(
+    entries: &[(Value, Value)],
+    entry_index: usize,
+    claimed_keys: Option<&[Value]>,
+  ) -> bool {
+    let key = &entries[entry_index].0;
+    Self::is_unconsumed_equivalent_key(
+      key,
+      entries[..entry_index]
+        .iter()
+        .map(|(candidate, _)| candidate),
+      claimed_keys,
+    )
+  }
+
+  fn is_unconsumed_equivalent_key<'k>(
+    key: &Value,
+    earlier_keys: impl Iterator<Item = &'k Value>,
+    claimed_keys: Option<&[Value]>,
+  ) -> bool {
+    let earlier_equivalent_keys = earlier_keys.filter(|candidate| *candidate == key).count();
+    let consumed_equivalent_keys = claimed_keys.map_or(0, |keys| {
+      keys.iter().filter(|candidate| *candidate == key).count()
+    });
+
+    earlier_equivalent_keys >= consumed_equivalent_keys
+  }
+
+  fn find_unconsumed_map_entry<'m>(
+    entries: &'m [(Value, Value)],
+    claimed_keys: Option<&[Value]>,
+    predicate: impl Fn(&Value) -> bool,
+  ) -> Option<(usize, &'m (Value, Value))> {
+    entries.iter().enumerate().find(|(entry_index, (key, _))| {
+      predicate(key) && Self::is_unconsumed_map_entry(entries, *entry_index, claimed_keys)
+    })
+  }
+
+  fn find_single_map_entry_matching(
+    &self,
+    entries: &[(Value, Value)],
+    predicate: impl Fn(&Value) -> bool,
+  ) -> Option<(usize, Value, Value)> {
+    Self::find_unconsumed_map_entry(entries, self.validated_keys.as_deref(), predicate)
+      .map(|(entry_index, (key, value))| (entry_index, key.clone(), value.clone()))
+  }
+
+  /// Find the first unconsumed map entry for a primitive identifier used as a
+  /// non-repeating member key. The outer option indicates whether the
+  /// identifier is one of the key domains handled by this fast path.
+  fn find_single_map_entry(
+    &self,
+    entries: &[(Value, Value)],
+    ident: &Identifier<'a>,
+  ) -> Option<Option<(usize, Value, Value)>> {
+    let entry = if is_ident_any_type(self.state.cddl, ident) {
+      self.find_single_map_entry_matching(entries, |_| true)
+    } else if is_ident_string_data_type(self.state.cddl, ident) {
+      self.find_single_map_entry_matching(entries, |key| matches!(key, Value::Text(_)))
+    } else if ident_numeric_kind(self.state.cddl, ident).is_some_and(NumericKind::admits_int) {
+      self.find_single_map_entry_matching(entries, |key| matches!(key, Value::Integer(_)))
+    } else if is_ident_bool_data_type(self.state.cddl, ident) {
+      self.find_single_map_entry_matching(entries, |key| matches!(key, Value::Bool(_)))
+    } else if is_ident_null_data_type(self.state.cddl, ident) {
+      self.find_single_map_entry_matching(entries, |key| matches!(key, Value::Null))
+    } else if is_ident_byte_string_data_type(self.state.cddl, ident) {
+      self.find_single_map_entry_matching(entries, |key| matches!(key, Value::Bytes(_)))
+    } else if matches!(
+      ident_numeric_kind(self.state.cddl, ident),
+      Some(NumericKind::Float)
+    ) {
+      self.find_single_map_entry_matching(entries, |key| matches!(key, Value::Float(_)))
+    } else if is_ident_bignum_data_type(self.state.cddl, ident) {
+      let cddl = self.state.cddl;
+      self.find_single_map_entry_matching(entries, |key| is_bignum_value(cddl, ident, key))
+    } else {
+      return None;
+    };
+
+    Some(entry)
   }
 
   /// Create a new CBORValidator with inherited recursion state
@@ -726,6 +1084,103 @@ impl<'a> CBORValidator<'a> {
       Ok(None)
     }
   }
+
+  fn visit_group_transactional<T: std::fmt::Debug + 'static>(
+    &mut self,
+    group: &Group<'a>,
+    map_keys: Option<&[Value]>,
+  ) -> visitor::Result<Error<T>>
+  where
+    cbor::Error<T>: From<cbor::Error<std::io::Error>>,
+  {
+    if group.group_choices.len() > 1 {
+      self.state.is_multi_group_choice = true;
+    }
+
+    // Map equality/inequality validation
+    if self.state.is_ctrl_map_equality {
+      if let Some(t) = &self.state.ctrl {
+        if let Value::Map(m) = &self.cbor {
+          let entry_counts = entry_counts_from_group(self.state.cddl, group);
+          let len = m.len();
+          if let ControlOperator::EQ | ControlOperator::NE = t {
+            if !validate_entry_count(&entry_counts, len) {
+              for ec in entry_counts.iter() {
+                if let Some(occur) = &ec.entry_occurrence {
+                  self.add_error(format!(
+                    "expected array with length per occurrence {}",
+                    occur,
+                  ));
+                } else {
+                  self.add_error(format!(
+                    "expected array with length {}, got {}",
+                    ec.count, len
+                  ));
+                }
+              }
+              return Ok(());
+            }
+          }
+        }
+      }
+    }
+
+    self.state.is_ctrl_map_equality = false;
+
+    let initial_error_count = self.errors.len();
+    let checkpoint = self.clone();
+    let mut choice_errors = Vec::new();
+
+    for group_choice in group.group_choices.iter() {
+      let mut candidate = checkpoint.clone();
+      candidate.errors.truncate(initial_error_count);
+      let error_count = candidate.errors.len();
+      candidate.visit_group_choice(group_choice)?;
+
+      let mut has_parent_visible_unexpected_key = false;
+      if candidate.errors.len() == error_count {
+        if let Some(keys) = map_keys {
+          for (entry_index, key) in keys.iter().enumerate() {
+            if Self::is_unconsumed_equivalent_key(
+              key,
+              keys[..entry_index].iter(),
+              candidate.validated_keys.as_deref(),
+            ) {
+              // Preserve the parent's existing no-retry behavior for an
+              // ordinary unmatched key. Retry only when the new multiplicity
+              // check exposes an equivalent physical pair that the parent's
+              // membership check would have hidden.
+              if !candidate
+                .validated_keys
+                .as_ref()
+                .is_some_and(|claimed_keys| claimed_keys.contains(key))
+              {
+                has_parent_visible_unexpected_key = true;
+              }
+              candidate.add_error(format!("unexpected key {:?}", key));
+            }
+          }
+        }
+      }
+
+      if has_parent_visible_unexpected_key {
+        *self = candidate;
+        return Ok(());
+      }
+
+      if candidate.errors.len() == error_count {
+        *self = candidate;
+        return Ok(());
+      }
+
+      choice_errors.extend(candidate.errors.into_iter().skip(initial_error_count));
+    }
+
+    *self = checkpoint;
+    self.errors.truncate(initial_error_count);
+    self.errors.extend(choice_errors);
+    Ok(())
+  }
 }
 
 // Resolved range endpoint. RFC 8610 §2.2.2.1: ranges are defined between two
@@ -980,59 +1435,7 @@ where
   }
 
   fn visit_group(&mut self, g: &Group<'a>) -> visitor::Result<Error<T>> {
-    if g.group_choices.len() > 1 {
-      self.state.is_multi_group_choice = true;
-    }
-
-    // Map equality/inequality validation
-    if self.state.is_ctrl_map_equality {
-      if let Some(t) = &self.state.ctrl {
-        if let Value::Map(m) = &self.cbor {
-          let entry_counts = entry_counts_from_group(self.state.cddl, g);
-          let len = m.len();
-          if let ControlOperator::EQ | ControlOperator::NE = t {
-            if !validate_entry_count(&entry_counts, len) {
-              for ec in entry_counts.iter() {
-                if let Some(occur) = &ec.entry_occurrence {
-                  self.add_error(format!(
-                    "expected array with length per occurrence {}",
-                    occur,
-                  ));
-                } else {
-                  self.add_error(format!(
-                    "expected array with length {}, got {}",
-                    ec.count, len
-                  ));
-                }
-              }
-              return Ok(());
-            }
-          }
-        }
-      }
-    }
-
-    self.state.is_ctrl_map_equality = false;
-
-    let initial_error_count = self.errors.len();
-    for group_choice in g.group_choices.iter() {
-      let error_count = self.errors.len();
-      self.visit_group_choice(group_choice)?;
-      if self.errors.len() == error_count {
-        // Disregard invalid group choice validation errors if one of the
-        // choices validates successfully
-        let group_choice_error_count = self.errors.len() - initial_error_count;
-        if group_choice_error_count > 0 {
-          for _ in 0..group_choice_error_count {
-            self.errors.pop();
-          }
-        }
-
-        return Ok(());
-      }
-    }
-
-    Ok(())
+    self.visit_group_transactional::<T>(g, None)
   }
 
   fn visit_group_choice(&mut self, gc: &GroupChoice<'a>) -> visitor::Result<Error<T>> {
@@ -2667,24 +3070,12 @@ where
           }
 
           #[allow(clippy::needless_collect)]
-          let m = m.iter().map(|entry| entry.0.clone()).collect::<Vec<_>>();
+          let keys = m.iter().map(|entry| entry.0.clone()).collect::<Vec<_>>();
 
-          self.visit_group(group)?;
-
-          // A key is unexpected unless some group entry consumed it
-          // (validated_keys of None is an empty consumed set). This runs after
-          // the whole group has been visited so that a key rejected by one
-          // entry can still be claimed by a later one, which is what makes
-          // wildcard entry order irrelevant.
-          for k in m.into_iter() {
-            if !self
-              .validated_keys
-              .as_ref()
-              .is_some_and(|keys| keys.contains(&k))
-            {
-              self.add_error(format!("unexpected key {:?}", k));
-            }
-          }
+          // A map-group alternative succeeds only after every physical key is
+          // accounted for. This lets an unexpected-key failure retry the next
+          // alternative with the original claim state.
+          self.visit_group_transactional::<T>(group, Some(&keys))?;
 
           self.state.is_cut_present = false;
           self.cut_value = None;
@@ -3536,132 +3927,14 @@ where
         match &self.state.occurrence {
           #[cfg(feature = "ast-span")]
           Some(Occur::Optional { .. }) | None => {
-            // An `any`-keyed entry matches any map entry; consume the first
-            // not-yet-validated one
-            if is_ident_any_type(self.state.cddl, ident) && !self.validating_value {
-              if let Some((k, v)) = m.iter().find(|(k, _)| {
-                !self
-                  .validated_keys
-                  .as_ref()
-                  .is_some_and(|keys| keys.contains(k))
-              }) {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                let _ = write!(self.state.data_location, "/{:?}", v);
-              } else if !entry_optional {
-                self.add_error(format!("map requires entry key of type {}", ident));
+            if !self.validating_value {
+              let entries = m.clone();
+              if let Some(entry) = self.find_single_map_entry(&entries, ident) {
+                if !self.claim_single_map_entry(entry, entry_optional) && !entry_optional {
+                  self.add_error(format!("map requires entry key of type {}", ident));
+                }
+                return Ok(());
               }
-              return Ok(());
-            }
-
-            if is_ident_string_data_type(self.state.cddl, ident) && !self.validating_value {
-              if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Text(_))) {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                let _ = write!(self.state.data_location, "/{:?}", v);
-              } else if !entry_optional {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
-              return Ok(());
-            }
-
-            if ident_numeric_kind(self.state.cddl, ident).is_some_and(NumericKind::admits_int)
-              && !self.validating_value
-            {
-              if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Integer(_))) {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                let _ = write!(self.state.data_location, "/{:?}", v);
-              } else if !entry_optional {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
-              return Ok(());
-            }
-
-            if is_ident_bool_data_type(self.state.cddl, ident) && !self.validating_value {
-              if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Bool(_))) {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                let _ = write!(self.state.data_location, "/{:?}", v);
-              } else if !entry_optional {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
-              return Ok(());
-            }
-
-            if is_ident_null_data_type(self.state.cddl, ident) && !self.validating_value {
-              if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Null)) {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                let _ = write!(self.state.data_location, "/{:?}", v);
-              } else if !entry_optional {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
-              return Ok(());
-            }
-
-            if is_ident_byte_string_data_type(self.state.cddl, ident) && !self.validating_value {
-              if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Bytes(_))) {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                let _ = write!(self.state.data_location, "/{:?}", v);
-              } else if !entry_optional {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
-              return Ok(());
-            }
-
-            if matches!(
-              ident_numeric_kind(self.state.cddl, ident),
-              Some(NumericKind::Float)
-            ) && !self.validating_value
-            {
-              if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Float(_))) {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                let _ = write!(self.state.data_location, "/{:?}", v);
-              } else if !entry_optional {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
-              return Ok(());
-            }
-
-            if is_ident_bignum_data_type(self.state.cddl, ident) && !self.validating_value {
-              if let Some((k, v)) = m
-                .iter()
-                .find(|(k, _)| is_bignum_value(self.state.cddl, ident, k))
-              {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                let _ = write!(self.state.data_location, "/{:?}", v);
-              } else {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
-              return Ok(());
             }
 
             if token::lookup_ident(ident.ident)
@@ -3679,133 +3952,14 @@ where
           }
           #[cfg(not(feature = "ast-span"))]
           Some(Occur::Optional {}) | None => {
-            // An `any`-keyed entry matches any map entry; consume the first
-            // not-yet-validated one
-            if is_ident_any_type(self.state.cddl, ident) && !self.validating_value {
-              if let Some((k, v)) = m.iter().find(|(k, _)| {
-                !self
-                  .validated_keys
-                  .as_ref()
-                  .is_some_and(|keys| keys.contains(k))
-              }) {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                self.state.data_location.push_str(&format!("/{:?}", v));
-              } else if !entry_optional {
-                self.add_error(format!("map requires entry key of type {}", ident));
+            if !self.validating_value {
+              let entries = m.clone();
+              if let Some(entry) = self.find_single_map_entry(&entries, ident) {
+                if !self.claim_single_map_entry(entry, entry_optional) && !entry_optional {
+                  self.add_error(format!("map requires entry key of type {}", ident));
+                }
+                return Ok(());
               }
-              return Ok(());
-            }
-
-            if is_ident_string_data_type(self.state.cddl, ident) && !self.validating_value {
-              if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Text(_))) {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                self.state.data_location.push_str(&format!("/{}", value));
-              } else if !entry_optional {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
-
-              return Ok(());
-            }
-
-            if ident_numeric_kind(self.state.cddl, ident).is_some_and(NumericKind::admits_int)
-              && !self.validating_value
-            {
-              if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Integer(_))) {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                self.state.data_location.push_str(&format!("/{}", value));
-              } else if !entry_optional {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
-              return Ok(());
-            }
-
-            if is_ident_bool_data_type(self.state.cddl, ident) && !self.validating_value {
-              if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Bool(_))) {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                self.state.data_location.push_str(&format!("/{}", value));
-              } else if !entry_optional {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
-              return Ok(());
-            }
-
-            if is_ident_null_data_type(self.state.cddl, ident) && !self.validating_value {
-              if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Null)) {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                self.state.data_location.push_str(&format!("/{}", value));
-              } else if !entry_optional {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
-              return Ok(());
-            }
-
-            if is_ident_byte_string_data_type(self.state.cddl, ident) && !self.validating_value {
-              if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Bytes(_))) {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                self.state.data_location.push_str(&format!("/{}", value));
-              } else if !entry_optional {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
-              return Ok(());
-            }
-
-            if matches!(
-              ident_numeric_kind(self.state.cddl, ident),
-              Some(NumericKind::Float)
-            ) && !self.validating_value
-            {
-              if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Float(_))) {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                self.state.data_location.push_str(&format!("/{}", value));
-              } else if !entry_optional {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
-              return Ok(());
-            }
-
-            if is_ident_bignum_data_type(self.state.cddl, ident) && !self.validating_value {
-              if let Some((k, v)) = m
-                .iter()
-                .find(|(k, _)| is_bignum_value(self.state.cddl, ident, k))
-              {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                self.state.data_location.push_str(&format!("/{}", value));
-              } else {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
-              return Ok(());
             }
 
             if token::lookup_ident(ident.ident)
@@ -4374,13 +4528,17 @@ where
       self.visit_occurrence(occur)?;
     }
 
+    let entry_error_count = self.errors.len();
     let current_location = self.state.data_location.clone();
+    self.active_single_entry_claim = None;
 
+    let mut entry_claim_position = None;
     if let Some(mk) = &entry.member_key {
       let error_count = self.errors.len();
       self.state.is_member_key = true;
       self.visit_memberkey(mk)?;
       self.state.is_member_key = false;
+      entry_claim_position = self.active_single_entry_claim.take();
 
       // Move to next entry if member key validation fails
       if self.errors.len() != error_count {
@@ -4440,7 +4598,43 @@ where
 
       self.state.data_location = current_location;
 
+      let value_valid = cv.errors.is_empty();
       self.errors.append(&mut cv.errors);
+
+      // Key selection is necessarily earlier than value validation. If the
+      // selected pair fails, another one-to-one assignment of the direct
+      // claims can still validate. Search that assignment transactionally
+      // before retaining this error.
+      if !value_valid && !self.probing_single_entry_assignment {
+        if let Some(claim_position) = entry_claim_position {
+          let generic_context = self.current_generic_evaluation_context();
+          if self.try_reassign_failed_single_entries::<T>(claim_position, entry, generic_context)? {
+            self.errors.truncate(entry_error_count);
+          } else if entry
+            .occur
+            .as_ref()
+            .is_some_and(|occur| matches!(occur.occur, Occur::Optional { .. }))
+            && !Self::member_key_has_cut(entry)
+          {
+            // An optional entry without a cut matches a complete key/value
+            // pair, not the key alone (RFC 8610 §3.5.4). If its selected
+            // value fails and no alternative assignment works, leave the
+            // pair available to a later member and take the zero-width path.
+            self.remove_single_map_entry_claim(claim_position);
+            self.errors.truncate(entry_error_count);
+            self.state.advance_to_next_entry = true;
+          }
+        }
+      }
+
+      if self.errors.len() == entry_error_count {
+        if let Some(claim) = entry_claim_position
+          .and_then(|claim_position| self.single_entry_claims.get_mut(claim_position))
+        {
+          claim.entry = Some(entry.clone());
+        }
+      }
+
       if entry.occur.is_some() {
         self.state.occurrence = None;
       }
@@ -4498,15 +4692,78 @@ where
         cv.state.is_multi_type_choice = self.state.is_multi_type_choice;
         cv.visit_rule(rule)?;
 
+        let child_succeeded = cv.errors.is_empty();
         self.errors.append(&mut cv.errors);
 
-        // The child validated the same map in the same group context, so keys
-        // it consumed count toward this validator's unexpected-key check
-        if let Some(keys) = cv.validated_keys {
-          self
-            .validated_keys
-            .get_or_insert_with(Vec::new)
-            .extend(keys);
+        if child_succeeded {
+          // The child starts with fresh state, so it can select a physical pair
+          // already claimed by the parent. Preserve the parent's historical
+          // generic isolation, but relocate a colliding direct claim through
+          // transactional assignment instead of counting the same index
+          // twice. Non-overlapping direct and occurrence-aware claims still
+          // contribute to the parent ledger.
+          if let Some(child_validated_keys) = cv.validated_keys {
+            for (child_key_index, key) in child_validated_keys.into_iter().enumerate() {
+              if let Some(child_claim) = cv
+                .single_entry_claims
+                .iter()
+                .find(|claim| claim.validated_key_index == child_key_index)
+              {
+                if self
+                  .single_entry_claims
+                  .iter()
+                  .any(|claim| claim.entry_index == child_claim.entry_index)
+                {
+                  let child_entry = match &child_claim.entry {
+                    Some(entry) => entry.clone(),
+                    None => continue,
+                  };
+                  let entries = match &self.cbor {
+                    Value::Map(entries) => entries.clone(),
+                    _ => continue,
+                  };
+                  let placeholder = entries.iter().enumerate().find(|(entry_index, _)| {
+                    !self
+                      .single_entry_claims
+                      .iter()
+                      .any(|claim| claim.entry_index == *entry_index)
+                  });
+                  let (placeholder_index, (placeholder_key, _)) = match placeholder {
+                    Some(placeholder) => placeholder,
+                    None => continue,
+                  };
+
+                  let validated_key_count = self.validated_keys.as_ref().map_or(0, Vec::len);
+                  self.claim_single_map_key(placeholder_index, placeholder_key.clone());
+                  let parent_claim_position = self.single_entry_claims.len() - 1;
+                  let parent_claim = &mut self.single_entry_claims[parent_claim_position];
+                  parent_claim.entry = Some(child_entry.clone());
+                  parent_claim.generic_context = child_claim.generic_context.clone();
+
+                  if !self.try_reassign_failed_single_entries::<T>(
+                    parent_claim_position,
+                    &child_entry,
+                    child_claim.generic_context.clone(),
+                  )? {
+                    self.single_entry_claims.pop();
+                    if let Some(keys) = &mut self.validated_keys {
+                      keys.truncate(validated_key_count);
+                    }
+                    self.active_single_entry_claim = None;
+                  }
+                  continue;
+                }
+
+                self.claim_single_map_key(child_claim.entry_index, key);
+                if let Some(parent_claim) = self.single_entry_claims.last_mut() {
+                  parent_claim.entry = child_claim.entry.clone();
+                  parent_claim.generic_context = child_claim.generic_context.clone();
+                }
+              } else {
+                self.validated_keys.get_or_insert_with(Vec::new).push(key);
+              }
+            }
+          }
         }
 
         return Ok(());
@@ -4978,14 +5235,14 @@ where
         // Retrieve the value from key unless optional/zero or more, in which
         // case advance to next group entry
         let k = token_value_into_cbor_value(value.clone());
+        let entries = o.clone();
 
         #[cfg(feature = "ast-span")]
-        if let Some(v) = o
-          .iter()
-          .find_map(|entry| if entry.0 == k { Some(&entry.1) } else { None })
+        if let Some((entry_index, claimed_key, v)) =
+          self.find_single_map_entry_matching(&entries, |candidate| candidate == &k)
         {
-          self.validated_keys.get_or_insert(vec![k.clone()]).push(k);
-          self.object_value = Some(v.clone());
+          self.claim_single_map_key(entry_index, claimed_key);
+          self.object_value = Some(v);
           let _ = write!(self.state.data_location, "/{}", value);
 
           None
@@ -5011,12 +5268,11 @@ where
         }
 
         #[cfg(not(feature = "ast-span"))]
-        if let Some(v) = o
-          .iter()
-          .find_map(|entry| if entry.0 == k { Some(&entry.1) } else { None })
+        if let Some((entry_index, claimed_key, v)) =
+          self.find_single_map_entry_matching(&entries, |candidate| candidate == &k)
         {
-          self.validated_keys.get_or_insert(vec![k.clone()]).push(k);
-          self.object_value = Some(v.clone());
+          self.claim_single_map_key(entry_index, claimed_key);
+          self.object_value = Some(v);
           self.state.data_location.push_str(&format!("/{}", value));
 
           None

--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -160,7 +160,7 @@ pub struct CBORValidator<'a> {
   pub state: super::ValidationState<'a>,
   cbor: Value,
   errors: Vec<ValidationError>,
-  // cbor object value hoisted from previous state of AST evaluation
+  // Direct map-member value relayed from key validation to its group entry.
   object_value: Option<Value>,
   // Str value of cut detected in current state of AST evaluation
   cut_value: Option<Type1<'a>>,
@@ -176,8 +176,10 @@ pub struct CBORValidator<'a> {
   // Isolated compatibility probes must not recursively start another map
   // assignment search when the tested pair does not match.
   probing_single_entry_assignment: bool,
-  // Collect map entry values that have yet to be validated
-  values_to_validate: Option<Vec<Value>>,
+  // Candidate batch produced while visiting one repeating map member's key.
+  // `visit_value_member_key_entry` immediately takes this relay field so the
+  // physical indices and values cannot affect a later group entry.
+  map_entry_candidates: Option<Vec<(usize, Value)>>,
   // Whether or not the validator is validating a map entry value
   validating_value: bool,
   range_upper: Option<usize>,
@@ -198,7 +200,7 @@ impl<'a> CBORValidator<'a> {
       single_entry_claims: Vec::new(),
       active_single_entry_claim: None,
       probing_single_entry_assignment: false,
-      values_to_validate: None,
+      map_entry_candidates: None,
       validating_value: false,
       range_upper: None,
     }
@@ -218,7 +220,7 @@ impl<'a> CBORValidator<'a> {
       single_entry_claims: Vec::new(),
       active_single_entry_claim: None,
       probing_single_entry_assignment: false,
-      values_to_validate: None,
+      map_entry_candidates: None,
       validating_value: false,
       range_upper: None,
     }
@@ -238,7 +240,7 @@ impl<'a> CBORValidator<'a> {
       single_entry_claims: Vec::new(),
       active_single_entry_claim: None,
       probing_single_entry_assignment: false,
-      values_to_validate: None,
+      map_entry_candidates: None,
       validating_value: false,
       range_upper: None,
     }
@@ -258,7 +260,7 @@ impl<'a> CBORValidator<'a> {
       single_entry_claims: Vec::new(),
       active_single_entry_claim: None,
       probing_single_entry_assignment: false,
-      values_to_validate: None,
+      map_entry_candidates: None,
       validating_value: false,
       range_upper: None,
     }
@@ -524,7 +526,7 @@ impl<'a> CBORValidator<'a> {
     claimed_entries: &[usize],
     max_matches: Option<usize>,
     predicate: impl Fn(&Value) -> bool,
-  ) -> (Vec<usize>, Vec<Value>) {
+  ) -> Vec<(usize, Value)> {
     entries
       .iter()
       .enumerate()
@@ -533,7 +535,7 @@ impl<'a> CBORValidator<'a> {
           .then(|| (entry_index, value.clone()))
       })
       .take(max_matches.unwrap_or(usize::MAX))
-      .unzip()
+      .collect()
   }
 
   /// Find the first unconsumed map entry for a primitive identifier used as a
@@ -4032,13 +4034,9 @@ where
               None
             };
 
-            if let Some((matched_entries, values_to_validate)) = matches {
-              self.claimed_map_entries.extend(matched_entries);
-              self.values_to_validate = Some(values_to_validate);
-            }
-
-            if let Some(values_to_validate) = &self.values_to_validate {
-              let count = values_to_validate.len();
+            if let Some(map_entry_candidates) = matches {
+              let count = map_entry_candidates.len();
+              self.map_entry_candidates = Some(map_entry_candidates);
               match occur {
                 Occur::ZeroOrMore { .. } => {}
                 Occur::OneOrMore { .. } if count == 0 => self.add_error(format!(
@@ -4110,6 +4108,14 @@ where
     &mut self,
     entry: &ValueMemberKeyEntry<'a>,
   ) -> visitor::Result<Error<T>> {
+    // These fields only relay a key visitor's result to this group entry.
+    // Clear unexpected leftovers defensively in release builds while making
+    // the entry-lifetime invariant visible during development.
+    debug_assert!(self.map_entry_candidates.is_none());
+    debug_assert!(self.object_value.is_none());
+    self.map_entry_candidates = None;
+    self.object_value = None;
+
     if let Some(occur) = &entry.occur {
       self.visit_occurrence(occur)?;
     }
@@ -4118,33 +4124,47 @@ where
     let current_location = self.state.data_location.clone();
     self.active_single_entry_claim = None;
 
-    let mut entry_claim_position = None;
-    if let Some(mk) = &entry.member_key {
-      let error_count = self.errors.len();
-      self.state.is_member_key = true;
-      self.visit_memberkey(mk)?;
-      self.state.is_member_key = false;
-      entry_claim_position = self.active_single_entry_claim.take();
+    let (entry_claim_position, map_entry_candidates, object_value) =
+      if let Some(mk) = &entry.member_key {
+        let error_count = self.errors.len();
+        self.state.is_member_key = true;
+        let member_key_result = self.visit_memberkey(mk);
+        self.state.is_member_key = false;
+        let entry_claim_position = self.active_single_entry_claim.take();
 
-      // Move to next entry if member key validation fails
-      if self.errors.len() != error_count {
-        self.state.advance_to_next_entry = true;
-        return Ok(());
-      }
-    }
+        // Consume both possible key-to-value relay paths before any exit,
+        // including a visitor error or a key/occurrence validation failure.
+        let map_entry_candidates = self.map_entry_candidates.take();
+        let object_value = self.object_value.take();
+        member_key_result?;
 
-    if let Some(values) = &self.values_to_validate {
-      for v in values.iter() {
+        if let Some(candidates) = &map_entry_candidates {
+          self
+            .claimed_map_entries
+            .extend(candidates.iter().map(|(entry_index, _)| *entry_index));
+        }
+
+        // Move to next entry if member key validation fails
+        if self.errors.len() != error_count {
+          self.state.advance_to_next_entry = true;
+          return Ok(());
+        }
+
+        (entry_claim_position, map_entry_candidates, object_value)
+      } else {
+        (None, None, None)
+      };
+
+    if let Some(candidates) = map_entry_candidates {
+      debug_assert!(object_value.is_none());
+      for (_, value) in candidates {
         #[cfg(all(feature = "additional-controls", target_arch = "wasm32"))]
-        let mut cv = CBORValidator::new(
-          self.state.cddl,
-          v.clone(),
-          self.state.enabled_features.clone(),
-        );
+        let mut cv =
+          CBORValidator::new(self.state.cddl, value, self.state.enabled_features.clone());
         #[cfg(all(feature = "additional-controls", not(target_arch = "wasm32")))]
-        let mut cv = CBORValidator::new(self.state.cddl, v.clone(), self.state.enabled_features);
+        let mut cv = CBORValidator::new(self.state.cddl, value, self.state.enabled_features);
         #[cfg(not(feature = "additional-controls"))]
-        let mut cv = CBORValidator::new(self.state.cddl, v.clone());
+        let mut cv = CBORValidator::new(self.state.cddl, value);
 
         cv.state.generic_rules = self.state.generic_rules.clone();
         cv.state.eval_generic_rule = self.state.eval_generic_rule;
@@ -4166,7 +4186,7 @@ where
       return Ok(());
     }
 
-    if let Some(v) = self.object_value.take() {
+    if let Some(v) = object_value {
       #[cfg(all(feature = "additional-controls", target_arch = "wasm32"))]
       let mut cv = CBORValidator::new(self.state.cddl, v, self.state.enabled_features.clone());
       #[cfg(all(feature = "additional-controls", not(target_arch = "wasm32")))]
@@ -4225,8 +4245,10 @@ where
         self.state.occurrence = None;
       }
 
-      Ok(())
-    } else if !self.state.advance_to_next_entry {
+      return Ok(());
+    }
+
+    if !self.state.advance_to_next_entry {
       self.visit_type(&entry.entry_type)
     } else {
       Ok(())

--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -557,6 +557,23 @@ impl<'a> CBORValidator<'a> {
       .map(|(entry_index, (key, value))| (entry_index, key.clone(), value.clone()))
   }
 
+  fn collect_unconsumed_map_entries_matching(
+    entries: &[(Value, Value)],
+    claimed_keys: Option<&[Value]>,
+    max_matches: Option<usize>,
+    predicate: impl Fn(&Value) -> bool,
+  ) -> (Vec<Value>, Vec<Value>) {
+    entries
+      .iter()
+      .enumerate()
+      .filter_map(|(entry_index, (key, value))| {
+        (predicate(key) && Self::is_unconsumed_map_entry(entries, entry_index, claimed_keys))
+          .then(|| (key.clone(), value.clone()))
+      })
+      .take(max_matches.unwrap_or(usize::MAX))
+      .unzip()
+  }
+
   /// Find the first unconsumed map entry for a primitive identifier used as a
   /// non-repeating member key. The outer option indicates whether the
   /// identifier is one of the key domains handled by this fast path.
@@ -3976,390 +3993,132 @@ where
             self.visit_value(&token::Value::TEXT(ident.ident.into()))
           }
           Some(occur) => {
-            // An `any`-keyed table (e.g. `* any => v`) matches entries of any
-            // key type, so every not-yet-validated value is a candidate.
-            if is_ident_any_type(self.state.cddl, ident) {
-              let mut matched_keys = Vec::new();
-              let values_to_validate = m
-                .iter()
-                .filter_map(|(k, v)| {
-                  if self
-                    .validated_keys
-                    .as_ref()
-                    .is_some_and(|keys| keys.contains(k))
-                  {
-                    return None;
-                  }
-
-                  matched_keys.push(k.clone());
-                  Some(v.clone())
-                })
-                .collect::<Vec<_>>();
-
-              self
-                .validated_keys
-                .get_or_insert_with(Vec::new)
-                .extend(matched_keys);
-
-              self.values_to_validate = Some(values_to_validate);
-            }
-
-            if is_ident_string_data_type(self.state.cddl, ident) {
-              let mut matched_keys = Vec::new();
-              let values_to_validate = m
-                .iter()
-                .filter_map(|(k, v)| {
-                  if self
-                    .validated_keys
-                    .as_ref()
-                    .is_some_and(|keys| keys.contains(k))
-                  {
-                    return None;
-                  }
-
-                  if matches!(k, Value::Text(_)) {
-                    matched_keys.push(k.clone());
-                    Some(v.clone())
-                  } else {
-                    // Not this entry's key type. Leave the key for another group entry to
-                    // consume; keys that no entry consumes are reported by the map-level
-                    // unexpected-key check once the whole group has been visited.
-                    None
-                  }
-                })
-                .collect::<Vec<_>>();
-
-              self
-                .validated_keys
-                .get_or_insert_with(Vec::new)
-                .extend(matched_keys);
-
-              self.values_to_validate = Some(values_to_validate);
-            }
-
-            if let Some(kind) =
+            // Repeating primitive-key entries greedily claim unconsumed pairs
+            // in their key domain, up to any upper bound. The occurrence
+            // bounds apply to those matches, not to the enclosing map's size.
+            let claimed_keys = self.validated_keys.as_deref();
+            let max_matches = match occur {
+              Occur::Exact { upper, .. } => *upper,
+              _ => None,
+            };
+            let matches = if is_ident_any_type(self.state.cddl, ident) {
+              Some(Self::collect_unconsumed_map_entries_matching(
+                m,
+                claimed_keys,
+                max_matches,
+                |_| true,
+              ))
+            } else if is_ident_string_data_type(self.state.cddl, ident) {
+              Some(Self::collect_unconsumed_map_entries_matching(
+                m,
+                claimed_keys,
+                max_matches,
+                |key| matches!(key, Value::Text(_)),
+              ))
+            } else if let Some(kind) =
               ident_numeric_kind(self.state.cddl, ident).filter(|k| k.admits_int())
             {
               // `number` admits both, so this block also claims float keys; the
-              // float-only block below then leaves them alone.
+              // float-only branch below is reserved for float-only types.
               let admits_float = kind.admits_float();
-              let mut matched_keys = Vec::new();
-              let values_to_validate = m
-                .iter()
-                .filter_map(|(k, v)| {
-                  if self
-                    .validated_keys
-                    .as_ref()
-                    .is_some_and(|keys| keys.contains(k))
-                  {
-                    return None;
-                  }
-
-                  if matches!(k, Value::Integer(_))
-                    || (admits_float && matches!(k, Value::Float(_)))
-                  {
-                    matched_keys.push(k.clone());
-                    Some(v.clone())
-                  } else {
-                    // Not this entry's key type. Leave the key for another group entry to
-                    // consume; keys that no entry consumes are reported by the map-level
-                    // unexpected-key check once the whole group has been visited.
-                    None
-                  }
-                })
-                .collect::<Vec<_>>();
-
-              self
-                .validated_keys
-                .get_or_insert_with(Vec::new)
-                .extend(matched_keys);
-
-              self.values_to_validate = Some(values_to_validate);
-            }
-
-            if is_ident_bool_data_type(self.state.cddl, ident) {
-              let mut matched_keys = Vec::new();
-              let values_to_validate = m
-                .iter()
-                .filter_map(|(k, v)| {
-                  if self
-                    .validated_keys
-                    .as_ref()
-                    .is_some_and(|keys| keys.contains(k))
-                  {
-                    return None;
-                  }
-
-                  if matches!(k, Value::Bool(_)) {
-                    matched_keys.push(k.clone());
-                    Some(v.clone())
-                  } else {
-                    // Not this entry's key type. Leave the key for another group entry to
-                    // consume; keys that no entry consumes are reported by the map-level
-                    // unexpected-key check once the whole group has been visited.
-                    None
-                  }
-                })
-                .collect::<Vec<_>>();
-
-              self
-                .validated_keys
-                .get_or_insert_with(Vec::new)
-                .extend(matched_keys);
-
-              self.values_to_validate = Some(values_to_validate);
-            }
-
-            if is_ident_byte_string_data_type(self.state.cddl, ident) {
-              let mut matched_keys = Vec::new();
-              let values_to_validate = m
-                .iter()
-                .filter_map(|(k, v)| {
-                  if self
-                    .validated_keys
-                    .as_ref()
-                    .is_some_and(|keys| keys.contains(k))
-                  {
-                    return None;
-                  }
-
-                  if matches!(k, Value::Bytes(_)) {
-                    matched_keys.push(k.clone());
-                    Some(v.clone())
-                  } else {
-                    // Not this entry's key type. Leave the key for another group entry to
-                    // consume; keys that no entry consumes are reported by the map-level
-                    // unexpected-key check once the whole group has been visited.
-                    None
-                  }
-                })
-                .collect::<Vec<_>>();
-
-              self
-                .validated_keys
-                .get_or_insert_with(Vec::new)
-                .extend(matched_keys);
-
-              self.values_to_validate = Some(values_to_validate);
-            }
-
-            if is_ident_null_data_type(self.state.cddl, ident) {
-              let mut matched_keys = Vec::new();
-              let values_to_validate = m
-                .iter()
-                .filter_map(|(k, v)| {
-                  if self
-                    .validated_keys
-                    .as_ref()
-                    .is_some_and(|keys| keys.contains(k))
-                  {
-                    return None;
-                  }
-
-                  if matches!(k, Value::Null) {
-                    matched_keys.push(k.clone());
-                    Some(v.clone())
-                  } else {
-                    // Not this entry's key type. Leave the key for another group entry to
-                    // consume; keys that no entry consumes are reported by the map-level
-                    // unexpected-key check once the whole group has been visited.
-                    None
-                  }
-                })
-                .collect::<Vec<_>>();
-
-              self
-                .validated_keys
-                .get_or_insert_with(Vec::new)
-                .extend(matched_keys);
-
-              self.values_to_validate = Some(values_to_validate);
-            }
-
-            // `number` is already fully handled by the integer block above; matching
-            // float-only here keeps this block from firing again and overwriting
-            // the values it collected.
-            if matches!(
+              Some(Self::collect_unconsumed_map_entries_matching(
+                m,
+                claimed_keys,
+                max_matches,
+                |key| {
+                  matches!(key, Value::Integer(_))
+                    || (admits_float && matches!(key, Value::Float(_)))
+                },
+              ))
+            } else if is_ident_bool_data_type(self.state.cddl, ident) {
+              Some(Self::collect_unconsumed_map_entries_matching(
+                m,
+                claimed_keys,
+                max_matches,
+                |key| matches!(key, Value::Bool(_)),
+              ))
+            } else if is_ident_byte_string_data_type(self.state.cddl, ident) {
+              Some(Self::collect_unconsumed_map_entries_matching(
+                m,
+                claimed_keys,
+                max_matches,
+                |key| matches!(key, Value::Bytes(_)),
+              ))
+            } else if is_ident_null_data_type(self.state.cddl, ident) {
+              Some(Self::collect_unconsumed_map_entries_matching(
+                m,
+                claimed_keys,
+                max_matches,
+                |key| matches!(key, Value::Null),
+              ))
+            } else if matches!(
               ident_numeric_kind(self.state.cddl, ident),
               Some(NumericKind::Float)
             ) {
-              let mut matched_keys = Vec::new();
-              let values_to_validate = m
-                .iter()
-                .filter_map(|(k, v)| {
-                  if self
-                    .validated_keys
-                    .as_ref()
-                    .is_some_and(|keys| keys.contains(k))
-                  {
-                    return None;
-                  }
+              Some(Self::collect_unconsumed_map_entries_matching(
+                m,
+                claimed_keys,
+                max_matches,
+                |key| matches!(key, Value::Float(_)),
+              ))
+            } else if is_ident_bignum_data_type(self.state.cddl, ident) {
+              let cddl = self.state.cddl;
+              Some(Self::collect_unconsumed_map_entries_matching(
+                m,
+                claimed_keys,
+                max_matches,
+                |key| is_bignum_value(cddl, ident, key),
+              ))
+            } else {
+              None
+            };
 
-                  if matches!(k, Value::Float(_)) {
-                    matched_keys.push(k.clone());
-                    Some(v.clone())
-                  } else {
-                    // Not this entry's key type. Leave the key for another group entry to
-                    // consume; keys that no entry consumes are reported by the map-level
-                    // unexpected-key check once the whole group has been visited.
-                    None
-                  }
-                })
-                .collect::<Vec<_>>();
-
+            if let Some((matched_keys, values_to_validate)) = matches {
               self
                 .validated_keys
                 .get_or_insert_with(Vec::new)
                 .extend(matched_keys);
-
               self.values_to_validate = Some(values_to_validate);
             }
 
-            if is_ident_bignum_data_type(self.state.cddl, ident) {
-              let mut matched_keys = Vec::new();
-              let values_to_validate = m
-                .iter()
-                .filter_map(|(k, v)| {
-                  if self
-                    .validated_keys
-                    .as_ref()
-                    .is_some_and(|keys| keys.contains(k))
+            if let Some(values_to_validate) = &self.values_to_validate {
+              let count = values_to_validate.len();
+              match occur {
+                Occur::ZeroOrMore { .. } => {}
+                Occur::OneOrMore { .. } if count == 0 => self.add_error(format!(
+                  "object must contain at least one entry with key type {}",
+                  ident
+                )),
+                Occur::OneOrMore { .. } => {}
+                Occur::Exact { lower, upper, .. } => {
+                  if lower.is_some_and(|lower| count < lower)
+                    || upper.is_some_and(|upper| count > upper)
                   {
-                    return None;
-                  }
-
-                  if is_bignum_value(self.state.cddl, ident, k) {
-                    matched_keys.push(k.clone());
-                    Some(v.clone())
-                  } else {
-                    // Not this entry's key type. Leave the key for another group entry to
-                    // consume; keys that no entry consumes are reported by the map-level
-                    // unexpected-key check once the whole group has been visited.
-                    None
-                  }
-                })
-                .collect::<Vec<_>>();
-
-              self
-                .validated_keys
-                .get_or_insert_with(Vec::new)
-                .extend(matched_keys);
-
-              self.values_to_validate = Some(values_to_validate);
-            }
-
-            #[cfg(feature = "ast-span")]
-            if let Occur::ZeroOrMore { .. } | Occur::OneOrMore { .. } = occur {
-              if let Occur::OneOrMore { .. } = occur {
-                if m.is_empty() {
-                  self.add_error(format!(
-                    "map cannot be empty, one or more entries with key type {} required",
-                    ident
-                  ));
-                  return Ok(());
-                }
-              }
-            } else if let Occur::Exact { lower, upper, .. } = occur {
-              if let Some(values_to_validate) = &self.values_to_validate {
-                if let Some(lower) = lower {
-                  if let Some(upper) = upper {
-                    if values_to_validate.len() < *lower || values_to_validate.len() > *upper {
-                      if lower == upper {
-                        self.add_error(format!(
-                          "object must contain exactly {} entries of key of type {}",
-                          lower, ident,
-                        ));
-                      } else {
-                        self.add_error(format!(
-                          "object must contain between {} and {} entries of key of type {}",
-                          lower, upper, ident,
-                        ));
-                      }
-
-                      return Ok(());
+                    match (lower, upper) {
+                      (Some(lower), Some(upper)) if lower == upper => self.add_error(format!(
+                        "object must contain exactly {} entries with key type {}",
+                        lower, ident,
+                      )),
+                      (Some(lower), Some(upper)) => self.add_error(format!(
+                        "object must contain between {} and {} entries with key type {}",
+                        lower, upper, ident,
+                      )),
+                      (Some(lower), None) => self.add_error(format!(
+                        "object must contain at least {} entries with key type {}",
+                        lower, ident,
+                      )),
+                      (None, Some(upper)) => self.add_error(format!(
+                        "object must contain no more than {} entries with key type {}",
+                        upper, ident,
+                      )),
+                      (None, None) => {}
                     }
                   }
-
-                  if values_to_validate.len() < *lower {
-                    self.add_error(format!(
-                      "object must contain at least {} entries of key of type {}",
-                      lower, ident,
-                    ));
-
-                    return Ok(());
-                  }
                 }
-
-                if let Some(upper) = upper {
-                  if values_to_validate.len() > *upper {
-                    self.add_error(format!(
-                      "object must contain no more than {} entries of key of type {}",
-                      upper, ident,
-                    ));
-
-                    return Ok(());
-                  }
-                }
-
-                return Ok(());
+                Occur::Optional { .. } => {}
               }
-            }
 
-            #[cfg(not(feature = "ast-span"))]
-            if let Occur::ZeroOrMore {} | Occur::OneOrMore {} = occur {
-              if let Occur::OneOrMore {} = occur {
-                if m.is_empty() {
-                  self.add_error(format!(
-                    "object cannot be empty, one or more entries with key type {} required",
-                    ident
-                  ));
-                  return Ok(());
-                }
-              }
-            } else if let Occur::Exact { lower, upper } = occur {
-              if let Some(values_to_validate) = &self.values_to_validate {
-                if let Some(lower) = lower {
-                  if let Some(upper) = upper {
-                    if values_to_validate.len() < *lower || values_to_validate.len() > *upper {
-                      if lower == upper {
-                        self.add_error(format!(
-                          "object must contain exactly {} entries of key of type {}",
-                          lower, ident,
-                        ));
-                      } else {
-                        self.add_error(format!(
-                          "object must contain between {} and {} entries of key of type {}",
-                          lower, upper, ident,
-                        ));
-                      }
-
-                      return Ok(());
-                    }
-                  }
-
-                  if values_to_validate.len() < *lower {
-                    self.add_error(format!(
-                      "object must contain at least {} entries of key of type {}",
-                      lower, ident,
-                    ));
-
-                    return Ok(());
-                  }
-                }
-
-                if let Some(upper) = upper {
-                  if values_to_validate.len() > *upper {
-                    self.add_error(format!(
-                      "object must contain no more than {} entries of key of type {}",
-                      upper, ident,
-                    ));
-
-                    return Ok(());
-                  }
-                }
-
-                return Ok(());
-              }
+              return Ok(());
             }
 
             // `any` keys have already collected their values above; nothing

--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -148,7 +148,6 @@ struct GenericEvaluationContext<'a> {
 #[derive(Clone)]
 struct SingleMapEntryClaim<'a> {
   entry_index: usize,
-  validated_key_index: usize,
   entry: Option<ValueMemberKeyEntry<'a>>,
   generic_context: Option<GenericEvaluationContext<'a>>,
 }
@@ -165,8 +164,10 @@ pub struct CBORValidator<'a> {
   object_value: Option<Value>,
   // Str value of cut detected in current state of AST evaluation
   cut_value: Option<Type1<'a>>,
-  // Collect map entry keys that have already been validated
-  validated_keys: Option<Vec<Value>>,
+  // Physical indices into the current decoded map are the authoritative
+  // ownership ledger. CBOR key equivalence is a separate validity concern and
+  // must never determine whether a pair is available or accounted for.
+  claimed_map_entries: Vec<usize>,
   // Direct non-repeating claims used by physical-pair allocation. Each claim
   // retains the member context needed for transactional reassignment.
   single_entry_claims: Vec<SingleMapEntryClaim<'a>>,
@@ -193,7 +194,7 @@ impl<'a> CBORValidator<'a> {
       errors: Vec::default(),
       object_value: None,
       cut_value: None,
-      validated_keys: None,
+      claimed_map_entries: Vec::new(),
       single_entry_claims: Vec::new(),
       active_single_entry_claim: None,
       probing_single_entry_assignment: false,
@@ -213,7 +214,7 @@ impl<'a> CBORValidator<'a> {
       errors: Vec::default(),
       object_value: None,
       cut_value: None,
-      validated_keys: None,
+      claimed_map_entries: Vec::new(),
       single_entry_claims: Vec::new(),
       active_single_entry_claim: None,
       probing_single_entry_assignment: false,
@@ -233,7 +234,7 @@ impl<'a> CBORValidator<'a> {
       errors: Vec::default(),
       object_value: None,
       cut_value: None,
-      validated_keys: None,
+      claimed_map_entries: Vec::new(),
       single_entry_claims: Vec::new(),
       active_single_entry_claim: None,
       probing_single_entry_assignment: false,
@@ -253,7 +254,7 @@ impl<'a> CBORValidator<'a> {
       errors: Vec::default(),
       object_value: None,
       cut_value: None,
-      validated_keys: None,
+      claimed_map_entries: Vec::new(),
       single_entry_claims: Vec::new(),
       active_single_entry_claim: None,
       probing_single_entry_assignment: false,
@@ -272,11 +273,11 @@ impl<'a> CBORValidator<'a> {
   /// occurrence. A missing optional entry skips its value type entirely.
   fn claim_single_map_entry(
     &mut self,
-    entry: Option<(usize, Value, Value)>,
+    entry: Option<(usize, Value)>,
     entry_optional: bool,
   ) -> bool {
-    if let Some((entry_index, key, value)) = entry {
-      self.claim_single_map_key(entry_index, key);
+    if let Some((entry_index, value)) = entry {
+      self.claim_single_map_key(entry_index);
       let _ = write!(self.state.data_location, "/{:?}", value);
       self.object_value = Some(value);
       true
@@ -289,14 +290,12 @@ impl<'a> CBORValidator<'a> {
     }
   }
 
-  fn claim_single_map_key(&mut self, entry_index: usize, key: Value) {
+  fn claim_single_map_key(&mut self, entry_index: usize) {
     let generic_context = self.current_generic_evaluation_context();
-    let validated_keys = self.validated_keys.get_or_insert_with(Vec::new);
-    let validated_key_index = validated_keys.len();
-    validated_keys.push(key.clone());
+    debug_assert!(!self.claimed_map_entries.contains(&entry_index));
+    self.claimed_map_entries.push(entry_index);
     self.single_entry_claims.push(SingleMapEntryClaim {
       entry_index,
-      validated_key_index,
       entry: None,
       generic_context,
     });
@@ -305,16 +304,12 @@ impl<'a> CBORValidator<'a> {
 
   fn remove_single_map_entry_claim(&mut self, claim_position: usize) {
     let claim = self.single_entry_claims.remove(claim_position);
-
-    if let Some(keys) = &mut self.validated_keys {
-      if claim.validated_key_index < keys.len() {
-        keys.remove(claim.validated_key_index);
-        for remaining_claim in &mut self.single_entry_claims {
-          if remaining_claim.validated_key_index > claim.validated_key_index {
-            remaining_claim.validated_key_index -= 1;
-          }
-        }
-      }
+    if let Some(ledger_position) = self
+      .claimed_map_entries
+      .iter()
+      .position(|entry_index| *entry_index == claim.entry_index)
+    {
+      self.claimed_map_entries.remove(ledger_position);
     }
   }
 
@@ -492,59 +487,26 @@ impl<'a> CBORValidator<'a> {
         None => return Ok(false),
       };
       let entry_index = entry_indices[entry_slot];
-      let key = entries[entry_index].0.clone();
       let claim = &mut self.single_entry_claims[claim_position];
       claim.entry_index = entry_index;
       claim.entry = Some(claim_entries[claim_slot].clone());
       claim.generic_context = claim_generic_contexts[claim_slot].clone();
-      if let Some(keys) = &mut self.validated_keys {
-        keys[claim.validated_key_index] = key;
-      }
     }
 
     Ok(true)
   }
 
-  /// Whether the physical entry at `entry_index` is still available.
-  ///
-  /// Counting equivalent earlier entries keeps two physical pairs distinct
-  /// even when their decoded keys compare equal (for example duplicate text
-  /// keys or +0/-0 float keys).
-  fn is_unconsumed_map_entry(
-    entries: &[(Value, Value)],
-    entry_index: usize,
-    claimed_keys: Option<&[Value]>,
-  ) -> bool {
-    let key = &entries[entry_index].0;
-    Self::is_unconsumed_equivalent_key(
-      key,
-      entries[..entry_index]
-        .iter()
-        .map(|(candidate, _)| candidate),
-      claimed_keys,
-    )
-  }
-
-  fn is_unconsumed_equivalent_key<'k>(
-    key: &Value,
-    earlier_keys: impl Iterator<Item = &'k Value>,
-    claimed_keys: Option<&[Value]>,
-  ) -> bool {
-    let earlier_equivalent_keys = earlier_keys.filter(|candidate| *candidate == key).count();
-    let consumed_equivalent_keys = claimed_keys.map_or(0, |keys| {
-      keys.iter().filter(|candidate| *candidate == key).count()
-    });
-
-    earlier_equivalent_keys >= consumed_equivalent_keys
+  fn is_unconsumed_map_entry(entry_index: usize, claimed_entries: &[usize]) -> bool {
+    !claimed_entries.contains(&entry_index)
   }
 
   fn find_unconsumed_map_entry<'m>(
     entries: &'m [(Value, Value)],
-    claimed_keys: Option<&[Value]>,
+    claimed_entries: &[usize],
     predicate: impl Fn(&Value) -> bool,
   ) -> Option<(usize, &'m (Value, Value))> {
     entries.iter().enumerate().find(|(entry_index, (key, _))| {
-      predicate(key) && Self::is_unconsumed_map_entry(entries, *entry_index, claimed_keys)
+      predicate(key) && Self::is_unconsumed_map_entry(*entry_index, claimed_entries)
     })
   }
 
@@ -552,23 +514,23 @@ impl<'a> CBORValidator<'a> {
     &self,
     entries: &[(Value, Value)],
     predicate: impl Fn(&Value) -> bool,
-  ) -> Option<(usize, Value, Value)> {
-    Self::find_unconsumed_map_entry(entries, self.validated_keys.as_deref(), predicate)
-      .map(|(entry_index, (key, value))| (entry_index, key.clone(), value.clone()))
+  ) -> Option<(usize, Value)> {
+    Self::find_unconsumed_map_entry(entries, &self.claimed_map_entries, predicate)
+      .map(|(entry_index, (_, value))| (entry_index, value.clone()))
   }
 
   fn collect_unconsumed_map_entries_matching(
     entries: &[(Value, Value)],
-    claimed_keys: Option<&[Value]>,
+    claimed_entries: &[usize],
     max_matches: Option<usize>,
     predicate: impl Fn(&Value) -> bool,
-  ) -> (Vec<Value>, Vec<Value>) {
+  ) -> (Vec<usize>, Vec<Value>) {
     entries
       .iter()
       .enumerate()
       .filter_map(|(entry_index, (key, value))| {
-        (predicate(key) && Self::is_unconsumed_map_entry(entries, entry_index, claimed_keys))
-          .then(|| (key.clone(), value.clone()))
+        (predicate(key) && Self::is_unconsumed_map_entry(entry_index, claimed_entries))
+          .then(|| (entry_index, value.clone()))
       })
       .take(max_matches.unwrap_or(usize::MAX))
       .unzip()
@@ -581,7 +543,7 @@ impl<'a> CBORValidator<'a> {
     &self,
     entries: &[(Value, Value)],
     ident: &Identifier<'a>,
-  ) -> Option<Option<(usize, Value, Value)>> {
+  ) -> Option<Option<(usize, Value)>> {
     let entry = if is_ident_any_type(self.state.cddl, ident) {
       self.find_single_map_entry_matching(entries, |_| true)
     } else if is_ident_string_data_type(self.state.cddl, ident) {
@@ -1158,20 +1120,17 @@ impl<'a> CBORValidator<'a> {
       if candidate.errors.len() == error_count {
         if let Some(keys) = map_keys {
           for (entry_index, key) in keys.iter().enumerate() {
-            if Self::is_unconsumed_equivalent_key(
-              key,
-              keys[..entry_index].iter(),
-              candidate.validated_keys.as_deref(),
-            ) {
+            if Self::is_unconsumed_map_entry(entry_index, &candidate.claimed_map_entries) {
               // Preserve the parent's existing no-retry behavior for an
               // ordinary unmatched key. Retry only when the new multiplicity
               // check exposes an equivalent physical pair that the parent's
               // membership check would have hidden.
-              if !candidate
-                .validated_keys
-                .as_ref()
-                .is_some_and(|claimed_keys| claimed_keys.contains(key))
-              {
+              let has_claimed_equivalent_key = candidate
+                .claimed_map_entries
+                .iter()
+                .filter_map(|claimed_index| keys.get(*claimed_index))
+                .any(|claimed_key| claimed_key == key);
+              if !has_claimed_equivalent_key {
                 has_parent_visible_unexpected_key = true;
               }
               candidate.add_error(format!("unexpected key {:?}", key));
@@ -3035,7 +2994,10 @@ where
           if self.state.is_member_key {
             let current_location = self.state.data_location.clone();
 
-            for (k, v) in m.iter() {
+            for (entry_index, (k, v)) in m.iter().enumerate() {
+              if !Self::is_unconsumed_map_entry(entry_index, &self.claimed_map_entries) {
+                continue;
+              }
               #[cfg(feature = "additional-controls")]
               #[cfg(all(feature = "additional-controls", target_arch = "wasm32"))]
               let mut cv = CBORValidator::new(
@@ -3059,10 +3021,7 @@ where
 
               if cv.errors.is_empty() {
                 self.object_value = Some(v.clone());
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
+                self.claimed_map_entries.push(entry_index);
                 self.state.data_location = current_location;
                 return Ok(());
               }
@@ -3151,7 +3110,10 @@ where
         Value::Map(m) if self.state.is_member_key => {
           let current_location = self.state.data_location.clone();
 
-          for (k, v) in m.iter() {
+          for (entry_index, (k, v)) in m.iter().enumerate() {
+            if !Self::is_unconsumed_map_entry(entry_index, &self.claimed_map_entries) {
+              continue;
+            }
             #[cfg(all(feature = "additional-controls", target_arch = "wasm32"))]
             let mut cv = CBORValidator::new(
               self.state.cddl,
@@ -3174,10 +3136,7 @@ where
 
             if cv.errors.is_empty() {
               self.object_value = Some(v.clone());
-              self
-                .validated_keys
-                .get_or_insert(vec![k.clone()])
-                .push(k.clone());
+              self.claimed_map_entries.push(entry_index);
               self.state.data_location = current_location;
               return Ok(());
             }
@@ -3996,7 +3955,7 @@ where
             // Repeating primitive-key entries greedily claim unconsumed pairs
             // in their key domain, up to any upper bound. The occurrence
             // bounds apply to those matches, not to the enclosing map's size.
-            let claimed_keys = self.validated_keys.as_deref();
+            let claimed_entries = &self.claimed_map_entries;
             let max_matches = match occur {
               Occur::Exact { upper, .. } => *upper,
               _ => None,
@@ -4004,14 +3963,14 @@ where
             let matches = if is_ident_any_type(self.state.cddl, ident) {
               Some(Self::collect_unconsumed_map_entries_matching(
                 m,
-                claimed_keys,
+                claimed_entries,
                 max_matches,
                 |_| true,
               ))
             } else if is_ident_string_data_type(self.state.cddl, ident) {
               Some(Self::collect_unconsumed_map_entries_matching(
                 m,
-                claimed_keys,
+                claimed_entries,
                 max_matches,
                 |key| matches!(key, Value::Text(_)),
               ))
@@ -4023,7 +3982,7 @@ where
               let admits_float = kind.admits_float();
               Some(Self::collect_unconsumed_map_entries_matching(
                 m,
-                claimed_keys,
+                claimed_entries,
                 max_matches,
                 |key| {
                   matches!(key, Value::Integer(_))
@@ -4033,21 +3992,21 @@ where
             } else if is_ident_bool_data_type(self.state.cddl, ident) {
               Some(Self::collect_unconsumed_map_entries_matching(
                 m,
-                claimed_keys,
+                claimed_entries,
                 max_matches,
                 |key| matches!(key, Value::Bool(_)),
               ))
             } else if is_ident_byte_string_data_type(self.state.cddl, ident) {
               Some(Self::collect_unconsumed_map_entries_matching(
                 m,
-                claimed_keys,
+                claimed_entries,
                 max_matches,
                 |key| matches!(key, Value::Bytes(_)),
               ))
             } else if is_ident_null_data_type(self.state.cddl, ident) {
               Some(Self::collect_unconsumed_map_entries_matching(
                 m,
-                claimed_keys,
+                claimed_entries,
                 max_matches,
                 |key| matches!(key, Value::Null),
               ))
@@ -4057,7 +4016,7 @@ where
             ) {
               Some(Self::collect_unconsumed_map_entries_matching(
                 m,
-                claimed_keys,
+                claimed_entries,
                 max_matches,
                 |key| matches!(key, Value::Float(_)),
               ))
@@ -4065,7 +4024,7 @@ where
               let cddl = self.state.cddl;
               Some(Self::collect_unconsumed_map_entries_matching(
                 m,
-                claimed_keys,
+                claimed_entries,
                 max_matches,
                 |key| is_bignum_value(cddl, ident, key),
               ))
@@ -4073,11 +4032,8 @@ where
               None
             };
 
-            if let Some((matched_keys, values_to_validate)) = matches {
-              self
-                .validated_keys
-                .get_or_insert_with(Vec::new)
-                .extend(matched_keys);
+            if let Some((matched_entries, values_to_validate)) = matches {
+              self.claimed_map_entries.extend(matched_entries);
               self.values_to_validate = Some(values_to_validate);
             }
 
@@ -4118,135 +4074,6 @@ where
                 Occur::Optional { .. } => {}
               }
 
-              return Ok(());
-            }
-
-            // `any` keys have already collected their values above; nothing
-            // further to match, and the prelude fall-through below must not
-            // reject them
-            if is_ident_any_type(self.state.cddl, ident) {
-              return Ok(());
-            }
-
-            if is_ident_string_data_type(self.state.cddl, ident) && !self.validating_value {
-              if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Text(_))) {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                let _ = write!(self.state.data_location, "/{:?}", v);
-              } else if (!matches!(occur, Occur::ZeroOrMore { .. }) && m.is_empty())
-                || (matches!(occur, Occur::ZeroOrMore { .. }) && !m.is_empty())
-              {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
-
-              return Ok(());
-            }
-
-            if ident_numeric_kind(self.state.cddl, ident).is_some_and(NumericKind::admits_int)
-              && !self.validating_value
-            {
-              if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Integer(_))) {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                let _ = write!(self.state.data_location, "/{:?}", v);
-              } else if (!matches!(occur, Occur::ZeroOrMore { .. }) && m.is_empty())
-                || (matches!(occur, Occur::ZeroOrMore { .. }) && !m.is_empty())
-              {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
-              return Ok(());
-            }
-
-            if is_ident_bool_data_type(self.state.cddl, ident) && !self.validating_value {
-              if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Bool(_))) {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                let _ = write!(self.state.data_location, "/{:?}", v);
-              } else if (!matches!(occur, Occur::ZeroOrMore { .. }) && m.is_empty())
-                || (matches!(occur, Occur::ZeroOrMore { .. }) && !m.is_empty())
-              {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
-              return Ok(());
-            }
-
-            if is_ident_null_data_type(self.state.cddl, ident) && !self.validating_value {
-              if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Null)) {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                let _ = write!(self.state.data_location, "/{:?}", v);
-              } else if (!matches!(occur, Occur::ZeroOrMore { .. }) && m.is_empty())
-                || (matches!(occur, Occur::ZeroOrMore { .. }) && !m.is_empty())
-              {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
-              return Ok(());
-            }
-
-            if is_ident_byte_string_data_type(self.state.cddl, ident) && !self.validating_value {
-              if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Bytes(_))) {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                let _ = write!(self.state.data_location, "/{:?}", v);
-              } else if (!matches!(occur, Occur::ZeroOrMore { .. }) && m.is_empty())
-                || (matches!(occur, Occur::ZeroOrMore { .. }) && !m.is_empty())
-              {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
-              return Ok(());
-            }
-
-            if matches!(
-              ident_numeric_kind(self.state.cddl, ident),
-              Some(NumericKind::Float)
-            ) && !self.validating_value
-            {
-              if let Some((k, v)) = m.iter().find(|(k, _)| matches!(k, Value::Float(_))) {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                let _ = write!(self.state.data_location, "/{:?}", v);
-              } else if (!matches!(occur, Occur::ZeroOrMore { .. }) && m.is_empty())
-                || (matches!(occur, Occur::ZeroOrMore { .. }) && !m.is_empty())
-              {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
-              return Ok(());
-            }
-
-            if is_ident_bignum_data_type(self.state.cddl, ident) && !self.validating_value {
-              if let Some((k, v)) = m
-                .iter()
-                .find(|(k, _)| is_bignum_value(self.state.cddl, ident, k))
-              {
-                self
-                  .validated_keys
-                  .get_or_insert(vec![k.clone()])
-                  .push(k.clone());
-                self.object_value = Some(v.clone());
-                let _ = write!(self.state.data_location, "/{:?}", v);
-              } else if (!matches!(occur, Occur::ZeroOrMore { .. }) && m.is_empty())
-                || (matches!(occur, Occur::ZeroOrMore { .. }) && !m.is_empty())
-              {
-                self.add_error(format!("map requires entry key of type {}", ident));
-              }
               return Ok(());
             }
 
@@ -4448,82 +4275,33 @@ where
 
         cv.state.generic_rules = self.state.generic_rules.clone();
         cv.state.eval_generic_rule = Some(entry.name.ident);
+        if let Some(rule) = cv
+          .state
+          .generic_rules
+          .iter_mut()
+          .find(|rule| rule.name == entry.name.ident)
+        {
+          let current_args_start = rule.args.len().saturating_sub(rule.params.len());
+          rule.args = rule.args[current_args_start..].to_vec();
+        }
         cv.state.is_multi_type_choice = self.state.is_multi_type_choice;
+        cv.state.is_multi_group_choice = self.state.is_multi_group_choice;
+        // A named group is semantically equivalent to its parenthesized
+        // definition (RFC 8610 Appendix C), so it participates in the same
+        // transactional map-pair assignment. Inheriting the complete claim
+        // state lets `*` observe width zero, makes `+` reject reuse, and still
+        // allows the direct-claim allocator to reassign earlier parent claims.
+        cv.claimed_map_entries = self.claimed_map_entries.clone();
+        cv.single_entry_claims = self.single_entry_claims.clone();
         cv.visit_rule(rule)?;
 
         let child_succeeded = cv.errors.is_empty();
-        self.errors.append(&mut cv.errors);
-
         if child_succeeded {
-          // The child starts with fresh state, so it can select a physical pair
-          // already claimed by the parent. Preserve the parent's historical
-          // generic isolation, but relocate a colliding direct claim through
-          // transactional assignment instead of counting the same index
-          // twice. Non-overlapping direct and occurrence-aware claims still
-          // contribute to the parent ledger.
-          if let Some(child_validated_keys) = cv.validated_keys {
-            for (child_key_index, key) in child_validated_keys.into_iter().enumerate() {
-              if let Some(child_claim) = cv
-                .single_entry_claims
-                .iter()
-                .find(|claim| claim.validated_key_index == child_key_index)
-              {
-                if self
-                  .single_entry_claims
-                  .iter()
-                  .any(|claim| claim.entry_index == child_claim.entry_index)
-                {
-                  let child_entry = match &child_claim.entry {
-                    Some(entry) => entry.clone(),
-                    None => continue,
-                  };
-                  let entries = match &self.cbor {
-                    Value::Map(entries) => entries.clone(),
-                    _ => continue,
-                  };
-                  let placeholder = entries.iter().enumerate().find(|(entry_index, _)| {
-                    !self
-                      .single_entry_claims
-                      .iter()
-                      .any(|claim| claim.entry_index == *entry_index)
-                  });
-                  let (placeholder_index, (placeholder_key, _)) = match placeholder {
-                    Some(placeholder) => placeholder,
-                    None => continue,
-                  };
-
-                  let validated_key_count = self.validated_keys.as_ref().map_or(0, Vec::len);
-                  self.claim_single_map_key(placeholder_index, placeholder_key.clone());
-                  let parent_claim_position = self.single_entry_claims.len() - 1;
-                  let parent_claim = &mut self.single_entry_claims[parent_claim_position];
-                  parent_claim.entry = Some(child_entry.clone());
-                  parent_claim.generic_context = child_claim.generic_context.clone();
-
-                  if !self.try_reassign_failed_single_entries::<T>(
-                    parent_claim_position,
-                    &child_entry,
-                    child_claim.generic_context.clone(),
-                  )? {
-                    self.single_entry_claims.pop();
-                    if let Some(keys) = &mut self.validated_keys {
-                      keys.truncate(validated_key_count);
-                    }
-                    self.active_single_entry_claim = None;
-                  }
-                  continue;
-                }
-
-                self.claim_single_map_key(child_claim.entry_index, key);
-                if let Some(parent_claim) = self.single_entry_claims.last_mut() {
-                  parent_claim.entry = child_claim.entry.clone();
-                  parent_claim.generic_context = child_claim.generic_context.clone();
-                }
-              } else {
-                self.validated_keys.get_or_insert_with(Vec::new).push(key);
-              }
-            }
-          }
+          self.claimed_map_entries = std::mem::take(&mut cv.claimed_map_entries);
+          self.single_entry_claims = std::mem::take(&mut cv.single_entry_claims);
+          self.active_single_entry_claim = None;
         }
+        self.errors.append(&mut cv.errors);
 
         return Ok(());
       }
@@ -4997,10 +4775,10 @@ where
         let entries = o.clone();
 
         #[cfg(feature = "ast-span")]
-        if let Some((entry_index, claimed_key, v)) =
+        if let Some((entry_index, v)) =
           self.find_single_map_entry_matching(&entries, |candidate| candidate == &k)
         {
-          self.claim_single_map_key(entry_index, claimed_key);
+          self.claim_single_map_key(entry_index);
           self.object_value = Some(v);
           let _ = write!(self.state.data_location, "/{}", value);
 
@@ -5027,10 +4805,10 @@ where
         }
 
         #[cfg(not(feature = "ast-span"))]
-        if let Some((entry_index, claimed_key, v)) =
+        if let Some((entry_index, v)) =
           self.find_single_map_entry_matching(&entries, |candidate| candidate == &k)
         {
-          self.claim_single_map_key(entry_index, claimed_key);
+          self.claim_single_map_key(entry_index);
           self.object_value = Some(v);
           self.state.data_location.push_str(&format!("/{}", value));
 

--- a/src/validator/json.rs
+++ b/src/validator/json.rs
@@ -166,8 +166,10 @@ pub struct JSONValidator<'a> {
   cut_value: Option<Cow<'a, str>>,
   // Collect map entry keys that have already been validated
   validated_keys: Option<Vec<String>>,
-  // Collect map entry values that have yet to be validated
-  values_to_validate: Option<Vec<Value>>,
+  // Candidate pairs produced while visiting one repeating map member's key.
+  // The group entry takes this relay immediately and commits only candidates
+  // whose values also match the member.
+  map_entry_candidates: Option<Vec<(String, Value)>>,
 }
 
 impl<'a> JSONValidator<'a> {
@@ -182,7 +184,7 @@ impl<'a> JSONValidator<'a> {
       object_value: None,
       cut_value: None,
       validated_keys: None,
-      values_to_validate: None,
+      map_entry_candidates: None,
     }
   }
 
@@ -197,7 +199,68 @@ impl<'a> JSONValidator<'a> {
       object_value: None,
       cut_value: None,
       validated_keys: None,
-      values_to_validate: None,
+      map_entry_candidates: None,
+    }
+  }
+
+  fn new_with_recursion_state(&self, json: Value) -> JSONValidator<'a> {
+    #[cfg(all(feature = "additional-controls", target_arch = "wasm32"))]
+    let mut jv = JSONValidator::new(self.state.cddl, json, self.state.enabled_features.clone());
+    #[cfg(all(feature = "additional-controls", not(target_arch = "wasm32")))]
+    let mut jv = JSONValidator::new(self.state.cddl, json, self.state.enabled_features);
+    #[cfg(not(feature = "additional-controls"))]
+    let mut jv = JSONValidator::new(self.state.cddl, json);
+
+    jv.state.generic_rules = self.state.generic_rules.clone();
+    jv.state.eval_generic_rule = self.state.eval_generic_rule;
+    jv.state.visited_rules = self.state.visited_rules.clone();
+    jv
+  }
+
+  fn repeating_member_upper_bound(entry: &ValueMemberKeyEntry<'a>) -> Option<usize> {
+    entry.occur.as_ref().and_then(|occurrence| {
+      if let Occur::Exact { upper, .. } = occurrence.occur {
+        upper
+      } else {
+        None
+      }
+    })
+  }
+
+  fn validate_repeating_member_count(&mut self, entry: &ValueMemberKeyEntry<'a>, count: usize) {
+    let Some(occurrence) = &entry.occur else {
+      return;
+    };
+    let member_key = entry
+      .member_key
+      .as_ref()
+      .map(ToString::to_string)
+      .unwrap_or_else(|| "member".to_string());
+
+    match occurrence.occur {
+      Occur::OneOrMore { .. } if count == 0 => self.add_error(format!(
+        "object must contain at least one entry matching {}",
+        member_key
+      )),
+      Occur::Exact {
+        lower: Some(lower),
+        upper,
+        ..
+      } if count < lower => match upper {
+        Some(upper) if lower == upper => self.add_error(format!(
+          "object must contain exactly {} entries matching {}",
+          lower, member_key
+        )),
+        Some(upper) => self.add_error(format!(
+          "object must contain between {} and {} entries matching {}",
+          lower, upper, member_key
+        )),
+        None => self.add_error(format!(
+          "object must contain at least {} entries matching {}",
+          lower, member_key
+        )),
+      },
+      _ => {}
     }
   }
 
@@ -212,7 +275,7 @@ impl<'a> JSONValidator<'a> {
       object_value: None,
       cut_value: None,
       validated_keys: None,
-      values_to_validate: None,
+      map_entry_candidates: None,
     }
   }
 
@@ -227,7 +290,7 @@ impl<'a> JSONValidator<'a> {
       object_value: None,
       cut_value: None,
       validated_keys: None,
-      values_to_validate: None,
+      map_entry_candidates: None,
     }
   }
 
@@ -262,10 +325,15 @@ impl<'a> JSONValidator<'a> {
         // Retrieve the value from key unless optional/zero or more, in which
         // case advance to next group entry
         #[cfg(feature = "ast-span")]
-        if let Some(v) = o.get(t.as_ref()) {
+        if let Some(v) = o.get(t.as_ref()).filter(|_| {
+          !self
+            .validated_keys
+            .as_ref()
+            .is_some_and(|keys| keys.iter().any(|key| key == t.as_ref()))
+        }) {
           self
             .validated_keys
-            .get_or_insert(vec![t.to_string()])
+            .get_or_insert_with(Vec::new)
             .push(t.to_string());
           self.object_value = Some(v.clone());
           let _ = write!(self.state.data_location, "/{}", t);
@@ -286,10 +354,15 @@ impl<'a> JSONValidator<'a> {
         // Retrieve the value from key unless optional/zero or more, in which
         // case advance to next group entry
         #[cfg(not(feature = "ast-span"))]
-        if let Some(v) = o.get(t.as_ref()) {
+        if let Some(v) = o.get(t.as_ref()).filter(|_| {
+          !self
+            .validated_keys
+            .as_ref()
+            .is_some_and(|keys| keys.iter().any(|key| key == t.as_ref()))
+        }) {
           self
             .validated_keys
-            .get_or_insert(vec![t.to_string()])
+            .get_or_insert_with(Vec::new)
             .push(t.to_string());
           self.object_value = Some(v.clone());
           self.state.data_location.push_str(&format!("/{}", t));
@@ -2226,17 +2299,15 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
 
           self.visit_group(group)?;
 
-          // A key is unexpected unless some group entry consumed it
-          // (validated_keys of None is an empty consumed set)
-          if self.values_to_validate.is_none() {
-            for k in o.into_iter() {
-              if !self
-                .validated_keys
-                .as_ref()
-                .is_some_and(|keys| keys.contains(&k))
-              {
-                self.add_error(format!("unexpected key {:?}", k));
-              }
+          // A key is unexpected unless some group entry consumed its complete
+          // key/value pair (validated_keys of None is an empty consumed set).
+          for k in o.into_iter() {
+            if !self
+              .validated_keys
+              .as_ref()
+              .is_some_and(|keys| keys.contains(&k))
+            {
+              self.add_error(format!("unexpected key {:?}", k));
             }
           }
 
@@ -2878,134 +2949,21 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
 
           self.visit_value(&token::Value::TEXT(ident.ident.into()))
         }
-        Some(occur) => {
+        Some(_) => {
           if is_ident_string_data_type(self.state.cddl, ident)
             || is_ident_any_type(self.state.cddl, ident)
           {
-            let values_to_validate = o
+            let map_entry_candidates = o
               .iter()
               .filter_map(|(k, v)| match &self.validated_keys {
-                Some(keys) if !keys.contains(k) => Some(v.clone()),
+                Some(keys) if !keys.contains(k) => Some((k.clone(), v.clone())),
                 Some(_) => None,
-                None => Some(v.clone()),
+                None => Some((k.clone(), v.clone())),
               })
               .collect::<Vec<_>>();
 
-            self.values_to_validate = Some(values_to_validate);
-          }
-
-          #[cfg(feature = "ast-span")]
-          if let Occur::ZeroOrMore { .. } | Occur::OneOrMore { .. } = occur {
-            if let Occur::OneOrMore { .. } = occur {
-              if o.is_empty() {
-                self.add_error(format!(
-                  "object cannot be empty, one or more entries with key type {} required",
-                  ident
-                ));
-                return Ok(());
-              }
-            }
-          } else if let Occur::Exact { lower, upper, .. } = occur {
-            if let Some(values_to_validate) = &self.values_to_validate {
-              if let Some(lower) = lower {
-                if let Some(upper) = upper {
-                  if values_to_validate.len() < *lower || values_to_validate.len() > *upper {
-                    if lower == upper {
-                      self.add_error(format!(
-                        "object must contain exactly {} entries of key of type {}",
-                        lower, ident,
-                      ));
-                    } else {
-                      self.add_error(format!(
-                        "object must contain between {} and {} entries of key of type {}",
-                        lower, upper, ident,
-                      ));
-                    }
-
-                    return Ok(());
-                  }
-                }
-
-                if values_to_validate.len() < *lower {
-                  self.add_error(format!(
-                    "object must contain at least {} entries of key of type {}",
-                    lower, ident,
-                  ));
-
-                  return Ok(());
-                }
-              }
-
-              if let Some(upper) = upper {
-                if values_to_validate.len() > *upper {
-                  self.add_error(format!(
-                    "object must contain no more than {} entries of key of type {}",
-                    upper, ident,
-                  ));
-
-                  return Ok(());
-                }
-              }
-
-              return Ok(());
-            }
-          }
-
-          #[cfg(not(feature = "ast-span"))]
-          if let Occur::ZeroOrMore {} | Occur::OneOrMore {} = occur {
-            if let Occur::OneOrMore {} = occur {
-              if o.is_empty() {
-                self.add_error(format!(
-                  "object cannot be empty, one or more entries with key type {} required",
-                  ident
-                ));
-                return Ok(());
-              }
-            }
-          } else if let Occur::Exact { lower, upper } = occur {
-            if let Some(values_to_validate) = &self.values_to_validate {
-              if let Some(lower) = lower {
-                if let Some(upper) = upper {
-                  if values_to_validate.len() < *lower || values_to_validate.len() > *upper {
-                    if lower == upper {
-                      self.add_error(format!(
-                        "object must contain exactly {} entries of key of type {}",
-                        lower, ident,
-                      ));
-                    } else {
-                      self.add_error(format!(
-                        "object must contain between {} and {} entries of key of type {}",
-                        lower, upper, ident,
-                      ));
-                    }
-
-                    return Ok(());
-                  }
-                }
-
-                if values_to_validate.len() < *lower {
-                  self.add_error(format!(
-                    "object must contain at least {} entries of key of type {}",
-                    lower, ident,
-                  ));
-
-                  return Ok(());
-                }
-              }
-
-              if let Some(upper) = upper {
-                if values_to_validate.len() > *upper {
-                  self.add_error(format!(
-                    "object must contain no more than {} entries of key of type {}",
-                    upper, ident,
-                  ));
-
-                  return Ok(());
-                }
-              }
-
-              return Ok(());
-            }
+            self.map_entry_candidates = Some(map_entry_candidates);
+            return Ok(());
           }
 
           Ok(())
@@ -3029,58 +2987,72 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
     &mut self,
     entry: &ValueMemberKeyEntry<'a>,
   ) -> visitor::Result<Error> {
+    debug_assert!(self.map_entry_candidates.is_none());
+    debug_assert!(self.object_value.is_none());
+    self.map_entry_candidates = None;
+    self.object_value = None;
+
     if let Some(occur) = &entry.occur {
       self.visit_occurrence(occur)?;
     }
 
     let current_location = self.state.data_location.clone();
 
-    if let Some(mk) = &entry.member_key {
+    let (map_entry_candidates, object_value) = if let Some(mk) = &entry.member_key {
       let error_count = self.errors.len();
       self.state.is_member_key = true;
-      self.visit_memberkey(mk)?;
+      let member_key_result = self.visit_memberkey(mk);
       self.state.is_member_key = false;
+
+      let map_entry_candidates = self.map_entry_candidates.take();
+      let object_value = self.object_value.take();
+      member_key_result?;
 
       // Move to next entry if member key validation fails
       if self.errors.len() != error_count {
         self.state.advance_to_next_entry = true;
         return Ok(());
       }
-    }
 
-    if let Some(values) = &self.values_to_validate {
-      for v in values.iter() {
-        #[cfg(all(feature = "additional-controls", target_arch = "wasm32"))]
-        let mut jv = JSONValidator::new(
-          self.state.cddl,
-          v.clone(),
-          self.state.enabled_features.clone(),
-        );
-        #[cfg(all(feature = "additional-controls", not(target_arch = "wasm32")))]
-        let mut jv = JSONValidator::new(self.state.cddl, v.clone(), self.state.enabled_features);
-        #[cfg(not(feature = "additional-controls"))]
-        let mut jv = JSONValidator::new(self.state.cddl, v.clone());
+      (map_entry_candidates, object_value)
+    } else {
+      (None, None)
+    };
 
-        jv.state.generic_rules = self.state.generic_rules.clone();
-        jv.state.eval_generic_rule = self.state.eval_generic_rule;
+    if let Some(candidates) = map_entry_candidates {
+      debug_assert!(object_value.is_none());
+      let max_matches = Self::repeating_member_upper_bound(entry).unwrap_or(usize::MAX);
+      let mut match_count = 0;
+
+      for (key, value) in candidates {
+        if match_count == max_matches {
+          break;
+        }
+
+        let mut jv = self.new_with_recursion_state(value);
         jv.state.is_multi_type_choice = self.state.is_multi_type_choice;
         jv.state.is_multi_group_choice = self.state.is_multi_group_choice;
-        jv.state.data_location.push_str(&self.state.data_location);
+        let _ = write!(
+          jv.state.data_location,
+          "{}/{}",
+          self.state.data_location, key
+        );
         jv.state.type_group_name_entry = self.state.type_group_name_entry;
         jv.visit_type(&entry.entry_type)?;
 
-        self.state.data_location = current_location.clone();
-
-        self.errors.append(&mut jv.errors);
-        if entry.occur.is_some() {
-          self.state.occurrence = None;
+        if jv.errors.is_empty() {
+          self.validated_keys.get_or_insert_with(Vec::new).push(key);
+          match_count += 1;
         }
       }
 
+      self.validate_repeating_member_count(entry, match_count);
+      self.state.data_location = current_location;
+      self.state.occurrence = None;
       return Ok(());
     }
 
-    if let Some(v) = self.object_value.take() {
+    if let Some(v) = object_value {
       #[cfg(all(feature = "additional-controls", target_arch = "wasm32"))]
       let mut jv = JSONValidator::new(self.state.cddl, v, self.state.enabled_features.clone());
       #[cfg(all(feature = "additional-controls", not(target_arch = "wasm32")))]

--- a/tests/cbor.rs
+++ b/tests/cbor.rs
@@ -717,6 +717,402 @@ fn validate_optional_type_domain_map_entry_absent() -> Result<(), Box<dyn Error>
 }
 
 #[test]
+fn validate_single_type_domain_map_entries_do_not_reuse_consumed_keys() {
+  let name_only = b"\xa1\x64name\x63bob"; // {"name": "bob"}
+  let name_and_a = b"\xa2\x64name\x63bob\x61a\x05"; // {"name": "bob", "a": 5}
+  let name_and_bad_a = b"\xa2\x64name\x63bob\x61a\x63bad"; // {"name": "bob", "a": "bad"}
+
+  let optional = r#"m = { name: tstr, ? tstr => uint }"#;
+  validate_cbor_from_slice(optional, name_only, None).unwrap();
+  validate_cbor_from_slice(optional, name_and_a, None).unwrap();
+  validate_cbor_from_slice(optional, name_and_bad_a, None).unwrap_err();
+
+  // Occurrence-less entries use the same finder, but must still require one
+  // unconsumed matching key.
+  let required = r#"m = { name: tstr, tstr => uint }"#;
+  validate_cbor_from_slice(required, name_and_a, None).unwrap();
+  validate_cbor_from_slice(required, name_only, None).unwrap_err();
+}
+
+#[test]
+fn validate_optional_type_domain_miss_skips_composite_value() {
+  let empty_map = b"\xa0";
+  let name_only = b"\xa1\x64name\x63bob"; // {"name": "bob"}
+
+  // A missing optional member skips the entire entry. Its value type must not
+  // be evaluated against the enclosing map or a previously consumed value.
+  validate_cbor_from_slice(r#"m = { ? tstr => [uint] }"#, empty_map, None).unwrap();
+  validate_cbor_from_slice(r#"m = { ? any => [uint] }"#, empty_map, None).unwrap();
+  validate_cbor_from_slice(r#"m = { name: tstr, ? tstr => [uint] }"#, name_only, None).unwrap();
+}
+
+#[test]
+fn validate_optional_primitive_domains_do_not_reuse_consumed_keys() {
+  let cases = [
+    (
+      r#"m = { ? tstr => tstr, ? tstr => uint }"#,
+      Value::Text("k".into()),
+    ),
+    (
+      r#"m = { ? int => tstr, ? int => uint }"#,
+      Value::Integer(1.into()),
+    ),
+    (
+      r#"m = { ? bool => tstr, ? bool => uint }"#,
+      Value::Bool(true),
+    ),
+    (r#"m = { ? null => tstr, ? null => uint }"#, Value::Null),
+    (
+      r#"m = { ? bytes => tstr, ? bytes => uint }"#,
+      Value::Bytes(vec![1]),
+    ),
+    (
+      r#"m = { ? float => tstr, ? float => uint }"#,
+      Value::Float(1.5),
+    ),
+    (
+      r#"m = { ? biguint => tstr, ? biguint => uint }"#,
+      Value::Tag(2, Box::new(Value::Bytes(vec![1]))),
+    ),
+    (
+      r#"m = { ? bignint => tstr, ? bignint => uint }"#,
+      Value::Tag(3, Box::new(Value::Bytes(vec![1]))),
+    ),
+  ];
+
+  for (schema, key) in cases {
+    let mut bytes = Vec::new();
+    ciborium::ser::into_writer(
+      &Value::Map(vec![(key, Value::Text("owned".into()))]),
+      &mut bytes,
+    )
+    .unwrap();
+
+    let result = validate_cbor_from_slice(schema, &bytes, None);
+    assert!(result.is_ok(), "schema {} failed: {:?}", schema, result);
+  }
+
+  // Bignum finders must treat a genuine optional miss like every other
+  // primitive domain; occurrence-less bignum entries remain required.
+  let empty_map = b"\xa0";
+  validate_cbor_from_slice(r#"m = { ? biguint => uint }"#, empty_map, None).unwrap();
+  validate_cbor_from_slice(r#"m = { ? bignint => uint }"#, empty_map, None).unwrap();
+  validate_cbor_from_slice(r#"m = { biguint => uint }"#, empty_map, None).unwrap_err();
+  validate_cbor_from_slice(r#"m = { bignint => uint }"#, empty_map, None).unwrap_err();
+}
+
+#[test]
+fn validate_single_type_domain_map_entries_do_not_hide_equivalent_pairs() {
+  let schema = r#"m = { ? tstr => tstr, ? tstr => uint }"#;
+
+  // This duplicate-key map is invalid CBOR. Even without uniform
+  // validity-boundary rejection, the second pair must remain uncovered rather
+  // than disappear behind the first claim.
+  let duplicate_text_keys = b"\xa2\x61a\x61x\x61a\x63bad";
+  let error = validate_cbor_from_slice(schema, duplicate_text_keys, None).unwrap_err();
+  assert!(error.to_string().contains("unexpected key"));
+
+  // A claim for the first text pair must not make an equivalent second pair
+  // count as consumed when the following optional member has a disjoint key
+  // domain.
+  let error = validate_cbor_from_slice(
+    r#"m = { ? tstr => tstr, ? int => uint }"#,
+    duplicate_text_keys,
+    None,
+  )
+  .unwrap_err();
+  assert!(error.to_string().contains("unexpected key"));
+
+  let error = validate_cbor_from_slice(
+    r#"m = { a: tstr, ? tstr => uint }"#,
+    duplicate_text_keys,
+    None,
+  )
+  .unwrap_err();
+  assert!(error.to_string().contains("unexpected key"));
+
+  // A literal lookup must allocate a still-unconsumed equivalent pair rather
+  // than adding a second claim for the first pair. Otherwise the final
+  // optional entry can mistake two claims for consumption of both pairs and
+  // silently hide this invalid byte-string value.
+  let duplicate_after_prior_claim = b"\xa2\x61a\x61x\x61a\x41z";
+  let error = validate_cbor_from_slice(
+    r#"m = { ? tstr => tstr, a: tstr, ? tstr => uint }"#,
+    duplicate_after_prior_claim,
+    None,
+  )
+  .unwrap_err();
+  assert!(error.to_string().contains("expected type tstr"));
+
+  // A generic child that validates the same map must propagate both claim
+  // ledgers. Otherwise the following literal reclaims the child's first pair
+  // and the final primitive member mistakes two claims for both physical
+  // pairs, reproducing the branch-worsened false accept.
+  let error = validate_cbor_from_slice(
+    "g<K, V> = (K => V)\nm = { g<tstr, tstr>, a: tstr, ? tstr => uint }",
+    duplicate_after_prior_claim,
+    None,
+  )
+  .unwrap_err();
+  assert!(error.to_string().contains("expected type tstr"));
+
+  // Once the only pair has been claimed, a later optional literal is absent.
+  // A later required literal cannot reuse that pair.
+  let one_claimed_literal = b"\xa1\x61a\x61x";
+  validate_cbor_from_slice(
+    r#"m = { ? tstr => tstr, ? a: uint }"#,
+    one_claimed_literal,
+    None,
+  )
+  .unwrap();
+  validate_cbor_from_slice(
+    r#"m = { ? tstr => tstr, a: uint }"#,
+    one_claimed_literal,
+    None,
+  )
+  .unwrap_err();
+
+  // RFC 8949 treats +0 and -0 as equivalent map keys, so this is also an
+  // invalid duplicate-key map. The second pair must remain uncovered.
+  let equivalent_float_keys = b"\xa2\xf9\x00\x00\x61x\xf9\x80\x00\x63bad";
+  let error = validate_cbor_from_slice(
+    r#"m = { ? float => tstr, ? float => uint }"#,
+    equivalent_float_keys,
+    None,
+  )
+  .unwrap_err();
+  assert!(error.to_string().contains("unexpected key"));
+
+  // A generic child validates the same physical map. If it independently
+  // selects the parent's pair, the outward merge must count that physical
+  // index once. Otherwise the invalid second pair appears consumed.
+  let error = validate_cbor_from_slice(
+    "g<K, V> = (K => V)\nm = { ? tstr => tstr, g<tstr, tstr>, ? tstr => uint }",
+    duplicate_after_prior_claim,
+    None,
+  )
+  .unwrap_err();
+  assert!(error.to_string().contains("unexpected key"), "{}", error);
+}
+
+#[test]
+fn validate_repeating_map_entries_are_greedy() {
+  let one_text_uint = b"\xa1\x61a\x01"; // {"a": 1}
+
+  // RFC 8610 Appendix A makes occurrences greedy and possessive. The first
+  // entry consumes the only pair, so the required entry cannot match it.
+  validate_cbor_from_slice(r#"m = { * any => any, tstr => uint }"#, one_text_uint, None)
+    .unwrap_err();
+  validate_cbor_from_slice(r#"m = { tstr => uint, * any => any }"#, one_text_uint, None).unwrap();
+
+  // A positive lower bound also consumes the pair and therefore leaves no
+  // distinct pair for the required entry.
+  validate_cbor_from_slice(
+    r#"m = { + any => uint, tstr => uint }"#,
+    one_text_uint,
+    None,
+  )
+  .unwrap_err();
+  validate_cbor_from_slice(
+    r#"m = { 1*1 any => uint, tstr => uint }"#,
+    one_text_uint,
+    None,
+  )
+  .unwrap_err();
+
+  // The same wildcard-first allocation remains valid when the direct member
+  // is optional.
+  validate_cbor_from_slice(
+    r#"m = { * any => any, ? tstr => uint }"#,
+    one_text_uint,
+    None,
+  )
+  .unwrap();
+}
+
+#[test]
+fn validate_single_map_entry_claims_are_transactional_across_group_choices() {
+  let one_text_value = b"\xa1\x61a\x61x"; // {"a": "x"}
+
+  // A failed alternative must not leave a claim that hides the pair from the
+  // next alternative or from final closed-map accounting.
+  let error = validate_cbor_from_slice(
+    r#"m = { tstr => uint // ? tstr => bytes }"#,
+    one_text_value,
+    None,
+  )
+  .unwrap_err();
+  assert!(error.to_string().contains("unexpected key"));
+
+  // The second alternative can validly own the pair after the first
+  // alternative fails its value validation.
+  validate_cbor_from_slice(
+    r#"m = { tstr => uint // tstr => tstr }"#,
+    one_text_value,
+    None,
+  )
+  .unwrap();
+}
+
+#[test]
+fn validate_optional_map_entries_are_greedy() {
+  let cases = [
+    (
+      r#"m = { ? tstr => any, tstr => any }"#,
+      Value::Text("a".into()),
+    ),
+    (
+      r#"m = { ? int => any, int => any }"#,
+      Value::Integer(1.into()),
+    ),
+    (r#"m = { ? bool => any, bool => any }"#, Value::Bool(true)),
+    (r#"m = { ? null => any, null => any }"#, Value::Null),
+    (
+      r#"m = { ? bytes => any, bytes => any }"#,
+      Value::Bytes(vec![1]),
+    ),
+    (r#"m = { ? float => any, float => any }"#, Value::Float(1.5)),
+    (
+      r#"m = { ? biguint => any, biguint => any }"#,
+      Value::Tag(2, Box::new(Value::Bytes(vec![1]))),
+    ),
+    (
+      r#"m = { ? bignint => any, bignint => any }"#,
+      Value::Tag(3, Box::new(Value::Bytes(vec![1]))),
+    ),
+  ];
+
+  for (schema, key) in cases {
+    let mut bytes = Vec::new();
+    ciborium::ser::into_writer(
+      &Value::Map(vec![(key, Value::Integer(1.into()))]),
+      &mut bytes,
+    )
+    .unwrap();
+
+    let result = validate_cbor_from_slice(schema, &bytes, None);
+    assert!(result.is_err(), "schema {} unexpectedly matched", schema);
+  }
+
+  let text_pair = b"\xa1\x61a\x01"; // {"a": 1}
+  validate_cbor_from_slice(r#"m = { ? tstr => any, a: any }"#, text_pair, None).unwrap_err();
+  validate_cbor_from_slice(r#"m = { ? a: any, tstr => any }"#, text_pair, None).unwrap_err();
+}
+
+#[test]
+fn validate_optional_arrow_value_failure_can_fall_through() {
+  let text_value = b"\xa1\x61a\x61x"; // {"a": "x"}
+
+  // RFC 8610 §3.5.4: without a cut, failure of the optional entry's value
+  // type leaves the pair available to a later matching entry.
+  validate_cbor_from_slice(r#"m = { ? tstr => uint, tstr => tstr }"#, text_value, None).unwrap();
+
+  // The colon shortcut includes a cut. Once `a` matches, the bad `uint`
+  // value commits the failure and the later type-domain member cannot rescue
+  // the pair.
+  validate_cbor_from_slice(r#"m = { ? a: uint, tstr => tstr }"#, text_value, None).unwrap_err();
+
+  // This is RFC 8610 §3.5.4's extensible-map example. The arrow form permits
+  // the wildcard to cover a known key whose optional value type does not
+  // match; the colon form locks the pair and rejects it.
+  let extension_value = b"\xa1\x6coptional-key\x68nonsense";
+  validate_cbor_from_slice(
+    r#"m = { ? "optional-key" => int, * tstr => any }"#,
+    extension_value,
+    None,
+  )
+  .unwrap();
+  validate_cbor_from_slice(
+    r#"m = { ? "optional-key": int, * tstr => any }"#,
+    extension_value,
+    None,
+  )
+  .unwrap_err();
+}
+
+#[test]
+fn validate_optional_single_map_entry_assignment_considers_values() {
+  let schema = r#"m = { ? tstr => any, tstr => tstr }"#;
+
+  // Both distinct keys are in the same domain. The order-stable allocation
+  // policy assigns the text-valued pair to the required member and the
+  // integer-valued pair to the optional member in either CBOR encoding.
+  let text_value_first = b"\xa2\x61a\x61x\x61b\x01";
+  let integer_value_first = b"\xa2\x61a\x01\x61b\x61x";
+
+  validate_cbor_from_slice(schema, text_value_first, None).unwrap();
+  validate_cbor_from_slice(schema, integer_value_first, None).unwrap();
+
+  // Occurrence-less direct members use the same policy. The broad first
+  // member can move to the integer-valued pair so the second member owns the
+  // text-valued pair.
+  validate_cbor_from_slice(
+    r#"m = { tstr => any, tstr => tstr }"#,
+    text_value_first,
+    None,
+  )
+  .unwrap();
+
+  // A valid allocation can require a cycle longer than one exchange:
+  // required takes pair 0, optional 1 moves to pair 1, and optional 2 moves
+  // to pair 2. A pairwise-only repair cannot find this assignment.
+  let three_way_schema = r#"m = { ? tstr => (int / bool), ? tstr => any, tstr => int }"#;
+  let three_way_assignment = b"\xa3\x61a\x01\x61b\xf5\x61c\x41\x00";
+  validate_cbor_from_slice(three_way_schema, three_way_assignment, None).unwrap();
+
+  // Generic group children allocate the same physical map. Their direct
+  // claims must retain the member schema needed by the parent assignment.
+  let generic_schema = "g<K, V> = (? K => V)\nm = { g<tstr, 1..2>, tstr => 1, * any => any }";
+  let required_value_first = b"\xa2\x61a\x01\x61b\x02";
+  let generic_value_first = b"\xa2\x61b\x02\x61a\x01";
+  validate_cbor_from_slice(generic_schema, required_value_first, None).unwrap();
+  validate_cbor_from_slice(generic_schema, generic_value_first, None).unwrap();
+
+  // Independent generic children initially select pair 0. The outward merge
+  // must relocate the second child to a compatible free pair instead of
+  // dropping its member/schema vertex as a duplicate parent claim.
+  let two_generic_schema = "g<K, V> = (? K => V)\n\
+    h<K, V> = (? K => V)\n\
+    m = { g<tstr, any>, h<tstr, any> }";
+  let two_generic_pairs = b"\xa2\x61a\x01\x61b\x02";
+  validate_cbor_from_slice(two_generic_schema, two_generic_pairs, None).unwrap();
+
+  // The colliding child need not accept the placeholder itself. Matching can
+  // move the earlier broad child to that pair and retain pair 0 for the
+  // narrower child.
+  let two_generic_swap_schema = "g<K, V> = (? K => V)\n\
+    h<K, V> = (? K => V)\n\
+    m = { g<tstr, any>, h<tstr, int> }";
+  let integer_then_bool = b"\xa2\x61a\x01\x61b\xf5";
+  validate_cbor_from_slice(two_generic_swap_schema, integer_then_bool, None).unwrap();
+
+  // Two uses of the same generic rule have distinct instantiations. The
+  // second claim must not replay with the first use's `any` argument.
+  let repeated_generic_schema = "g<K, V> = (? K => V)\n\
+    m = { g<tstr, any>, g<tstr, int> }";
+  let two_bool_values = b"\xa2\x61a\xf5\x61b\xf4";
+  validate_cbor_from_slice(repeated_generic_schema, two_bool_values, None).unwrap_err();
+
+  let repeated_identical_schema = "g<K, V> = (? K => V)\n\
+    m = { g<tstr, any>, g<tstr, any> }";
+  validate_cbor_from_slice(repeated_identical_schema, two_bool_values, None).unwrap();
+
+  let two_generic_cycle_schema = "g<K, V> = (? K => V)\n\
+    h<K, V> = (? K => V)\n\
+    m = { g<tstr, (int / bool)>, h<tstr, any>, tstr => int }";
+  validate_cbor_from_slice(two_generic_cycle_schema, three_way_assignment, None).unwrap();
+
+  // A failed assignment search is read-only. The next group alternative must
+  // start from its checkpoint and can claim both pairs with a wildcard.
+  validate_cbor_from_slice(
+    r#"m = { (? tstr => tstr, tstr => bytes) // * any => any }"#,
+    text_value_first,
+    None,
+  )
+  .unwrap();
+}
+
+#[test]
 fn validate_map_unexpected_entries_rejected() -> Result<(), Box<dyn Error>> {
   // A map entry unmatched by any group member is an unexpected key, including
   // when the group's only member is `?`-marked and absent
@@ -746,10 +1142,12 @@ fn validate_map_any_key_permits_extra_entries() -> Result<(), Box<dyn Error>> {
   let k1_ztext = b"\xa2\x61\x6b\x01\x61\x7a\x61\x61"; // {"k": 1, "z": "a"}
   let int_keyed = b"\xa2\x01\x02\x03\x04"; // {1: 2, 3: 4}
 
-  // the openness idiom, with and without other members, in both member orders
+  // Put the specific member before the extension point. RFC 8610 Appendix A
+  // makes the leading wildcard form greedy; Section 3.5.3 identifies that
+  // general-before-specific overlap as pathological.
   validate_cbor_from_slice(r#"m = { k: uint, * any => any }"#, k1, None)?;
   validate_cbor_from_slice(r#"m = { k: uint, * any => any }"#, k1_z9, None)?;
-  validate_cbor_from_slice(r#"m = { * any => any, k: uint }"#, k1_z9, None)?;
+  assert!(validate_cbor_from_slice(r#"m = { * any => any, k: uint }"#, k1_z9, None).is_err());
   // colon shortcut form
   validate_cbor_from_slice(r#"m = { k: uint, * any: any }"#, k1_z9, None)?;
   validate_cbor_from_slice(r#"m = { * any => any }"#, empty_map, None)?;

--- a/tests/cbor.rs
+++ b/tests/cbor.rs
@@ -1079,6 +1079,109 @@ fn validate_repeating_map_entries_count_only_unconsumed_matches() {
 }
 
 #[test]
+fn validate_repeating_map_member_candidates_are_entry_local() {
+  let text_value = b"\xa1\x61a\x61x"; // {"a": "x"}
+  let text_and_int_values = b"\xa2\x61a\x61x\x01\x02"; // {"a": "x", 1: 2}
+
+  // A repeating member's candidate values belong only to that entry. A
+  // later optional miss must take its zero-width path instead of validating
+  // the earlier member's value again (RFC 8610 Section 3.2).
+  validate_cbor_from_slice(
+    r#"m = { * tstr => tstr, ? int => [uint] }"#,
+    text_value,
+    None,
+  )
+  .unwrap();
+  validate_cbor_from_slice(
+    r#"m = { + tstr => tstr, ? int => [uint] }"#,
+    text_value,
+    None,
+  )
+  .unwrap();
+  validate_cbor_from_slice(
+    r#"m = { 1*2 tstr => tstr, ? int => [uint] }"#,
+    text_value,
+    None,
+  )
+  .unwrap();
+
+  // The same cleanup is required when the following direct member is
+  // present: it must validate its own selected value.
+  validate_cbor_from_slice(
+    r#"m = { * tstr => tstr, int => uint }"#,
+    text_and_int_values,
+    None,
+  )
+  .unwrap();
+  validate_cbor_from_slice(
+    r#"m = { + tstr => tstr, int => uint }"#,
+    text_and_int_values,
+    None,
+  )
+  .unwrap();
+  validate_cbor_from_slice(
+    r#"m = { 1*2 tstr => tstr, int => uint }"#,
+    text_and_int_values,
+    None,
+  )
+  .unwrap();
+
+  // Candidate lifetime cleanup must not weaken the current key-first value
+  // enforcement policy; complete-pair fallthrough is separate work.
+  validate_cbor_from_slice(r#"m = { * tstr => uint }"#, text_value, None).unwrap_err();
+}
+
+#[test]
+fn validate_empty_repeating_map_member_candidate_batch_is_entry_local() {
+  let bad_text_value = b"\xa1\x61a\x63bad"; // {"a": "bad"}
+  let good_text_value = b"\xa1\x61a\x01"; // {"a": 1}
+
+  // An empty repetition batch must not suppress a following direct value.
+  // Retain both the rejecting case and its accepting control.
+  validate_cbor_from_slice(
+    r#"m = { 0*2 int => tstr, ? tstr => uint }"#,
+    bad_text_value,
+    None,
+  )
+  .unwrap_err();
+  validate_cbor_from_slice(
+    r#"m = { 0*2 int => tstr, ? tstr => uint }"#,
+    good_text_value,
+    None,
+  )
+  .unwrap();
+
+  // Appendix A makes the wildcard greedy. Once it owns the pair, the
+  // optional entry is absent and must not revalidate the wildcard's value.
+  validate_cbor_from_slice(
+    r#"m = { * any => any, ? tstr => uint }"#,
+    bad_text_value,
+    None,
+  )
+  .unwrap();
+}
+
+#[test]
+fn validate_repeating_map_member_candidates_are_entry_local_across_group_choices() {
+  let text_value = b"\xa1\x61a\x61x"; // {"a": "x"}
+
+  // Entry-local cleanup also applies at group-choice boundaries, including
+  // after a failed alternative and before a following choice is attempted.
+  validate_cbor_from_slice(
+    r#"m = { (* tstr => uint // * tstr => tstr), ? int => [uint] }"#,
+    text_value,
+    None,
+  )
+  .unwrap();
+  validate_cbor_from_slice(
+    r#"m = { * tstr => tstr, (? int => [uint] // ? int => uint) }"#,
+    text_value,
+    None,
+  )
+  .unwrap();
+}
+
+#[test]
 fn validate_repeating_map_entry_counts_cover_primitive_key_paths() {
   let cases = [
     ("any", "any", "any", Value::Text("a".into())),

--- a/tests/cbor.rs
+++ b/tests/cbor.rs
@@ -883,16 +883,119 @@ fn validate_single_type_domain_map_entries_do_not_hide_equivalent_pairs() {
   .unwrap_err();
   assert!(error.to_string().contains("unexpected key"));
 
-  // A generic child validates the same physical map. If it independently
-  // selects the parent's pair, the outward merge must count that physical
-  // index once. Otherwise the invalid second pair appears consumed.
+  // A generic child shares the parent's physical ledger, so it selects the
+  // second pair and exposes that pair's incompatible byte-string value.
   let error = validate_cbor_from_slice(
     "g<K, V> = (K => V)\nm = { ? tstr => tstr, g<tstr, tstr>, ? tstr => uint }",
     duplicate_after_prior_claim,
     None,
   )
   .unwrap_err();
-  assert!(error.to_string().contains("unexpected key"), "{}", error);
+  assert!(
+    error.to_string().contains("expected type tstr"),
+    "{}",
+    error
+  );
+}
+
+#[test]
+fn validate_nan_map_keys_have_physical_pair_identity() {
+  let one_nan_text = b"\xa1\xf9\x7e\x00\x61x"; // {NaN: "x"}
+
+  // RFC 8610 Appendix C matches a map by assigning its physical key/value
+  // pairs to group entries. A claimed pair remains claimed even though its
+  // IEEE NaN key is not reflexively equal in Rust. Encoding width does not
+  // affect the identity of the one physical pair.
+  let nan_encodings: &[&[u8]] = &[
+    one_nan_text,
+    b"\xa1\xfa\x7f\xc0\x00\x00\x61x",
+    b"\xa1\xfb\x7f\xf8\x00\x00\x00\x00\x00\x00\x61x",
+  ];
+  for encoded in nan_encodings {
+    validate_cbor_from_slice(r#"m = { ? float => tstr }"#, encoded, None).unwrap();
+    validate_cbor_from_slice(r#"m = { ? float => tstr, ? float => uint }"#, encoded, None).unwrap();
+  }
+
+  // Repeating entries use the same ownership ledger. The first member owns
+  // the only pair, leaving width zero for the following repetition.
+  validate_cbor_from_slice(r#"m = { * float => tstr }"#, one_nan_text, None).unwrap();
+  validate_cbor_from_slice(
+    r#"m = { ? float => tstr, * float => uint }"#,
+    one_nan_text,
+    None,
+  )
+  .unwrap();
+  validate_cbor_from_slice(
+    r#"m = { ? float => tstr, + float => uint }"#,
+    one_nan_text,
+    None,
+  )
+  .unwrap_err();
+
+  // RFC 8949 Section 5.6.1 makes NaNs with different significands distinct
+  // map keys. These two half-precision payloads therefore form a valid map
+  // and must be counted as two physical occurrences.
+  let two_distinct_nans = b"\xa2\xf9\x7e\x00\x01\xf9\x7e\x01\x02";
+  validate_cbor_from_slice(r#"m = { 2*2 float => uint }"#, two_distinct_nans, None).unwrap();
+
+  // Ordinary reflexive float keys remain a control for the same paths.
+  let finite_float = b"\xa1\xf9\x3e\x00\x61x"; // {1.5: "x"}
+  validate_cbor_from_slice(
+    r#"m = { ? float => tstr, ? float => uint }"#,
+    finite_float,
+    None,
+  )
+  .unwrap();
+
+  // Owning the NaN pair must not hide a genuinely different, unclaimed pair
+  // from the final closed-map check.
+  let nan_and_integer = b"\xa2\xf9\x7e\x00\x61x\x01\x02";
+  let error =
+    validate_cbor_from_slice(r#"m = { ? float => tstr }"#, nan_and_integer, None).unwrap_err();
+  assert!(error.to_string().contains("unexpected key Integer"));
+}
+
+#[test]
+fn validate_nan_composite_map_keys_have_physical_pair_identity() {
+  // Value::PartialEq is also non-reflexive for a composite value containing
+  // NaN. Ownership must therefore use the outer map entry index, not recursive
+  // host-language value equality.
+  let array_key = b"\xa1\x81\xf9\x7e\x00\x61x"; // {[NaN]: "x"}
+  validate_cbor_from_slice(r#"m = { ? [float] => tstr }"#, array_key, None).unwrap();
+  validate_cbor_from_slice(
+    r#"m = { ? [float] => tstr, ? [float] => uint }"#,
+    array_key,
+    None,
+  )
+  .unwrap();
+
+  // The index ledger is local to each decoded map. It must also account for
+  // the NaN pair while validating a nested map used as the outer map's key.
+  let map_key = b"\xa1\xa1\xf9\x7e\x00\x01\x61x"; // {{NaN: 1}: "x"}
+  validate_cbor_from_slice(r#"m = { ? { float => uint } => tstr }"#, map_key, None).unwrap();
+}
+
+#[test]
+fn validate_generic_map_claims_share_parent_physical_ownership() {
+  let one_text_pair = b"\xa1\x61a\x61x"; // {"a": "x"}
+  let zero_or_more = "g<K, V> = (* K => V)\nm = { ? tstr => tstr, g<tstr, tstr> }";
+  let one_or_more = "g<K, V> = (+ K => V)\nm = { ? tstr => tstr, g<tstr, tstr> }";
+
+  // A named group has the same matching semantics as its parenthesized
+  // definition (RFC 8610 Appendix C). It must see the pair already claimed by
+  // the preceding parent member: `*` can take width zero, while `+` cannot.
+  validate_cbor_from_slice(zero_or_more, one_text_pair, None).unwrap();
+  validate_cbor_from_slice(one_or_more, one_text_pair, None).unwrap_err();
+
+  // A generic child's successful NaN claim must be transferred by physical
+  // index so the enclosing closed-map pass recognizes that exact pair.
+  let one_nan_text = b"\xa1\xf9\x7e\x00\x61x";
+  validate_cbor_from_slice(
+    "g<K, V> = (? K => V)\nm = { g<float, tstr> }",
+    one_nan_text,
+    None,
+  )
+  .unwrap();
 }
 
 #[test]
@@ -1221,6 +1324,17 @@ fn validate_optional_single_map_entry_assignment_considers_values() {
     h<K, V> = (? K => V)\n\
     m = { g<tstr, (int / bool)>, h<tstr, any>, tstr => int }";
   validate_cbor_from_slice(two_generic_cycle_schema, three_way_assignment, None).unwrap();
+
+  // Parent and generic children share one physical ownership ledger. Either
+  // text-key order must leave the byte-key pair for the later required member
+  // while assigning the two text pairs to the two generic children.
+  let generic_then_disjoint_schema = "g<K, V> = (? K => V)\n\
+    h<K, V> = (? K => V)\n\
+    m = { g<tstr, int>, h<tstr, int>, bytes => any }";
+  let text_byte_text = b"\xa3\x61a\x01\x41\x00\xf5\x61b\x02";
+  let text_byte_text_reversed = b"\xa3\x61b\x02\x41\x00\xf5\x61a\x01";
+  validate_cbor_from_slice(generic_then_disjoint_schema, text_byte_text, None).unwrap();
+  validate_cbor_from_slice(generic_then_disjoint_schema, text_byte_text_reversed, None).unwrap();
 
   // A failed assignment search is read-only. The next group alternative must
   // start from its checkpoint and can claim both pairs with a wildcard.

--- a/tests/cbor.rs
+++ b/tests/cbor.rs
@@ -1269,9 +1269,11 @@ fn validate_repeating_map_member_candidates_are_entry_local_across_group_choices
   let text_value = b"\xa1\x61a\x61x"; // {"a": "x"}
 
   // Entry-local cleanup also applies at group-choice boundaries, including
-  // after a failed alternative and before a following choice is attempted.
+  // after a locally failed alternative and before a following choice is
+  // attempted. `+` makes the first arm fail its complete-pair lower bound;
+  // retry triggered only by final closed-map coverage is separate work.
   validate_cbor_from_slice(
-    r#"m = { (* tstr => uint // * tstr => tstr), ? int => [uint] }"#,
+    r#"m = { (+ tstr => uint // * tstr => tstr), ? int => [uint] }"#,
     text_value,
     None,
   )

--- a/tests/cbor.rs
+++ b/tests/cbor.rs
@@ -931,6 +931,126 @@ fn validate_repeating_map_entries_are_greedy() {
 }
 
 #[test]
+fn validate_repeating_map_entries_count_only_unconsumed_matches() {
+  let a_only = b"\xa1\x61a\x01"; // {"a": 1}
+  let int_only = b"\xa1\x01\x01"; // {1: 1}
+  let int_and_bytes = b"\xa2\x01\x01\x41\xaa\x05"; // {1: 1, h'aa': 5}
+  let a_b = b"\xa2\x61a\x01\x61b\x02";
+  let a_b_c = b"\xa3\x61a\x01\x61b\x02\x61c\x03";
+  let a_b_c_d = b"\xa4\x61a\x01\x61b\x02\x61c\x03\x61d\x04";
+  let a_b_c_d_e = b"\xa5\x61a\x01\x61b\x02\x61c\x03\x61d\x04\x61e\x05";
+
+  // The occurrence applies to this member's unconsumed matches, not to the
+  // enclosing map's total size. This matters for both same-domain keys that
+  // an earlier member consumed and disjoint keys left for a later member.
+  validate_cbor_from_slice(r#"m = { a: uint, * tstr => uint }"#, a_only, None).unwrap();
+  validate_cbor_from_slice(r#"m = { a: uint, + tstr => uint }"#, a_only, None).unwrap_err();
+  validate_cbor_from_slice(r#"m = { * tstr => uint, int => uint }"#, int_only, None).unwrap();
+  validate_cbor_from_slice(r#"m = { + tstr => uint, int => uint }"#, int_only, None).unwrap_err();
+
+  // Preserve the original mixed-map reproduction for byte-string keys. A
+  // zero-width repetition succeeds even though the map itself is nonempty;
+  // adding a matching pair still validates and `+` still requires a match.
+  validate_cbor_from_slice(r#"m = { 1: uint, * bytes => any }"#, int_only, None).unwrap();
+  validate_cbor_from_slice(r#"m = { 1: uint, * bytes => any }"#, int_and_bytes, None).unwrap();
+  validate_cbor_from_slice(r#"m = { 1: uint, + bytes => any }"#, int_only, None).unwrap_err();
+
+  // Bounded occurrences count only the pairs left after `a` is consumed.
+  let bounded = r#"m = { a: uint, 2*3 tstr => uint }"#;
+  validate_cbor_from_slice(bounded, a_b, None).unwrap_err();
+  validate_cbor_from_slice(bounded, a_b_c, None).unwrap();
+  validate_cbor_from_slice(bounded, a_b_c_d, None).unwrap();
+  validate_cbor_from_slice(bounded, a_b_c_d_e, None).unwrap_err();
+
+  validate_cbor_from_slice(r#"m = { a: uint, *2 tstr => uint }"#, a_only, None).unwrap();
+  validate_cbor_from_slice(r#"m = { a: uint, *2 tstr => uint }"#, a_b_c, None).unwrap();
+  validate_cbor_from_slice(r#"m = { a: uint, *2 tstr => uint }"#, a_b_c_d, None).unwrap_err();
+  validate_cbor_from_slice(r#"m = { a: uint, 2* tstr => uint }"#, a_b, None).unwrap_err();
+  validate_cbor_from_slice(r#"m = { a: uint, 2* tstr => uint }"#, a_b_c, None).unwrap();
+
+  // A bounded repetition stops at its upper bound. It must not claim all
+  // matching pairs and then reject before a later member can own the rest.
+  validate_cbor_from_slice(r#"m = { 1*1 tstr => uint, tstr => uint }"#, a_b, None).unwrap();
+  validate_cbor_from_slice(r#"m = { *2 tstr => uint, tstr => uint }"#, a_b_c, None).unwrap();
+  validate_cbor_from_slice(r#"m = { 2*3 tstr => uint, tstr => uint }"#, a_b_c_d, None).unwrap();
+}
+
+#[test]
+fn validate_repeating_map_entry_counts_cover_primitive_key_paths() {
+  let cases = [
+    ("any", "any", "any", Value::Text("a".into())),
+    ("tstr", "tstr", "tstr", Value::Text("a".into())),
+    ("int", "int", "int", Value::Integer(1.into())),
+    ("uint", "uint", "uint", Value::Integer(1.into())),
+    ("nint", "nint", "nint", Value::Integer((-1).into())),
+    ("number/int", "int", "number", Value::Integer(1.into())),
+    ("number/float", "float", "number", Value::Float(1.5)),
+    ("bool", "bool", "bool", Value::Bool(true)),
+    ("null", "null", "null", Value::Null),
+    ("bytes", "bytes", "bytes", Value::Bytes(vec![1])),
+    ("float", "float", "float", Value::Float(1.5)),
+    (
+      "biguint",
+      "biguint",
+      "biguint",
+      Value::Tag(2, Box::new(Value::Bytes(vec![1]))),
+    ),
+    (
+      "bignint",
+      "bignint",
+      "bignint",
+      Value::Tag(3, Box::new(Value::Bytes(vec![1]))),
+    ),
+    (
+      "bigint/tag 2",
+      "bigint",
+      "bigint",
+      Value::Tag(2, Box::new(Value::Bytes(vec![1]))),
+    ),
+    (
+      "bigint/tag 3",
+      "bigint",
+      "bigint",
+      Value::Tag(3, Box::new(Value::Bytes(vec![1]))),
+    ),
+  ];
+
+  for (case_name, consuming_key_type, repeating_key_type, key) in cases {
+    let mut bytes = Vec::new();
+    ciborium::ser::into_writer(
+      &Value::Map(vec![(key, Value::Integer(1.into()))]),
+      &mut bytes,
+    )
+    .unwrap();
+
+    // The optional member greedily consumes the only pair. The following
+    // repetition therefore has width zero regardless of the enclosing map's
+    // size: `*` accepts that width and `+` rejects it.
+    let zero_or_more = format!(
+      "m = {{ ? {} => any, * {} => uint }}",
+      consuming_key_type, repeating_key_type
+    );
+    let one_or_more = format!(
+      "m = {{ ? {} => any, + {} => uint }}",
+      consuming_key_type, repeating_key_type
+    );
+    let result = validate_cbor_from_slice(&zero_or_more, &bytes, None);
+    assert!(
+      result.is_ok(),
+      "zero-or-more {} case failed: {:?}",
+      case_name,
+      result
+    );
+    let result = validate_cbor_from_slice(&one_or_more, &bytes, None);
+    assert!(
+      result.is_err(),
+      "one-or-more {} case unexpectedly matched",
+      case_name
+    );
+  }
+}
+
+#[test]
 fn validate_single_map_entry_claims_are_transactional_across_group_choices() {
   let one_text_value = b"\xa1\x61a\x61x"; // {"a": "x"}
 

--- a/tests/cbor.rs
+++ b/tests/cbor.rs
@@ -1162,6 +1162,109 @@ fn validate_empty_repeating_map_member_candidate_batch_is_entry_local() {
 }
 
 #[test]
+fn validate_primitive_numeric_map_member_key_domains() {
+  fn encode_one_pair(key: Value) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    ciborium::ser::into_writer(
+      &Value::Map(vec![(key, Value::Integer(1.into()))]),
+      &mut bytes,
+    )
+    .unwrap();
+    bytes
+  }
+
+  // RFC 8610 Appendix D defines uint/unsigned as major type 0, nint as
+  // major type 1, int as their union, and number as int / float.
+  let accepted = [
+    ("uint", Value::Integer(0.into())),
+    ("unsigned", Value::Integer(1.into())),
+    ("nint", Value::Integer((-1).into())),
+    ("int", Value::Integer(1.into())),
+    ("int", Value::Integer((-1).into())),
+    ("number", Value::Integer(0.into())),
+    ("number", Value::Float(1.5)),
+    ("number", Value::Float(f64::INFINITY)),
+    ("number", Value::Float(f64::NAN)),
+  ];
+  let rejected = [
+    ("uint", Value::Integer((-1).into())),
+    ("unsigned", Value::Integer((-1).into())),
+    ("nint", Value::Integer(0.into())),
+    ("nint", Value::Integer(1.into())),
+    ("int", Value::Float(1.5)),
+    ("number", Value::Bool(true)),
+  ];
+  for (key_type, key) in rejected {
+    let schema = format!("m = {{ ? {} => uint }}", key_type);
+    let result = validate_cbor_from_slice(&schema, &encode_one_pair(key), None);
+    assert!(
+      result.is_err(),
+      "single {} member accepted a key outside its domain",
+      key_type
+    );
+  }
+  for (key_type, key) in accepted {
+    let schema = format!("m = {{ ? {} => uint }}", key_type);
+    let result = validate_cbor_from_slice(&schema, &encode_one_pair(key), None);
+    assert!(
+      result.is_ok(),
+      "single {} member rejected a key in its domain: {:?}",
+      key_type,
+      result
+    );
+  }
+
+  // Repeating members use the same domains. Their wrong-sign controls keep a
+  // present, otherwise valid value from masking an over-broad key predicate.
+  for (key_type, key) in [
+    ("uint", Value::Integer(0.into())),
+    ("nint", Value::Integer((-1).into())),
+    ("number", Value::Integer((-1).into())),
+    ("number", Value::Float(1.5)),
+  ] {
+    let schema = format!("m = {{ + {} => uint }}", key_type);
+    let result = validate_cbor_from_slice(&schema, &encode_one_pair(key), None);
+    assert!(
+      result.is_ok(),
+      "repeating {} member rejected a key in its domain: {:?}",
+      key_type,
+      result
+    );
+  }
+  for (key_type, key) in [
+    ("uint", Value::Integer((-1).into())),
+    ("nint", Value::Integer(0.into())),
+  ] {
+    let schema = format!("m = {{ + {} => uint }}", key_type);
+    assert!(
+      validate_cbor_from_slice(&schema, &encode_one_pair(key), None).is_err(),
+      "repeating {} member accepted a key outside its domain",
+      key_type
+    );
+  }
+
+  // A wrong-sign key must stay unclaimed so a disjoint later member can own
+  // the complete pair in both the single and repeating claim paths.
+  let negative_key = encode_one_pair(Value::Integer((-1).into()));
+  validate_cbor_from_slice(
+    r#"m = { ? uint => any, nint => uint }"#,
+    &negative_key,
+    None,
+  )
+  .unwrap();
+  validate_cbor_from_slice(
+    r#"m = { * uint => any, nint => uint }"#,
+    &negative_key,
+    None,
+  )
+  .unwrap();
+
+  let zero_key = encode_one_pair(Value::Integer(0.into()));
+  validate_cbor_from_slice(r#"m = { ? nint => any, uint => uint }"#, &zero_key, None).unwrap();
+  validate_cbor_from_slice(r#"m = { * nint => any, uint => uint }"#, &zero_key, None).unwrap();
+}
+
+#[test]
 fn validate_repeating_map_member_candidates_are_entry_local_across_group_choices() {
   let text_value = b"\xa1\x61a\x61x"; // {"a": "x"}
 
@@ -1190,7 +1293,7 @@ fn validate_repeating_map_entry_counts_cover_primitive_key_paths() {
     ("uint", "uint", "uint", Value::Integer(1.into())),
     ("nint", "nint", "nint", Value::Integer((-1).into())),
     ("number/int", "int", "number", Value::Integer(1.into())),
-    ("number/float", "float", "number", Value::Float(1.5)),
+    ("number/float", "number", "number", Value::Float(1.5)),
     ("bool", "bool", "bool", Value::Bool(true)),
     ("null", "null", "null", Value::Null),
     ("bytes", "bytes", "bytes", Value::Bytes(vec![1])),

--- a/tests/cddl.rs
+++ b/tests/cddl.rs
@@ -148,7 +148,9 @@ fn validate_json_unexpected_entries_rejected() {
 /// permit unknown extra entries instead of rejecting them as unexpected keys
 #[test]
 fn validate_json_any_key_permits_extra_entries() {
-  // the openness idiom, with and without other members, in both member orders
+  // Put the specific member before the extension point. RFC 8610 Appendix A
+  // makes the leading wildcard form greedy; Section 3.5.3 identifies that
+  // general-before-specific overlap as pathological.
   validate_json_from_str(r#"m = { k: uint, * any => any }"#, r#"{"k": 1}"#, None).unwrap();
   validate_json_from_str(
     r#"m = { k: uint, * any => any }"#,
@@ -161,7 +163,7 @@ fn validate_json_any_key_permits_extra_entries() {
     r#"{"k": 1, "z": 9}"#,
     None,
   )
-  .unwrap();
+  .unwrap_err();
   // colon shortcut form
   validate_json_from_str(
     r#"m = { k: uint, * any: any }"#,

--- a/tests/map_table_complete_pair_claims.rs
+++ b/tests/map_table_complete_pair_claims.rs
@@ -1,0 +1,111 @@
+#![cfg(feature = "std")]
+#![cfg(feature = "cbor")]
+#![cfg(feature = "json")]
+#![cfg(not(feature = "lsp"))]
+#![cfg(not(target_arch = "wasm32"))]
+
+use cddl::{validate_cbor_from_slice, validate_json_from_str};
+
+fn json_validates(schema: &str, instance: &str) -> bool {
+  validate_json_from_str(schema, instance, None).is_ok()
+}
+
+fn cbor_validates(schema: &str, hex: &str) -> bool {
+  let bytes = hex::decode(hex).unwrap();
+  validate_cbor_from_slice(schema, &bytes, None).is_ok()
+}
+
+fn both_validate(schema: &str, json: &str, cbor_hex: &str) {
+  let json_result = json_validates(schema, json);
+  let cbor_result = cbor_validates(schema, cbor_hex);
+  assert!(
+    json_result && cbor_result,
+    "expected both formats to match {schema}; JSON {json}: {json_result}, CBOR {cbor_hex}: {cbor_result}",
+    schema = schema,
+    json = json,
+    json_result = json_result,
+    cbor_hex = cbor_hex,
+    cbor_result = cbor_result,
+  );
+}
+
+fn both_reject(schema: &str, json: &str, cbor_hex: &str) {
+  let json_result = json_validates(schema, json);
+  let cbor_result = cbor_validates(schema, cbor_hex);
+  assert!(
+    !json_result && !cbor_result,
+    "expected both formats to reject {schema}; JSON {json}: {json_result}, CBOR {cbor_hex}: {cbor_result}",
+    schema = schema,
+    json = json,
+    json_result = json_result,
+    cbor_hex = cbor_hex,
+    cbor_result = cbor_result,
+  );
+}
+
+#[test]
+fn repeating_tables_claim_only_complete_key_value_matches() {
+  // RFC 8610 Appendix C matches map pairs, not keys in isolation. The broad
+  // table cannot claim this pair because its value is not a uint, so the
+  // later specific member remains able to own it.
+  both_validate(
+    "m = { * any => uint, extra: tstr }",
+    r#"{"extra":"hi"}"#,
+    "a1656578747261626869",
+  );
+
+  // Two tables with the same key domain can partition pairs by value type.
+  both_validate(
+    "m = { * any => uint, * any => tstr }",
+    r#"{"a":"x","b":1}"#,
+    "a261616178616201",
+  );
+
+  // The already-working specific-before-general order remains valid.
+  both_validate(
+    "m = { extra: tstr, * any => uint }",
+    r#"{"extra":"hi","b":1}"#,
+    "a2656578747261626869616201",
+  );
+}
+
+#[test]
+fn occurrence_bounds_count_successful_pair_matches() {
+  // The upper bound applies after complete-pair probing. The first candidate
+  // fails the uint value type, but probing must continue until one compatible
+  // pair has been found; the later table then owns the text-valued pair.
+  both_validate(
+    "m = { 1*1 any => uint, * any => tstr }",
+    r#"{"a":"x","b":1}"#,
+    "a261616178616201",
+  );
+
+  // A lower bound is likewise based on complete pairs, not key candidates.
+  both_reject(
+    "m = { + any => uint, * any => tstr }",
+    r#"{"a":"x"}"#,
+    "a161616178",
+  );
+}
+
+#[test]
+fn complete_pair_claims_preserve_greedy_and_cut_behavior() {
+  // A compatible pair is greedily claimed by the first table. A later
+  // required member cannot reuse it.
+  both_reject(
+    "m = { * any => uint, extra: uint }",
+    r#"{"extra":1}"#,
+    "a165657874726101",
+  );
+
+  // With no compatible owner, a bad table value remains invalid.
+  both_reject("m = { * any => uint }", r#"{"a":"x"}"#, "a161616178");
+
+  // The colon shortcut carries a cut (RFC 8610 Section 3.5.4). Once its key
+  // matches, a later table must not rescue its bad value.
+  both_reject(
+    "m = { extra: uint, * any => tstr }",
+    r#"{"extra":"hi"}"#,
+    "a1656578747261626869",
+  );
+}


### PR DESCRIPTION
**Warning**: extends this open PR: #673. See just the work for this PR [here](https://github.com/anweiss/cddl/commit/85b99078878d858a0c95f13f6f0812fd45a8301f)

## Background

This is a subtle one because the Ruby gem is wrong on some of these (but you can look at the examples and clearly see that it's wrong. Similar to #668).

Previously, for repeating CDDL map members, the validators selected map entries based only on the key type. This PR changes them to claim an entry only when both its key and value match the member

Additionally, we port the fix from #672 to the JSON validator

## Relevant RFC 8610 rules

<summary>section list</summary>
<details>

- Section 2.1.2: a basic group entry matches a name/value pair.
- Section 3.2: an occurrence applies to one group entry; its bounds count matches of that entry.
- Section 3.5: CBOR maps do not impose pair ordering.
- Section 3.5.3: overlapping general-before-specific members can be pathologically non-deterministic.
- Section 3.5.4: a cut commits after the key matches, and the colon shortcut carries that cut.
- Normative Appendix A: repetitions are greedy and possessive.
- Normative Appendix C: a map matches when its pairs can be ordered so the resulting sequence matches the group.
</details>

## Rust and Ruby evidence

The comparison used Rust `cddl` and Ruby `cddl` gem 0.12.14

| Schema and instance | base | Ruby 0.12.14 | This PR | Basis |
| --- | ---: | ---: | ---: | --- |
| `{ * any => uint, extra: tstr }`, `{"extra":"hi"}` | reject | reject | accept | Sections 2.1.2 and Appendix C |
| `{ * any => uint, * any => tstr }`, `{"a":"x","b":1}` | reject | reject | accept | Sections 2.1.2, 3.5, Appendix C |
| `{ 1*1 any => uint, * any => tstr }`, `{"a":"x","b":1}` | reject | reject | accept | Section 3.2 and Appendix C |
| `{ * any => uint, extra: uint }`, `{"extra":1}` | JSON accept / CBOR reject | reject | reject | Appendix A greedy ownership |