### PR TITLE
fix(pest): parse, validate, and render byte-string literals

### DIFF
--- a/cddl.pest
+++ b/cddl.pest
@@ -322,17 +322,22 @@ escape_sequence = @{ "\\" ~ (
 // =============================================================================
 
 // Byte string values in various encodings
-// 'base64data' - base64 encoding
+// 'text' - unqualified UTF-8 bytes
 // h'hexdata' - base16 (hex) encoding
+// b64'base64-data' - base64 or base64url encoding
 // h"text" - hex-quoted form
-bytes_value = { bytes_b64 | bytes_b16 | bytes_h_quoted }
+// Prefixed content is validated semantically in the bridge so that
+// whitespace and comments inside the literal can be ignored (RFC 8610 §3.1)
+bytes_value = { bytes_b64 | bytes_b16 | bytes_h_quoted | bytes_utf8 }
 
-bytes_b64 = @{ "'" ~ BASE64_INNER ~ "'" }
+bytes_b64 = @{ "b64'" ~ BASE64_INNER ~ "'" }
 bytes_b16 = @{ "h'" ~ HEX_INNER ~ "'" }
 bytes_h_quoted = @{ "h" ~ "\"" ~ (!("\"") ~ ANY)* ~ "\"" }
+bytes_utf8 = @{ "'" ~ BYTE_STRING_INNER ~ "'" }
 
 BASE64_INNER = { (!(QUOTE) ~ ANY)* }
-HEX_INNER = { (ASCII_HEX_DIGIT | WHITESPACE)* }
+BYTE_STRING_INNER = { (!(QUOTE) ~ ANY)* }
+HEX_INNER = { (!(QUOTE) ~ ANY)* }
 
 QUOTE = _{ "'" }
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1312,18 +1312,10 @@ impl fmt::Display for Type2<'_> {
         core::str::from_utf8(value).map_err(|_| fmt::Error)?
       ),
       Type2::B16ByteString { value, .. } => {
-        write!(
-          f,
-          "{}",
-          core::str::from_utf8(value).map_err(|_| fmt::Error)?
-        )
+        write!(f, "{}", ByteValue::B16(Cow::Borrowed(value.as_ref())))
       }
       Type2::B64ByteString { value, .. } => {
-        write!(
-          f,
-          "{}",
-          core::str::from_utf8(value).map_err(|_| fmt::Error)?
-        )
+        write!(f, "{}", ByteValue::B64(Cow::Borrowed(value.as_ref())))
       }
       Type2::Typename {
         ident,

--- a/src/pest_bridge.rs
+++ b/src/pest_bridge.rs
@@ -352,6 +352,7 @@ fn get_friendly_rule_name(rule_type: &Rule) -> Option<String> {
     Rule::bytes_value => Some("byte string".to_string()),
     Rule::bytes_b16 => Some("base16 byte string".to_string()),
     Rule::bytes_b64 => Some("base64 byte string".to_string()),
+    Rule::bytes_utf8 => Some("unqualified byte string".to_string()),
     Rule::bytes_h_quoted => Some("hex-quoted byte string".to_string()),
     Rule::tag_expr => Some("tag expression".to_string()),
     Rule::id => Some("identifier".to_string()),
@@ -2753,17 +2754,73 @@ fn convert_number_to_type2<'a>(
   })
 }
 
-/// Decode uppercase hex (base16) bytes without requiring alloc feature
-fn hex_decode_upper(input: &[u8]) -> Result<Vec<u8>, ()> {
-  let decode_len = data_encoding::HEXUPPER
+/// Decode mixed-case hex (base16) bytes without requiring alloc feature.
+fn hex_decode(input: &[u8]) -> Result<Vec<u8>, ()> {
+  let decode_len = data_encoding::HEXLOWER_PERMISSIVE
     .decode_len(input.len())
     .map_err(|_| ())?;
   let mut output = vec![0u8; decode_len];
-  let len = data_encoding::HEXUPPER
+  let len = data_encoding::HEXLOWER_PERMISSIVE
     .decode_mut(input, &mut output)
     .map_err(|_| ())?;
   output.truncate(len);
   Ok(output)
+}
+
+/// Decode base64 bytes in either the base64 (RFC 4648 §4) or base64url
+/// (RFC 4648 §5) alphabet, as permitted by RFC 8610 §3.1. The alphabet is
+/// chosen from the alphabet-specific characters the literal actually uses and
+/// the payload is then decoded with that alphabet, so each variant is decoded
+/// as itself and a literal drawing from both variants is rejected instead of
+/// being normalized into a valid one (RFC 4648 §3.3 requires rejecting
+/// characters outside the chosen alphabet). Padding is optional because the
+/// diagnostic notation RFC 8610 §3.1 defers to (RFC 8949 §8) notates byte
+/// strings without padding; when padding is present it must be canonical.
+fn base64_decode(input: &[u8]) -> Result<Vec<u8>, &'static str> {
+  let uses_classic = input.contains(&b'+') || input.contains(&b'/');
+  let uses_url = input.contains(&b'-') || input.contains(&b'_');
+  if uses_classic && uses_url {
+    return Err("Base64 literal mixes the RFC 4648 base64 and base64url alphabets");
+  }
+
+  // The two alphabets differ only in `+/` versus `-_`, so a literal that uses
+  // neither pair decodes identically under either one.
+  let encoding = match (uses_classic, input.contains(&b'=')) {
+    (true, true) => &data_encoding::BASE64,
+    (true, false) => &data_encoding::BASE64_NOPAD,
+    (false, true) => &data_encoding::BASE64URL,
+    (false, false) => &data_encoding::BASE64URL_NOPAD,
+  };
+
+  let decode_len = encoding
+    .decode_len(input.len())
+    .map_err(|_| "Invalid base64 encoding")?;
+  let mut output = vec![0u8; decode_len];
+  let len = encoding
+    .decode_mut(input, &mut output)
+    .map_err(|_| "Invalid base64 encoding")?;
+  output.truncate(len);
+  Ok(output)
+}
+
+/// Remove whitespace and comments from the content of a prefixed byte
+/// string. RFC 8610 §3.1: "any whitespace present within the string
+/// (including comments) is ignored in the prefixed case".
+fn clean_prefixed_byte_string(content: &str) -> String {
+  let mut cleaned = String::with_capacity(content.len());
+  let mut chars = content.chars();
+  while let Some(c) = chars.next() {
+    if c == ';' {
+      for c in chars.by_ref() {
+        if c == '\n' {
+          break;
+        }
+      }
+    } else if !c.is_whitespace() {
+      cleaned.push(c);
+    }
+  }
+  cleaned
 }
 
 /// Convert bytes value to Type2
@@ -2775,11 +2832,10 @@ fn convert_bytes_value_to_type2<'a>(
 ) -> Result<ast::Type2<'a>, Error> {
   for inner in pair.into_inner() {
     match inner.as_rule() {
-      Rule::bytes_b64 => {
+      Rule::bytes_utf8 => {
         let bytes_str = inner.as_str();
         // Remove quotes
         let content = &bytes_str[1..bytes_str.len() - 1];
-        // Single-quoted byte strings are UTF-8 encoded text, not base64
         return Ok(ast::Type2::UTF8ByteString {
           value: Cow::Owned(content.as_bytes().to_vec()),
           span,
@@ -2789,8 +2845,8 @@ fn convert_bytes_value_to_type2<'a>(
         let bytes_str = inner.as_str();
         // Remove h' and '
         let content = &bytes_str[2..bytes_str.len() - 1];
-        let cleaned: String = content.chars().filter(|c| !c.is_whitespace()).collect();
-        let decoded = hex_decode_upper(cleaned.as_bytes()).map_err(|_| Error::PARSER {
+        let cleaned = clean_prefixed_byte_string(content);
+        let decoded = hex_decode(cleaned.as_bytes()).map_err(|_| Error::PARSER {
           position: pest_span_to_position(&inner.as_span(), input),
           msg: ErrorMsg {
             short: "Invalid base16 encoding".to_string(),
@@ -2798,6 +2854,23 @@ fn convert_bytes_value_to_type2<'a>(
           },
         })?;
         return Ok(ast::Type2::B16ByteString {
+          value: Cow::Owned(decoded),
+          span,
+        });
+      }
+      Rule::bytes_b64 => {
+        let bytes_str = inner.as_str();
+        // Remove b64' and '
+        let content = &bytes_str[4..bytes_str.len() - 1];
+        let cleaned = clean_prefixed_byte_string(content);
+        let decoded = base64_decode(cleaned.as_bytes()).map_err(|short| Error::PARSER {
+          position: pest_span_to_position(&inner.as_span(), input),
+          msg: ErrorMsg {
+            short: short.to_string(),
+            extended: None,
+          },
+        })?;
+        return Ok(ast::Type2::B64ByteString {
           value: Cow::Owned(decoded),
           span,
         });
@@ -2831,11 +2904,10 @@ fn convert_bytes_value_to_type2<'a>(
 ) -> Result<ast::Type2<'a>, Error> {
   for inner in pair.into_inner() {
     match inner.as_rule() {
-      Rule::bytes_b64 => {
+      Rule::bytes_utf8 => {
         let bytes_str = inner.as_str();
         // Remove quotes
         let content = &bytes_str[1..bytes_str.len() - 1];
-        // Single-quoted byte strings are UTF-8 encoded text, not base64
         return Ok(ast::Type2::UTF8ByteString {
           value: Cow::Owned(content.as_bytes().to_vec()),
         });
@@ -2844,14 +2916,29 @@ fn convert_bytes_value_to_type2<'a>(
         let bytes_str = inner.as_str();
         // Remove h' and '
         let content = &bytes_str[2..bytes_str.len() - 1];
-        let cleaned: String = content.chars().filter(|c| !c.is_whitespace()).collect();
-        let decoded = hex_decode_upper(cleaned.as_bytes()).map_err(|_| Error::PARSER {
+        let cleaned = clean_prefixed_byte_string(content);
+        let decoded = hex_decode(cleaned.as_bytes()).map_err(|_| Error::PARSER {
           msg: ErrorMsg {
             short: "Invalid base16 encoding".to_string(),
             extended: None,
           },
         })?;
         return Ok(ast::Type2::B16ByteString {
+          value: Cow::Owned(decoded),
+        });
+      }
+      Rule::bytes_b64 => {
+        let bytes_str = inner.as_str();
+        // Remove b64' and '
+        let content = &bytes_str[4..bytes_str.len() - 1];
+        let cleaned = clean_prefixed_byte_string(content);
+        let decoded = base64_decode(cleaned.as_bytes()).map_err(|short| Error::PARSER {
+          msg: ErrorMsg {
+            short: short.to_string(),
+            extended: None,
+          },
+        })?;
+        return Ok(ast::Type2::B64ByteString {
           value: Cow::Owned(decoded),
         });
       }

--- a/src/token.rs
+++ b/src/token.rs
@@ -5,9 +5,6 @@ use alloc::borrow::Cow;
 #[cfg(feature = "std")]
 use std::borrow::Cow;
 
-#[cfg(not(feature = "std"))]
-use alloc::string::String;
-
 #[cfg(target_arch = "wasm32")]
 use serde::{Deserialize, Serialize};
 
@@ -512,20 +509,18 @@ impl fmt::Display for ByteValue<'_> {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
       ByteValue::UTF8(b) => write!(f, "'{}'", core::str::from_utf8(b).map_err(|_| fmt::Error)?),
-      ByteValue::B16(b) => write!(
-        f,
-        "h'{}'",
-        String::from_utf8(b.to_vec())
-          .map_err(|_| fmt::Error)?
-          .replace(' ', "")
-      ),
-      ByteValue::B64(b) => write!(
-        f,
-        "b64'{}'",
-        String::from_utf8(b.to_vec())
-          .map_err(|_| fmt::Error)?
-          .replace(' ', "")
-      ),
+      ByteValue::B16(b) => {
+        f.write_str("h'")?;
+        data_encoding::HEXLOWER.encode_write(b, f)?;
+        f.write_str("'")
+      }
+      ByteValue::B64(b) => {
+        // RFC 8949 §8: byte strings are notated in the base encodings
+        // without padding
+        f.write_str("b64'")?;
+        data_encoding::BASE64URL_NOPAD.encode_write(b, f)?;
+        f.write_str("'")
+      }
     }
   }
 }

--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -3357,6 +3357,9 @@ where
       Type2::B16ByteString { value, .. } => {
         self.visit_value(&token::Value::BYTE(ByteValue::B16(value.clone())))
       }
+      Type2::B64ByteString { value, .. } => {
+        self.visit_value(&token::Value::BYTE(ByteValue::B64(value.clone())))
+      }
       Type2::ParenthesizedType { pt, .. } => self.visit_type(pt),
       Type2::Unwrap {
         ident,
@@ -3731,13 +3734,6 @@ where
       Type2::Any { .. } => Ok(()),
       #[cfg(not(feature = "ast-span"))]
       Type2::Any {} => Ok(()),
-      _ => {
-        self.add_error(format!(
-          "unsupported data type for validating cbor, got {}",
-          t2
-        ));
-        Ok(())
-      }
     }
   }
 
@@ -4707,6 +4703,17 @@ where
             }
           }
         },
+        token::Value::BYTE(bv) if self.state.ctrl.is_none() => {
+          let expected = match bv {
+            ByteValue::UTF8(value) | ByteValue::B16(value) | ByteValue::B64(value) => value,
+          };
+
+          if expected.as_ref() == b {
+            None
+          } else {
+            Some(format!("expected {}, got {:?}", bv, b))
+          }
+        }
         #[cfg(feature = "additional-controls")]
         token::Value::TEXT(t) => match &self.state.ctrl {
           Some(ControlOperator::ABNFB) => {

--- a/tests/byte_string_literal_diagnostics.rs
+++ b/tests/byte_string_literal_diagnostics.rs
@@ -1,0 +1,194 @@
+#![cfg(feature = "std")]
+#![cfg(feature = "cbor")]
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::borrow::Cow;
+use std::fmt::Write;
+
+#[cfg(feature = "json")]
+use cddl::validator::validate_json_from_str;
+use cddl::{
+  ast::Type2, parser::cddl_from_str, token::ByteValue, validator::validate_cbor_from_slice,
+};
+
+#[test]
+fn decoded_byte_values_and_ast_nodes_render_as_cddl_literals() {
+  for (value, expected) in [
+    (
+      ByteValue::B16(Cow::Borrowed(&[0xaa, 0x00, 0xff])),
+      "h'aa00ff'",
+    ),
+    (ByteValue::B16(Cow::Borrowed(b"AA")), "h'4141'"),
+    (ByteValue::B64(Cow::Borrowed(&[0xfb, 0xff])), "b64'-_8'"),
+    (ByteValue::B64(Cow::Borrowed(b"AA")), "b64'QUE'"),
+  ] {
+    assert_eq!(value.to_string(), expected);
+    assert_eq!(Type2::from(value).to_string(), expected);
+  }
+}
+
+#[test]
+fn invalid_unqualified_byte_string_state_remains_fallible() {
+  let value = ByteValue::UTF8(Cow::Borrowed(&[0xff]));
+  let mut rendered = String::new();
+  assert!(write!(&mut rendered, "{}", value).is_err());
+
+  rendered.clear();
+  assert!(write!(&mut rendered, "{}", Type2::from(value)).is_err());
+}
+
+#[test]
+fn decoded_byte_string_literals_format_and_reparse() {
+  for (source, expected) in [
+    ("m = b64'- _8 ='", "m = b64'-_8'"),
+    ("m = b64'-_8'", "m = b64'-_8'"),
+    ("m = b64'+/8='", "m = b64'-_8'"),
+    ("m = b64'+/8'", "m = b64'-_8'"),
+    ("m = b64'EjRWeA'", "m = b64'EjRWeA'"),
+    ("m = b64'EjRWeA=='", "m = b64'EjRWeA'"),
+    ("m = h'AA 00 FF'", "m = h'aa00ff'"),
+  ] {
+    let cddl = cddl_from_str(source, false).unwrap();
+    let formatted = cddl.to_string();
+    assert_eq!(formatted.trim(), expected);
+
+    let reparsed = cddl_from_str(&formatted, false).unwrap();
+    assert_eq!(reparsed.to_string(), formatted);
+  }
+}
+
+#[test]
+fn comments_inside_prefixed_byte_strings_are_ignored() {
+  for (source, expected) in [
+    (
+      "m = h'4342 ; comment with hex digits 4F52\n4F52'",
+      "m = h'43424f52'",
+    ),
+    ("m = b64'Ej ; note\nRWeA'", "m = b64'EjRWeA'"),
+  ] {
+    let cddl = cddl_from_str(source, false).unwrap();
+    assert_eq!(cddl.to_string().trim(), expected);
+  }
+}
+
+#[test]
+fn non_utf8_byte_literal_mismatches_return_diagnostics() {
+  for (literal, rendered) in [("h'AA'", "h'aa'"), ("b64'qg=='", "b64'qg'")] {
+    let error = validate_cbor_from_slice(&format!("m = {}", literal), b"\x01", None)
+      .expect_err("an integer must not match a byte-string literal")
+      .to_string();
+
+    assert!(
+      error.contains(&format!("expected {}", rendered)) && error.contains("got"),
+      "unexpected diagnostic for {}: {}",
+      literal,
+      error
+    );
+  }
+}
+
+#[test]
+fn decoded_byte_literal_accepting_and_rejecting_controls() {
+  for (literal, matching_cbor) in [
+    ("h'AA'", b"\x41\xaa".as_slice()),
+    ("b64'qg=='", b"\x41\xaa"),
+    ("b64'qg'", b"\x41\xaa"),
+  ] {
+    let schema = format!("m = {}", literal);
+    validate_cbor_from_slice(&schema, matching_cbor, None)
+      .unwrap_or_else(|error| panic!("{} rejected matching bytes: {}", literal, error));
+    validate_cbor_from_slice(&schema, b"\x41\xab", None)
+      .expect_err("a distinct byte string must not match the literal");
+  }
+}
+
+#[test]
+fn base64_alphabet_and_padding_variants_decode_identically() {
+  for literal in ["b64'-_8='", "b64'-_8'", "b64'+/8='", "b64'+/8'"] {
+    let schema = format!("m = {}", literal);
+    validate_cbor_from_slice(&schema, b"\x42\xfb\xff", None)
+      .unwrap_or_else(|error| panic!("{} rejected matching bytes: {}", literal, error));
+    validate_cbor_from_slice(&schema, b"\x42\xfb\xfe", None)
+      .expect_err("a distinct byte string must not match the literal");
+  }
+}
+
+#[test]
+fn base64_literals_mixing_both_rfc_4648_alphabets_are_rejected() {
+  // RFC 8610 §3.1 admits a base64 literal in the RFC 4648 §4 alphabet *or*
+  // the §5 alphabet; RFC 4648 §3.3 requires rejecting characters outside the
+  // chosen alphabet. A literal drawing from both belongs to neither.
+  for schema in [
+    "m = b64'+_8'",
+    "m = b64'-/8'",
+    "m = b64'+_8='",
+    "m = b64'-/8='",
+    "m = b64'Ej-W+A'",
+  ] {
+    let error = cddl_from_str(schema, false)
+      .expect_err(&format!(
+        "parser accepted mixed-alphabet literal: {}",
+        schema
+      ))
+      .to_string();
+
+    assert!(
+      error.contains("mixes the RFC 4648 base64 and base64url alphabets"),
+      "unexpected diagnostic for {}: {}",
+      schema,
+      error
+    );
+  }
+
+  // Accepting controls: either alphabet alone still decodes, with or without
+  // padding, and renders as unpadded base64url.
+  for (schema, expected) in [
+    ("m = b64'-_8'", "m = b64'-_8'"),
+    ("m = b64'+/8'", "m = b64'-_8'"),
+    ("m = b64'-_8='", "m = b64'-_8'"),
+    ("m = b64'+/8='", "m = b64'-_8'"),
+    ("m = b64'EjRWeA'", "m = b64'EjRWeA'"),
+  ] {
+    let cddl = cddl_from_str(schema, false)
+      .unwrap_or_else(|error| panic!("parser rejected {}: {}", schema, error));
+    assert_eq!(cddl.to_string().trim(), expected);
+  }
+}
+
+#[cfg(feature = "json")]
+#[cfg(feature = "additional-controls")]
+#[test]
+fn mixed_alphabet_rejection_is_shared_by_the_json_validator() {
+  // The alphabet check lives in the parser, so CBOR and JSON validation
+  // reject the same literals for the same reason.
+  let error = validate_json_from_str("m = tstr .b64u b64'+_8'", "\"-_8\"", None)
+    .expect_err("the JSON validator must reject a mixed-alphabet literal")
+    .to_string();
+  assert!(
+    error.contains("mixes the RFC 4648 base64 and base64url alphabets"),
+    "unexpected JSON diagnostic: {}",
+    error
+  );
+
+  // Accepting control: the same schema with a single-alphabet controller
+  // still validates.
+  validate_json_from_str("m = tstr .b64u b64'-_8'", "\"-_8\"", None)
+    .expect("a single-alphabet controller must still validate");
+}
+
+#[test]
+fn malformed_encoded_byte_literals_are_rejected() {
+  for schema in [
+    "m = h'A'",
+    "m = h'AG'",
+    "m = b64'qg='",
+    "m = b64'q'",
+    "m = b64'q=g='",
+  ] {
+    assert!(
+      cddl_from_str(schema, false).is_err(),
+      "parser accepted malformed literal: {}",
+      schema
+    );
+  }
+}

--- a/tests/grammar.rs
+++ b/tests/grammar.rs
@@ -148,7 +148,7 @@ escaped = "text with \"quotes\" and \n newline""#;
   #[test]
   fn test_byte_strings() {
     let input = r#"b16 = h'48656c6c6f'
-b64 = 'SGVsbG8='"#;
+b64 = b64'SGVsbG8='"#;
     let result = CDDLParser::parse(Rule::cddl, input);
     assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
   }

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -2,8 +2,9 @@
 
 use wasm_bindgen_test::*;
 
-use cddl::cddl_from_str;
+use cddl::{ast::Type2, cddl_from_str, token::ByteValue};
 use indoc::indoc;
+use std::borrow::Cow;
 
 #[wasm_bindgen_test]
 fn pass() {
@@ -23,4 +24,15 @@ fn pass() {
 fn fail() {
   let input = "invalid = {";
   assert!(cddl_from_str(input).is_err());
+}
+
+#[wasm_bindgen_test]
+fn decoded_byte_literals_format() {
+  for (value, expected) in [
+    (ByteValue::B16(Cow::Borrowed(&[0xaa])), "h'aa'"),
+    (ByteValue::B64(Cow::Borrowed(&[0xfb, 0xff])), "b64'-_8'"),
+  ] {
+    assert_eq!(value.to_string(), expected);
+    assert_eq!(Type2::from(value).to_string(), expected);
+  }
 }


### PR DESCRIPTION
This PR does three things:

Fixes three Pest migration regressions:
1. Adds support for base64url (dropped in #333)
2. Hex decoding used to only accept uppercase hex. Now it supports both (dropped in #334)
3. Fixed `Display for ByteValue` and `Display for Type2` not supporting round-tripping (it was rendering as UTF8 instead of printing bytes). Broke in #334

Some additional RFC 8610 §3.1 conformance gaps
1. support classic base64 alphabet (separate from base64url)
2. made padding optional (previously mandatory)
3. support comments & whitespace inside prefixed by strings

It also adds the missing CBOR validation path for `Type2::B64ByteString`

## Relevant RFC rules

<summary>section list</summary>
<details>

- RFC 8610 §3.1: byte strings "may be prefixed by `h` or `b64`. ... the
  string is interpreted as a sequence of pairs of hex digits (base16; see
  Section 8 of [RFC4648]) or a base64(url) string (**Section 4 or
  Section 5** of [RFC4648]), respectively (as with the diagnostic
  notation in Section 6 of [RFC7049] ...); **any whitespace present
  within the string (including comments) is ignored** in the prefixed
  case." Both base64 alphabets are therefore valid input.
- RFC 8949 §8 (obsoletes RFC 7049; RFC 8610 §3.1 defers to this
  diagnostic notation): "Byte strings are notated in one of the base
  encodings, **without padding**, ... `b64` for base64 or base64url (the
  actual encodings do not overlap, so the string remains unambiguous)."
  Its example is `b64'EjRWeA'` — unpadded. A parser that requires padding
  rejects the RFC's own example.
- RFC 8610 Appendix B: `bytes = [bsqual] %x27 *BCHAR %x27`,
  `bsqual = "h" / "b64"`.
- RFC 8610 Appendix G.1 (whitespace in prefixed byte strings) and G.2
  (unqualified `'...'` strings hold UTF-8 text bytes).
- RFC 9682 §2.1 and Appendix B (covering Err6543): the content of a
  prefixed byte-string literal is processed in a **semantic step after
  the syntax**; the whitespace/comment rules apply to that content. This
  PR implements exactly that split.
- RFC 8610 Appendix C (normative): a literal value matches CBOR data by
  decoded-value equality; mismatches reject normally.
- RFC 4648 §4 (base64), §5 (base64url), §8 (base16) define the encodings.

</details>

## Rust and Ruby evidence

The comparison used Rust `main` and Ruby `cddl` gem 0.12.14.

| Schema and CBOR value | main | Ruby 0.12.14 | This PR |
| --- | ---: | ---: | ---: |
| `m = h'AA'`, integer `1` | panic while formatting | reject | reject with `expected h'aa'` diagnostic |
| `m = h'AA'`, bytes `0xaa` | panic in literal path | accept | accept |
| `m = h'aa'`, bytes `0xaa` | parse error (uppercase-only decode) | accept | accept |
| `m = b64'qg=='`, integer `1` | parse error (no qualified B64 rule) | reject | reject with `expected b64'qg'` diagnostic |
| `m = b64'qg=='`, bytes `0xaa` | parse error | accept | accept |
| `m = b64'EjRWeA'` (RFC 8949 §8 example form), bytes `0x12345678` | parse error | accept | accept |
| `m = b64'EjRWeA=='`, bytes `0x12345678` | parse error | accept | accept |
| `m = b64'+/8='` (RFC 4648 §4 alphabet), bytes `0xfbff` | parse error | accept | accept |
| `m = b64'+/8'`, bytes `0xfbff` | parse error | accept | accept |
| `m = b64'-_8='`, bytes `0xfbff` | parse error | accept | accept |
| `m = b64'-_8'`, bytes `0xfbff` | parse error | accept | accept |
| `m = h'4342 ; comment␤4F52'`, bytes `"CBOR"` | parse error | crash (unrescued `ArgumentError`) | accept (RFC 8610 §3.1 ignores comments) |
| `m = b64'q g =='`, bytes `0xaa` | parse error | reject (strict decode) | accept (RFC 8610 §3.1 ignores whitespace) |
| `m = b64'qg='` (non-canonical padding), bytes `0xaa` | parse error | reject | reject at parse |
| `m = b64'+_8'` (mixed alphabets) | parse error | accept as `h'FBFF'` | reject at parse |
| `m = b64'-/8'` (mixed alphabets) | parse error | accept as `h'FBFF'` | reject at parse |
| `m = b64'+_8='` (mixed alphabets) | parse error | accept as `h'FBFF'` | reject at parse |
| `m = b64'+*8'` (outside both alphabets) | parse error | reject | reject at parse |
| `m = b64'-_9'` (non-zero trailing bits) | parse error | reject | reject at parse |