### PR TITLE
fix(validator): resolve incremental type choices consistently

### DIFF
--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -664,6 +664,49 @@ impl<'a> CBORValidator<'a> {
     Ok(())
   }
 
+  /// Validate every definition contributing to a named type choice from one
+  /// error checkpoint. Failed arms are tentative; their errors are retained
+  /// only when every arm fails.
+  fn visit_named_type_choice<T: std::fmt::Debug + 'static>(
+    &mut self,
+    ident: &Identifier<'a>,
+  ) -> visitor::Result<Error<T>>
+  where
+    cbor::Error<T>: From<cbor::Error<std::io::Error>>,
+  {
+    let choices = type_choice_types_from_ident(self.state.cddl, ident);
+
+    if choices.len() > 1 {
+      self.state.is_multi_type_choice = true;
+
+      if self.cbor.is_array() {
+        self.state.is_multi_type_choice_type_rule_validating_array = true;
+      }
+
+      let error_count = self.errors.len();
+      for choice in choices {
+        let current_error_count = self.errors.len();
+        self.visit_type(choice)?;
+        if self.errors.len() == current_error_count {
+          self.errors.truncate(error_count);
+          return Ok(());
+        }
+      }
+
+      return Ok(());
+    }
+
+    if let Some(choice) = choices.first() {
+      if choice.type_choices.len() > 1 && self.cbor.is_array() {
+        self.state.is_multi_type_choice_type_rule_validating_array = true;
+      }
+
+      return self.visit_type(choice);
+    }
+
+    Ok(())
+  }
+
   // Helper function to resolve a Type2 bound to a usize value
   fn resolve_range_bound(&self, bound: &Type2<'a>) -> std::result::Result<RangeBound, String> {
     match bound {
@@ -869,24 +912,6 @@ impl<'a> CBORValidator<'a> {
 
               cv.state.eval_generic_rule = Some(ge.name.ident);
               return cv.visit_rule(rule);
-            }
-          }
-
-          // Type socket with no main rule definition: its "/=" alternates
-          // are the only choices (visit_identifier cannot resolve these)
-          if rule_from_ident(cv.state.cddl, &ge.name).is_none() {
-            let alternates = type_choice_alternates_from_ident(cv.state.cddl, &ge.name);
-            if !alternates.is_empty() {
-              cv.state.is_multi_type_choice = true;
-              for t in alternates {
-                let error_count = cv.errors.len();
-                cv.visit_type(t)?;
-                if cv.errors.len() == error_count {
-                  cv.errors.clear();
-                  break;
-                }
-              }
-              return Ok(());
             }
           }
 
@@ -1283,51 +1308,7 @@ where
       }
     }
 
-    let type_choice_alternates = type_choice_alternates_from_ident(self.state.cddl, &tr.name);
-    if !type_choice_alternates.is_empty() {
-      self.state.is_multi_type_choice = true;
-
-      if self.cbor.is_array() {
-        self.state.is_multi_type_choice_type_rule_validating_array = true;
-      }
-
-      // When there are type choice alternates, we need to treat the main rule
-      // and all alternates as equal choices. According to RFC 8610 Section 2.2.2,
-      // "/=" extends a type by creating additional choices that should be
-      // combined with the main rule definition.
-      let error_count = self.errors.len();
-
-      // First try the main rule
-      let cur_errors = self.errors.len();
-      self.visit_type(&tr.value)?;
-      if self.errors.len() == cur_errors {
-        for _ in 0..self.errors.len() - error_count {
-          self.errors.pop();
-        }
-        return Ok(());
-      }
-
-      // Then try each alternate
-      for t in type_choice_alternates {
-        let cur_errors = self.errors.len();
-        self.visit_type(t)?;
-        if self.errors.len() == cur_errors {
-          for _ in 0..self.errors.len() - error_count {
-            self.errors.pop();
-          }
-          return Ok(());
-        }
-      }
-
-      // If we get here, none of the choices matched
-      return Ok(());
-    }
-
-    if tr.value.type_choices.len() > 1 && self.cbor.is_array() {
-      self.state.is_multi_type_choice_type_rule_validating_array = true;
-    }
-
-    self.visit_type(&tr.value)
+    self.visit_named_type_choice(&tr.name)
   }
 
   fn visit_group_rule(&mut self, gr: &GroupRule<'a>) -> visitor::Result<Error<T>> {
@@ -3328,24 +3309,6 @@ where
           }
         }
 
-        let type_choice_alternates = type_choice_alternates_from_ident(self.state.cddl, ident);
-        if !type_choice_alternates.is_empty() {
-          self.state.is_multi_type_choice = true;
-        }
-
-        let error_count = self.errors.len();
-        for t in type_choice_alternates {
-          let cur_errors = self.errors.len();
-          self.visit_type(t)?;
-          if self.errors.len() == cur_errors {
-            for _ in 0..self.errors.len() - error_count {
-              self.errors.pop();
-            }
-
-            return Ok(());
-          }
-        }
-
         self.visit_identifier(ident)
       }
       Type2::IntValue { value, .. } => self.visit_value(&token::Value::INT(*value)),
@@ -3756,23 +3719,44 @@ where
       }
     }
 
+    // A revisited rule only indicates a cycle when validation has not
+    // consumed any input since the previous visit, so recursion is tracked
+    // per data location: `t /= [t]` must recurse into nested elements
+    // (RFC 8610 Appendix A PEG matching) while a zero-progress reference
+    // like `a /= a` is still caught at its fixed position. NUL cannot
+    // appear in an identifier, so the key is unambiguous.
+    let visited_key = format!("{}\u{0}{}", ident.ident, self.state.data_location);
+
     // self.state.is_colon_shortcut_present is only true when the ident is part of a
     // member key
     if !self.state.is_colon_shortcut_present {
       if let Some(r) = rule_from_ident(self.state.cddl, ident) {
         // Check for recursion to prevent stack overflow
-        let rule_key = ident.ident.to_string();
-        if self.state.visited_rules.contains(&rule_key) {
+        if self.state.visited_rules.contains(&visited_key) {
           // We've already validated this rule in the current validation path
           // This is a recursive reference, so we allow it and assume it's valid
           return Ok(());
         }
 
         // Mark this rule as visited before recursing
-        self.state.visited_rules.insert(rule_key.clone());
+        self.state.visited_rules.insert(visited_key.clone());
         let result = self.visit_rule(r);
         // Remove the rule from visited set after processing
-        self.state.visited_rules.remove(&rule_key);
+        self.state.visited_rules.remove(&visited_key);
+
+        return result;
+      }
+
+      // A name may consist entirely of `/=` definitions (RFC 8610 Section
+      // 2.2.2). Such a choice has no base rule for `rule_from_ident` to find.
+      if !type_choice_types_from_ident(self.state.cddl, ident).is_empty() {
+        if self.state.visited_rules.contains(&visited_key) {
+          return Ok(());
+        }
+
+        self.state.visited_rules.insert(visited_key.clone());
+        let result = self.visit_named_type_choice(ident);
+        self.state.visited_rules.remove(&visited_key);
 
         return result;
       }
@@ -4321,24 +4305,6 @@ where
           self.active_single_entry_claim = None;
         }
         self.errors.append(&mut cv.errors);
-
-        return Ok(());
-      }
-    }
-
-    let type_choice_alternates = type_choice_alternates_from_ident(self.state.cddl, &entry.name);
-    if !type_choice_alternates.is_empty() {
-      self.state.is_multi_type_choice = true;
-    }
-
-    let error_count = self.errors.len();
-    for t in type_choice_alternates {
-      let cur_errors = self.errors.len();
-      self.visit_type(t)?;
-      if self.errors.len() == cur_errors {
-        for _ in 0..self.errors.len() - error_count {
-          self.errors.pop();
-        }
 
         return Ok(());
       }

--- a/src/validator/json.rs
+++ b/src/validator/json.rs
@@ -310,6 +310,43 @@ impl<'a> JSONValidator<'a> {
     Ok(())
   }
 
+  /// Validate every definition contributing to a named type choice from one
+  /// error checkpoint. Failed arms are tentative; their errors are retained
+  /// only when every arm fails.
+  fn visit_named_type_choice(&mut self, ident: &Identifier<'a>) -> visitor::Result<Error> {
+    let choices = type_choice_types_from_ident(self.state.cddl, ident);
+
+    if choices.len() > 1 {
+      self.state.is_multi_type_choice = true;
+
+      if self.json.is_array() {
+        self.state.is_multi_type_choice_type_rule_validating_array = true;
+      }
+
+      let error_count = self.errors.len();
+      for choice in choices {
+        let current_error_count = self.errors.len();
+        self.visit_type(choice)?;
+        if self.errors.len() == current_error_count {
+          self.errors.truncate(error_count);
+          return Ok(());
+        }
+      }
+
+      return Ok(());
+    }
+
+    if let Some(choice) = choices.first() {
+      if choice.type_choices.len() > 1 && self.json.is_array() {
+        self.state.is_multi_type_choice_type_rule_validating_array = true;
+      }
+
+      return self.visit_type(choice);
+    }
+
+    Ok(())
+  }
+
   fn validate_object_value(&mut self, value: &token::Value<'a>) -> visitor::Result<Error> {
     if let Value::Object(o) = &self.json {
       // Bareword member keys are converted to text string values
@@ -686,24 +723,6 @@ impl<'a> JSONValidator<'a> {
             }
           }
 
-          // Type socket with no main rule definition: its "/=" alternates
-          // are the only choices (visit_identifier cannot resolve these)
-          if rule_from_ident(jv.state.cddl, &ge.name).is_none() {
-            let alternates = type_choice_alternates_from_ident(jv.state.cddl, &ge.name);
-            if !alternates.is_empty() {
-              jv.state.is_multi_type_choice = true;
-              for t in alternates {
-                let error_count = jv.errors.len();
-                jv.visit_type(t)?;
-                if jv.errors.len() == error_count {
-                  jv.errors.clear();
-                  break;
-                }
-              }
-              return Ok(());
-            }
-          }
-
           jv.visit_identifier(&ge.name)
         })
       }
@@ -990,51 +1009,7 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
       }
     }
 
-    let type_choice_alternates = type_choice_alternates_from_ident(self.state.cddl, &tr.name);
-    if !type_choice_alternates.is_empty() {
-      self.state.is_multi_type_choice = true;
-
-      if self.json.is_array() {
-        self.state.is_multi_type_choice_type_rule_validating_array = true;
-      }
-
-      // When there are type choice alternates, we need to treat the main rule
-      // and all alternates as equal choices. According to RFC 8610 Section 2.2.2,
-      // "/=" extends a type by creating additional choices that should be
-      // combined with the main rule definition.
-      let error_count = self.errors.len();
-
-      // First try the main rule
-      let cur_errors = self.errors.len();
-      self.visit_type(&tr.value)?;
-      if self.errors.len() == cur_errors {
-        for _ in 0..self.errors.len() - error_count {
-          self.errors.pop();
-        }
-        return Ok(());
-      }
-
-      // Then try each alternate
-      for t in type_choice_alternates {
-        let cur_errors = self.errors.len();
-        self.visit_type(t)?;
-        if self.errors.len() == cur_errors {
-          for _ in 0..self.errors.len() - error_count {
-            self.errors.pop();
-          }
-          return Ok(());
-        }
-      }
-
-      // If we get here, none of the choices matched
-      return Ok(());
-    }
-
-    if tr.value.type_choices.len() > 1 && self.json.is_array() {
-      self.state.is_multi_type_choice_type_rule_validating_array = true;
-    }
-
-    self.visit_type(&tr.value)
+    self.visit_named_type_choice(&tr.name)
   }
 
   fn visit_group_rule(&mut self, gr: &GroupRule<'a>) -> visitor::Result<Error> {
@@ -2492,24 +2467,6 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
           }
         }
 
-        let type_choice_alternates = type_choice_alternates_from_ident(self.state.cddl, ident);
-        if !type_choice_alternates.is_empty() {
-          self.state.is_multi_type_choice = true;
-        }
-
-        let error_count = self.errors.len();
-        for t in type_choice_alternates {
-          let cur_errors = self.errors.len();
-          self.visit_type(t)?;
-          if self.errors.len() == cur_errors {
-            for _ in 0..self.errors.len() - error_count {
-              self.errors.pop();
-            }
-
-            return Ok(());
-          }
-        }
-
         self.visit_identifier(ident)
       }
       Type2::IntValue { value, .. } => self.visit_value(&token::Value::INT(*value)),
@@ -2714,8 +2671,16 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
       }
     }
 
+    // A revisited rule only indicates a cycle when validation has not
+    // consumed any input since the previous visit, so recursion is tracked
+    // per data location: `t /= [t]` must recurse into nested elements
+    // (RFC 8610 Appendix A PEG matching) while a zero-progress reference
+    // like `a /= a` is still caught at its fixed position. NUL cannot
+    // appear in an identifier, so the key is unambiguous.
+    let visited_key = format!("{}\u{0}{}", ident.ident, self.state.data_location);
+
     // Check for recursion before processing the identifier
-    if self.state.visited_rules.contains(ident.ident) {
+    if self.state.visited_rules.contains(&visited_key) {
       // We've seen this rule before in the current validation path, indicating a cycle
       self.add_error(format!(
         "Recursive rule reference detected: {}. This may indicate a circular definition in the CDDL schema.",
@@ -2729,10 +2694,19 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
     if !self.state.is_colon_shortcut_present {
       if let Some(r) = rule_from_ident(self.state.cddl, ident) {
         // Mark this rule as visited
-        self.state.visited_rules.insert(ident.ident.to_string());
+        self.state.visited_rules.insert(visited_key.clone());
         let result = self.visit_rule(r);
         // Remove this rule from visited set when we're done
-        self.state.visited_rules.remove(ident.ident);
+        self.state.visited_rules.remove(&visited_key);
+        return result;
+      }
+
+      // A name may consist entirely of `/=` definitions (RFC 8610 Section
+      // 2.2.2). Such a choice has no base rule for `rule_from_ident` to find.
+      if !type_choice_types_from_ident(self.state.cddl, ident).is_empty() {
+        self.state.visited_rules.insert(visited_key.clone());
+        let result = self.visit_named_type_choice(ident);
+        self.state.visited_rules.remove(&visited_key);
         return result;
       }
     }
@@ -2754,10 +2728,10 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
         for tc in rule.value.type_choices.iter() {
           if let Type2::Array { .. } = &tc.type1.type2 {
             // Mark this rule as visited for array type processing
-            self.state.visited_rules.insert(ident.ident.to_string());
+            self.state.visited_rules.insert(visited_key.clone());
             let result = self.visit_type_choice(tc);
             // Remove this rule from visited set when we're done
-            self.state.visited_rules.remove(ident.ident);
+            self.state.visited_rules.remove(&visited_key);
             return result;
           }
         }
@@ -2849,10 +2823,10 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
         if let Some(r) = rule_from_ident(self.state.cddl, ident) {
           if is_array_type_rule(self.state.cddl, ident) {
             // Mark this rule as visited for array type processing
-            self.state.visited_rules.insert(ident.ident.to_string());
+            self.state.visited_rules.insert(visited_key.clone());
             let result = self.visit_rule(r);
             // Remove this rule from visited set when we're done
-            self.state.visited_rules.remove(ident.ident);
+            self.state.visited_rules.remove(&visited_key);
             return result;
           }
         }
@@ -3138,24 +3112,6 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
             .validated_keys
             .get_or_insert_with(Vec::new)
             .extend(keys);
-        }
-
-        return Ok(());
-      }
-    }
-
-    let type_choice_alternates = type_choice_alternates_from_ident(self.state.cddl, &entry.name);
-    if !type_choice_alternates.is_empty() {
-      self.state.is_multi_type_choice = true;
-    }
-
-    let error_count = self.errors.len();
-    for t in type_choice_alternates {
-      let cur_errors = self.errors.len();
-      self.visit_type(t)?;
-      if self.errors.len() == cur_errors {
-        for _ in 0..self.errors.len() - error_count {
-          self.errors.pop();
         }
 
         return Ok(());

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -702,6 +702,21 @@ pub fn type_choice_alternates_from_ident<'a>(
     .collect::<Vec<_>>()
 }
 
+/// Find every type assigned to an identifier, in document order.
+///
+/// RFC 8610 Section 2.2.2 defines each `/=` assignment as another arm of the
+/// named type choice. Appendix C requires the arms to retain rule order.
+pub fn type_choice_types_from_ident<'a>(cddl: &'a CDDL, ident: &Identifier) -> Vec<&'a Type<'a>> {
+  cddl
+    .rules
+    .iter()
+    .filter_map(|r| match r {
+      Rule::Type { rule, .. } if &rule.name == ident => Some(&rule.value),
+      _ => None,
+    })
+    .collect::<Vec<_>>()
+}
+
 /// Find all group choice alternate rules from a given identifier
 pub fn group_choice_alternates_from_ident<'a>(
   cddl: &'a CDDL,

--- a/tests/incremental_type_choices.rs
+++ b/tests/incremental_type_choices.rs
@@ -1,0 +1,178 @@
+//! Incremental type-choice resolution regressions.
+//!
+//! RFC 8610 §2.2.2 makes every `/=` right-hand side an additional arm of
+//! the named type choice, and Appendix C requires those arms to be
+//! populated in source order.
+
+#![cfg(feature = "std")]
+#![cfg(all(feature = "cbor", feature = "json"))]
+#![cfg(not(target_arch = "wasm32"))]
+
+use cddl::{cddl_from_str, validate_cbor_from_slice, validate_json_from_str};
+
+const BASE_FIRST_ROOT: &str = r#"
+extended = bool
+extended /= text
+extended /= uint
+"#;
+
+const BASE_FIRST_ALIAS: &str = r#"
+root = extended
+extended = bool
+extended /= text
+extended /= uint
+"#;
+
+const ALTERNATE_ONLY_ROOT: &str = r#"
+extended /= text
+extended /= uint
+"#;
+
+const ALTERNATE_ONLY_ALIAS: &str = r#"
+root = extended
+extended /= text
+extended /= uint
+"#;
+
+fn assert_json_three_arm_choice(schema: &str) {
+  // Accept the base after two failed additions, and accept either addition.
+  validate_json_from_str(schema, "true", None).unwrap();
+  validate_json_from_str(schema, r#""x""#, None).unwrap();
+  validate_json_from_str(schema, "0", None).unwrap();
+
+  // Reject a value outside every arm.
+  validate_json_from_str(schema, "null", None).unwrap_err();
+}
+
+fn assert_cbor_three_arm_choice(schema: &str) {
+  // Accept the base after two failed additions, and accept either addition.
+  validate_cbor_from_slice(schema, &[0xf5], None).unwrap();
+  validate_cbor_from_slice(schema, &[0x61, b'x'], None).unwrap();
+  validate_cbor_from_slice(schema, &[0x00], None).unwrap();
+
+  // Reject a value outside every arm.
+  validate_cbor_from_slice(schema, &[0xf6], None).unwrap_err();
+}
+
+#[test]
+fn json_incremental_choice_is_root_independent_and_transactional() {
+  assert_json_three_arm_choice(BASE_FIRST_ROOT);
+  assert_json_three_arm_choice(BASE_FIRST_ALIAS);
+}
+
+#[test]
+fn cbor_incremental_choice_is_root_independent_and_transactional() {
+  assert_cbor_three_arm_choice(BASE_FIRST_ROOT);
+  assert_cbor_three_arm_choice(BASE_FIRST_ALIAS);
+}
+
+#[test]
+fn alternate_only_choice_remains_valid_at_root_and_through_alias() {
+  for schema in [ALTERNATE_ONLY_ROOT, ALTERNATE_ONLY_ALIAS] {
+    validate_json_from_str(schema, r#""x""#, None).unwrap();
+    validate_json_from_str(schema, "0", None).unwrap();
+    validate_json_from_str(schema, "true", None).unwrap_err();
+
+    validate_cbor_from_slice(schema, &[0x61, b'x'], None).unwrap();
+    validate_cbor_from_slice(schema, &[0x00], None).unwrap();
+    validate_cbor_from_slice(schema, &[0xf5], None).unwrap_err();
+  }
+}
+
+#[test]
+fn generic_rule_extended_by_a_matching_arm_keeps_validating() {
+  // A rule that carries generic parameters may be extended with `/=` under
+  // the same name. RFC 8610's grammar allows it (`rule = typename
+  // [genericparm] S assignt S type` with `assignt = "=" / "/="`), and both
+  // arms must honor the argument bound at the citation site.
+  //
+  // Pinned because the follow-up that teaches the duplicate check about
+  // generic arity could reject this schema by accident, and because the
+  // arms only resolve while the `/=` contribution spells its parameter the
+  // same way the plain `=` definition does — binding is keyed by parameter
+  // name. Ruby 0.12.14 is no oracle: it refuses the schema outright with
+  // `Augment "/=" not implemented for generics`.
+  let schema = "root = a<int>\na<t> = [t]\na<t> /= {k: t}\n";
+  cddl_from_str(schema, false).unwrap();
+
+  // Either arm matches, with `t` bound to `int` in both.
+  validate_json_from_str(schema, "[1]", None).unwrap();
+  validate_json_from_str(schema, r#"{"k":1}"#, None).unwrap();
+  validate_cbor_from_slice(schema, &[0x81, 0x01], None).unwrap();
+  validate_cbor_from_slice(schema, &[0xa1, 0x61, b'k', 0x01], None).unwrap();
+
+  // The binding is real, not vacuous: a `tstr` where the argument says
+  // `int` fails in both arms and both encodings.
+  validate_json_from_str(schema, r#"["x"]"#, None).unwrap_err();
+  validate_json_from_str(schema, r#"{"k":"x"}"#, None).unwrap_err();
+  validate_cbor_from_slice(schema, &[0x81, 0x61, b'x'], None).unwrap_err();
+  validate_cbor_from_slice(schema, &[0xa1, 0x61, b'k', 0x61, b'x'], None).unwrap_err();
+}
+
+#[test]
+fn recursive_choice_arms_consume_nested_data() {
+  // RFC 8610 §2.2.2 and Appendix C resolve every schema below to the choice
+  // (uint / [t]) no matter how `t` is reached, and PEG matching recurses
+  // into the array arm one data level at a time. Ruby cddl 0.12.14 accepts
+  // every accepting row here, root and alias alike.
+  const ROOT: &str = "t = uint\nt /= [t]\n";
+  const ALIAS: &str = "root = t\nt = uint\nt /= [t]\n";
+  const ALTERNATE_ONLY: &str = "t /= uint\nt /= [t]\n";
+
+  for schema in [ROOT, ALIAS, ALTERNATE_ONLY] {
+    for value in ["0", "[0]", "[[0]]", "[[[0]]]"] {
+      validate_json_from_str(schema, value, None)
+        .unwrap_or_else(|e| panic!("JSON {:?} rejected {}: {}", schema, value, e));
+    }
+    validate_json_from_str(schema, r#""x""#, None).unwrap_err();
+
+    for value in [
+      &[0x00][..],
+      &[0x81, 0x00],
+      &[0x81, 0x81, 0x00],
+      &[0x81, 0x81, 0x81, 0x00],
+    ] {
+      validate_cbor_from_slice(schema, value, None)
+        .unwrap_or_else(|e| panic!("CBOR {:?} rejected {:x?}: {}", schema, value, e));
+    }
+    validate_cbor_from_slice(schema, &[0x61, b'x'], None).unwrap_err();
+  }
+
+  // A value outside both arms must fail at every nesting depth instead of
+  // being waved through by a coarse recursion guard once `t` repeats.
+  for schema in [ROOT, ALIAS, ALTERNATE_ONLY] {
+    validate_json_from_str(schema, "[[true]]", None).unwrap_err();
+    validate_cbor_from_slice(schema, &[0x81, 0x81, 0xf5], None).unwrap_err();
+  }
+}
+
+#[test]
+fn mutually_recursive_incremental_choice_consumes_nested_data() {
+  // A realistic recursive shape: a list whose items are scalars or lists.
+  let schema = "list = [* item]\nitem = int\nitem /= list\n";
+
+  validate_json_from_str(schema, "[[1], 2]", None).unwrap();
+  validate_json_from_str(schema, "[[[3]], 4]", None).unwrap();
+  validate_json_from_str(schema, r#"[["x"]]"#, None).unwrap_err();
+
+  // [[1], 2] and [[[3]], 4]
+  validate_cbor_from_slice(schema, &[0x82, 0x81, 0x01, 0x02], None).unwrap();
+  validate_cbor_from_slice(schema, &[0x82, 0x81, 0x81, 0x03, 0x04], None).unwrap();
+  // [["x"]]
+  validate_cbor_from_slice(schema, &[0x81, 0x81, 0x61, b'x'], None).unwrap_err();
+}
+
+#[test]
+fn recursive_alternate_only_reference_completes_instead_of_crashing() {
+  // Before the shared resolver, the JSON validator overflowed its stack and
+  // aborted the process on this schema.
+  for schema in ["a /= a\n", "root = a\na /= a\n"] {
+    validate_json_from_str(schema, "0", None).unwrap_err();
+
+    // The CBOR recursion guard treats a revisited rule as satisfied, so the
+    // verdict for this degenerate schema is a vacuous accept (`a = a`
+    // behaves the same way); the regression pinned here is only that
+    // validation completes.
+    let _ = validate_cbor_from_slice(schema, &[0x00], None);
+  }
+}


### PR DESCRIPTION
This PR fixes named type choices assembled with /= so validation no longer depends on whether the name is the root rule or reached through a reference

Given the example
```
root = extended

extended = bool
extended /= text
extended /= uint
```
this PR adds a `type_choice_types_from_ident` which tracks every contribution in document order (order matters, because you can't do `extended = bool` after you've added an initial `/=`)

**NOTE**: to avoid a regression, this PR needs to be merged in a stack with #708 

## Relevant RFC rules

<details>
<summary>section list</summary>

- Section 2.2.2: `/=` adds alternatives to a named type choice, and a name may
  first be introduced with `/=`.
- Appendix C: a type choice "uses PEG semantics as discussed in Appendix A:
  the first choice that matches wins", and "the order of rules that contribute
  to a single rule name can very well matter". Appendix A supplies the PEG
  background that makes `/` a prioritized choice.
- Appendix C: incremental contributions populate the choice in rule order.
- Appendix C: when `/=` extends an undefined name, its right-hand side becomes
  the first entry in the choice. The appendix's duplicate-definition rule is
  stated only as "it is an error if the name was already defined with a
  different expression"; it does not spell out a later plain `=` after `/=`.
  Rejecting that ordering is therefore this implementation's policy —
  consistent with Appendix C (which offers no way to position a late base
  ahead of existing arms) and with Ruby 0.12.14 — not an explicit RFC mandate.

</details>

## Rust and Ruby evidence

The comparison uses Ruby `cddl` gem 0.12.14.

| Schema and instance | `main` | Ruby 0.12.14 | This PR | Basis |
| --- | ---: | ---: | ---: | --- |
| Same choice behind `root = extended`, value `0` | reject | accept | accept | Section 2.2.2 |
| Three-arm alias, matching base after two failed additions | reject | accepts equivalent base-first chain | accept | Section 2.2.2; Appendix A |
| `/=` followed by plain `=` | parsed, then root-dependent | rejects duplicate definition | parser rejects | Appendix C |
| `$foo /= int; $foo = text` (socket name) | parsed | rejects: `Duplicate rule definition $foo` | parser rejects | Appendix C; interop |
| `t = uint; t /= [t]` (root, alias, or alternate-only), values `0`, `[0]`, `[[0]]`, `[[[0]]]` | mixed: accepts depth ≤ 1, rejects depth ≥ 2 (JSON); alias rejects `[0]` under the first resolver draft; CBOR accepts deeper nesting only vacuously | accept (all depths, root and alias) | accept, by real validation, both encodings | Section 2.2.2; Appendix A PEG recursion |
| Same choice, value `[[true]]` (no arm matches at depth 2) | reject (JSON); accept (CBOR, vacuous — wrong) | reject | reject, both encodings | Section 2.2.2 |
| `list = [* item]; item = int; item /= list`, value `[[1], 2]` | reject (false recursion cycle) | accept | accept | Section 2.2.2; Appendix A |
`e = &(g); g = (red: shade, green: 2); shade = 1; shade /= 3`, root `e`, values `1`, `2`, `3`, `4` | reject, accept, accept, reject | accept, accept, accept, reject | accept, accept, accept, reject | Section 2.2.2; `&` enumeration member values resolve every arm |

Entries that are affected and differ from Ruby (but probably good to differ)

| Schema and instance | `main` | Ruby 0.12.14 | This PR | Basis |
| --- | ---: | ---: | ---: | --- |
| `a /= text; a = text` (identical expression) | parsed | `Warning: Identical redefinition` | parser rejects  (Appendix C says only when a redefinition MUST be an error, never when one must be accepted) | policy; pinned by test |
| `a /= a`, root `a`, value `0` | aborts (stack overflow, JSON) | error: deep recursion not implemented | reject (JSON); vacuous accept (CBOR) | recursion guard; degenerate schema |
| `a<t> = [t]; a<t> /= {k: t}`, root `a<int>`, values `[1]`, `{"k":1}` | accept both; rejects `["x"]`, `{"k":"x"}` | rejects the schema: `Augment "/=" not implemented for generics` (`lib/cddl.rb:211-214`) | identical to `main`, both encodings | grammar-legal (`assignt = "=" / "/="`); semantics not spelled out |
| `a /= text; a<t> = int` (generic head) | parsed | accepts, and both names stay live: Ruby stores generic rules in `@generics`, separate from `@rules | parser rejects: generics share the rule namespace | §3.10 and Appendix C |

Entries that are affected, but are wrong anyway and require follow-up work

| Schema and instance | `main` | Ruby 0.12.14 | This PR | Basis |
| --- | ---: | ---: | ---: | --- |
| `t /= int; t = (j: int)`, root `t` (cross-kind shadow) | parses; honors only the `/=` arm (accepts `1`) | rejects the schema: `Duplicate rule definition t` | parses; honors only the group-rule arm (accepts `{"j": 1}`) — inverted; follow-up rejects at parse | Appendix C; interop |
| `g //= (k: int); g = (j: int)`, root `{g}` | parses; honors only the `//=` arm | schema not accepted (gem-internal abort during rule merge; no verdict) | identical to `main`; follow-up rejects at parse | Appendix C; interop |
