### PR TITLE
fix(validator): keep byte string controls decoded

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1306,11 +1306,9 @@ impl fmt::Display for Type2<'_> {
       Type2::UintValue { value, .. } => write!(f, "{}", value),
       Type2::FloatValue { value, .. } => write!(f, "{}", value),
       Type2::TextValue { value, .. } => write!(f, "\"{}\"", value),
-      Type2::UTF8ByteString { value, .. } => write!(
-        f,
-        "'{}'",
-        core::str::from_utf8(value).map_err(|_| fmt::Error)?
-      ),
+      Type2::UTF8ByteString { value, .. } => {
+        write!(f, "{}", ByteValue::UTF8(Cow::Borrowed(value.as_ref())))
+      }
       Type2::B16ByteString { value, .. } => {
         write!(f, "{}", ByteValue::B16(Cow::Borrowed(value.as_ref())))
       }

--- a/src/token.rs
+++ b/src/token.rs
@@ -508,7 +508,12 @@ pub enum ByteValue<'a> {
 impl fmt::Display for ByteValue<'_> {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
-      ByteValue::UTF8(b) => write!(f, "'{}'", core::str::from_utf8(b).map_err(|_| fmt::Error)?),
+      ByteValue::UTF8(b) => match core::str::from_utf8(b) {
+        Ok(s) => write!(f, "'{}'", s),
+        // Non-UTF-8 bytes cannot use the '…' notation; h'…' denotes the
+        // same byte string.
+        Err(_) => write!(f, "{}", ByteValue::B16(Cow::Borrowed(b))),
+      },
       ByteValue::B16(b) => {
         f.write_str("h'")?;
         data_encoding::HEXLOWER.encode_write(b, f)?;

--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -2495,12 +2495,18 @@ where
           Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
             match &self.cbor {
               Value::Text(s) => {
-                match crate::validator::control::validate_b64u_text(target, controller, s, false) {
+                match crate::validator::control::validate_b64u_text(
+                  target,
+                  controller,
+                  s,
+                  false,
+                  Some(self.state.cddl),
+                ) {
                   Ok(is_valid) => {
                     if !is_valid {
                       self.add_error(format!(
-                        "text string \"{}\" does not match .b64u encoded bytes",
-                        s
+                        "text string \"{}\" does not match .b64u encoded bytes of {}",
+                        s, controller
                       ));
                     }
                   }
@@ -2527,12 +2533,18 @@ where
           Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
             match &self.cbor {
               Value::Text(s) => {
-                match crate::validator::control::validate_b64c_text(target, controller, s, false) {
+                match crate::validator::control::validate_b64c_text(
+                  target,
+                  controller,
+                  s,
+                  false,
+                  Some(self.state.cddl),
+                ) {
                   Ok(is_valid) => {
                     if !is_valid {
                       self.add_error(format!(
-                        "text string \"{}\" does not match .b64c encoded bytes",
-                        s
+                        "text string \"{}\" does not match .b64c encoded bytes of {}",
+                        s, controller
                       ));
                     }
                   }
@@ -2559,12 +2571,18 @@ where
           Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
             match &self.cbor {
               Value::Text(s) => {
-                match crate::validator::control::validate_b64u_text(target, controller, s, true) {
+                match crate::validator::control::validate_b64u_text(
+                  target,
+                  controller,
+                  s,
+                  true,
+                  Some(self.state.cddl),
+                ) {
                   Ok(is_valid) => {
                     if !is_valid {
                       self.add_error(format!(
-                        "text string \"{}\" does not match .b64u-sloppy encoded bytes",
-                        s
+                        "text string \"{}\" does not match .b64u-sloppy encoded bytes of {}",
+                        s, controller
                       ));
                     }
                   }
@@ -2591,12 +2609,18 @@ where
           Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
             match &self.cbor {
               Value::Text(s) => {
-                match crate::validator::control::validate_b64c_text(target, controller, s, true) {
+                match crate::validator::control::validate_b64c_text(
+                  target,
+                  controller,
+                  s,
+                  true,
+                  Some(self.state.cddl),
+                ) {
                   Ok(is_valid) => {
                     if !is_valid {
                       self.add_error(format!(
-                        "text string \"{}\" does not match .b64c-sloppy encoded bytes",
-                        s
+                        "text string \"{}\" does not match .b64c-sloppy encoded bytes of {}",
+                        s, controller
                       ));
                     }
                   }
@@ -2628,12 +2652,13 @@ where
                   controller,
                   s,
                   crate::validator::control::HexCase::Any,
+                  Some(self.state.cddl),
                 ) {
                   Ok(is_valid) => {
                     if !is_valid {
                       self.add_error(format!(
-                        "text string \"{}\" does not match .hex encoded bytes",
-                        s
+                        "text string \"{}\" does not match .hex encoded bytes of {}",
+                        s, controller
                       ));
                     }
                   }
@@ -2665,12 +2690,13 @@ where
                   controller,
                   s,
                   crate::validator::control::HexCase::Lower,
+                  Some(self.state.cddl),
                 ) {
                   Ok(is_valid) => {
                     if !is_valid {
                       self.add_error(format!(
-                        "text string \"{}\" does not match .hexlc encoded bytes",
-                        s
+                        "text string \"{}\" does not match .hexlc encoded bytes of {}",
+                        s, controller
                       ));
                     }
                   }
@@ -2702,12 +2728,13 @@ where
                   controller,
                   s,
                   crate::validator::control::HexCase::Upper,
+                  Some(self.state.cddl),
                 ) {
                   Ok(is_valid) => {
                     if !is_valid {
                       self.add_error(format!(
-                        "text string \"{}\" does not match .hexuc encoded bytes",
-                        s
+                        "text string \"{}\" does not match .hexuc encoded bytes of {}",
+                        s, controller
                       ));
                     }
                   }
@@ -2734,12 +2761,18 @@ where
           Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
             match &self.cbor {
               Value::Text(s) => {
-                match crate::validator::control::validate_b32_text(target, controller, s, false) {
+                match crate::validator::control::validate_b32_text(
+                  target,
+                  controller,
+                  s,
+                  false,
+                  Some(self.state.cddl),
+                ) {
                   Ok(is_valid) => {
                     if !is_valid {
                       self.add_error(format!(
-                        "text string \"{}\" does not match .b32 encoded bytes",
-                        s
+                        "text string \"{}\" does not match .b32 encoded bytes of {}",
+                        s, controller
                       ));
                     }
                   }
@@ -2766,12 +2799,18 @@ where
           Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
             match &self.cbor {
               Value::Text(s) => {
-                match crate::validator::control::validate_b32_text(target, controller, s, true) {
+                match crate::validator::control::validate_b32_text(
+                  target,
+                  controller,
+                  s,
+                  true,
+                  Some(self.state.cddl),
+                ) {
                   Ok(is_valid) => {
                     if !is_valid {
                       self.add_error(format!(
-                        "text string \"{}\" does not match .h32 encoded bytes",
-                        s
+                        "text string \"{}\" does not match .h32 encoded bytes of {}",
+                        s, controller
                       ));
                     }
                   }
@@ -2798,12 +2837,17 @@ where
           Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
             match &self.cbor {
               Value::Text(s) => {
-                match crate::validator::control::validate_b45_text(target, controller, s) {
+                match crate::validator::control::validate_b45_text(
+                  target,
+                  controller,
+                  s,
+                  Some(self.state.cddl),
+                ) {
                   Ok(is_valid) => {
                     if !is_valid {
                       self.add_error(format!(
-                        "text string \"{}\" does not match .b45 encoded bytes",
-                        s
+                        "text string \"{}\" does not match .b45 encoded bytes of {}",
+                        s, controller
                       ));
                     }
                   }
@@ -4703,7 +4747,21 @@ where
             }
           }
         },
-        token::Value::BYTE(bv) if self.state.ctrl.is_none() => {
+        token::Value::BYTE(bv)
+          if self.state.ctrl.is_none() || {
+            #[cfg(feature = "additional-controls")]
+            {
+              matches!(
+                self.state.ctrl,
+                Some(ControlOperator::CAT | ControlOperator::DET)
+              )
+            }
+            #[cfg(not(feature = "additional-controls"))]
+            {
+              false
+            }
+          } =>
+        {
           let expected = match bv {
             ByteValue::UTF8(value) | ByteValue::B16(value) | ByteValue::B64(value) => value,
           };
@@ -4736,36 +4794,8 @@ where
         #[cfg(feature = "additional-controls")]
         token::Value::BYTE(bv) => match &self.state.ctrl {
           Some(ControlOperator::ABNFB) => match bv {
-            ByteValue::UTF8(utf8bv) => validate_abnf(
-              std::str::from_utf8(utf8bv).map_err(Error::UTF8Parsing)?,
-              std::str::from_utf8(b).map_err(Error::UTF8Parsing)?,
-            )
-            .err()
-            .map(|e| {
-              format!(
-                "cbor bytes \"{:?}\" are not valid against abnf {}: {}",
-                b, bv, e
-              )
-            }),
-            ByteValue::B16(b16bv) => validate_abnf(
-              std::str::from_utf8(&base16::decode(b16bv).map_err(Error::Base16Decoding)?)
-                .map_err(Error::UTF8Parsing)?,
-              std::str::from_utf8(b).map_err(Error::UTF8Parsing)?,
-            )
-            .err()
-            .map(|e| {
-              format!(
-                "cbor bytes \"{:?}\" are not valid against abnf {}: {}",
-                b, bv, e
-              )
-            }),
-            ByteValue::B64(b64bv) => validate_abnf(
-              std::str::from_utf8(
-                &data_encoding::BASE64URL
-                  .decode(b64bv)
-                  .map_err(Error::Base64Decoding)?,
-              )
-              .map_err(Error::UTF8Parsing)?,
+            ByteValue::UTF8(abnf) | ByteValue::B16(abnf) | ByteValue::B64(abnf) => validate_abnf(
+              std::str::from_utf8(abnf).map_err(Error::UTF8Parsing)?,
               std::str::from_utf8(b).map_err(Error::UTF8Parsing)?,
             )
             .err()

--- a/src/validator/control.rs
+++ b/src/validator/control.rs
@@ -2,7 +2,7 @@
 #![cfg(not(feature = "lsp"))]
 
 use crate::{
-  ast::{GroupEntry, Identifier, MemberKey, Operator, RangeCtlOp, Rule, Type2, CDDL},
+  ast::{GroupEntry, Identifier, MemberKey, Operator, RangeCtlOp, Rule, Type2, TypeChoice, CDDL},
   token::ControlOperator,
 };
 
@@ -20,17 +20,45 @@ pub fn string_literals_from_ident<'a>(
   ident: &Identifier,
 ) -> Vec<&'a Type2<'a>> {
   let mut literals = Vec::new();
+  collect_string_literals_from_ident(cddl, ident, &mut Vec::new(), &mut literals);
+  literals
+}
+
+fn collect_string_literals_from_ident<'a>(
+  cddl: &'a CDDL<'a>,
+  ident: &Identifier,
+  visited: &mut Vec<&'a str>,
+  literals: &mut Vec<&'a Type2<'a>>,
+) {
+  // The cycle guard is per resolution, not per rule entry: `/=`
+  // choice-extension siblings share the rule name and must all contribute.
+  if visited.contains(&ident.ident) {
+    return;
+  }
+  let mut pushed = false;
   for r in cddl.rules.iter() {
     if let Rule::Type { rule, .. } = r {
       if rule.name == *ident {
+        if !pushed {
+          visited.push(rule.name.ident);
+          pushed = true;
+        }
         for tc in rule.value.type_choices.iter() {
+          // A choice carrying a range/control operator denotes a computed
+          // value, not the literal on its left-hand side; contributing that
+          // operand alone would silently collapse the computation. Skip the
+          // choice so resolution fails closed until composed operands are
+          // computed here.
+          if tc.type1.operator.is_some() {
+            continue;
+          }
           match &tc.type1.type2 {
             t @ Type2::TextValue { .. }
             | t @ Type2::UTF8ByteString { .. }
             | t @ Type2::B16ByteString { .. }
             | t @ Type2::B64ByteString { .. } => literals.push(t),
             Type2::Typename { ident, .. } => {
-              literals.append(&mut string_literals_from_ident(cddl, ident))
+              collect_string_literals_from_ident(cddl, ident, visited, literals)
             }
             _ => continue,
           }
@@ -38,8 +66,6 @@ pub fn string_literals_from_ident<'a>(
       }
     }
   }
-
-  literals
 }
 
 /// Retrieve all numeric values from a given rule identifier. Used for
@@ -65,6 +91,40 @@ pub fn numeric_values_from_ident<'a>(cddl: &'a CDDL<'a>, ident: &Identifier) -> 
   }
 
   literals
+}
+
+#[cfg(feature = "additional-controls")]
+#[derive(Clone, Copy)]
+enum ByteStringKind {
+  Utf8,
+  B16,
+  B64,
+}
+
+#[cfg(feature = "additional-controls")]
+fn concatenate_byte_literals<'a>(
+  target: &[u8],
+  controller: &[u8],
+  is_dedent: bool,
+  kind: ByteStringKind,
+) -> Type2<'a> {
+  let target = if is_dedent {
+    dedent_bytes(target)
+  } else {
+    target.to_vec()
+  };
+  let controller = if is_dedent {
+    dedent_bytes(controller)
+  } else {
+    controller.to_vec()
+  };
+  let value = [target, controller].concat();
+
+  match kind {
+    ByteStringKind::Utf8 => ByteValue::UTF8(value.into()).into(),
+    ByteStringKind::B16 => ByteValue::B16(value.into()).into(),
+    ByteStringKind::B64 => ByteValue::B64(value.into()).into(),
+  }
 }
 
 #[cfg(feature = "additional-controls")]
@@ -113,8 +173,6 @@ pub fn cat_operation<'a>(
         value: controller, ..
       } => match std::str::from_utf8(controller) {
         Ok(controller) => {
-          let controller = controller.trim_start_matches('\'').trim_end_matches('\'');
-
           if is_dedent {
             literals.push(format!("{}{}", dedent_str(value), dedent_str(controller)).into())
           } else {
@@ -126,39 +184,28 @@ pub fn cat_operation<'a>(
       // "testing" .cat h'313233'
       Type2::B16ByteString {
         value: controller, ..
-      } => match base16::decode(controller) {
-        Ok(controller) => match String::from_utf8(controller) {
-          Ok(controller) => {
-            if is_dedent {
-              literals.push(format!("{}{}", dedent_str(value), dedent_str(&controller)).into())
-            } else {
-              literals.push(format!("{}{}", value, controller).into())
-            }
+      } => match std::str::from_utf8(controller) {
+        Ok(controller) => {
+          if is_dedent {
+            literals.push(format!("{}{}", dedent_str(value), dedent_str(controller)).into())
+          } else {
+            literals.push(format!("{}{}", value, controller).into())
           }
-          Err(e) => return Err(format!("error decoding utf-8: {}", e)),
-        },
-        Err(e) => return Err(format!("error decoding base16 byte string literal: {}", e)),
+        }
+        Err(e) => return Err(format!("error decoding utf-8: {}", e)),
       },
       // "testing" .cat b64'MTIz'
       Type2::B64ByteString {
         value: controller, ..
-      } => match data_encoding::BASE64URL.decode(controller) {
-        Ok(controller) => match String::from_utf8(controller) {
-          Ok(controller) => {
-            if is_dedent {
-              literals.push(format!("{}{}", dedent_str(value), dedent_str(&controller)).into())
-            } else {
-              literals.push(format!("{}{}", value, controller).into())
-            }
+      } => match std::str::from_utf8(controller) {
+        Ok(controller) => {
+          if is_dedent {
+            literals.push(format!("{}{}", dedent_str(value), dedent_str(controller)).into())
+          } else {
+            literals.push(format!("{}{}", value, controller).into())
           }
-          Err(e) => return Err(format!("error decoding utf-8: {}", e)),
-        },
-        Err(e) => {
-          return Err(format!(
-            "error decoding base64 encoded byte string literal: {}",
-            e
-          ))
         }
+        Err(e) => return Err(format!("error decoding utf-8: {}", e)),
       },
       // "testing" .cat ( "123" / "1234" )
       Type2::ParenthesizedType { pt: controller, .. } => {
@@ -203,128 +250,80 @@ pub fn cat_operation<'a>(
 
       return Err(format!("invalid target type in {} control operator", ctrl));
     }
-    Type2::UTF8ByteString { value, .. } => match std::str::from_utf8(value) {
-      Ok(value) => match controller {
-        // 'testing' .cat "123"
-        Type2::TextValue {
-          value: controller, ..
-        } => {
-          let value = value.trim_start_matches('\'').trim_end_matches('\'');
-
-          if is_dedent {
-            literals.push(format!("{}{}", dedent_str(value), dedent_str(controller)).into())
-          } else {
-            literals.push(format!("{}{}", value, controller).into())
+    Type2::UTF8ByteString { value, .. } => match controller {
+      // 'testing' .cat "123"
+      Type2::TextValue {
+        value: controller, ..
+      } => literals.push(concatenate_byte_literals(
+        value,
+        controller.as_bytes(),
+        is_dedent,
+        ByteStringKind::Utf8,
+      )),
+      Type2::Typename { ident, .. } => {
+        let sl = string_literals_from_ident(cddl, ident);
+        if sl.is_empty() {
+          return Err(format!(
+            "controller of type rule {} is not a string literal",
+            ident
+          ));
+        }
+        for controller in sl.iter() {
+          literals.append(&mut cat_operation(cddl, target, controller, is_dedent)?)
+        }
+      }
+      // 'testing' .cat '123
+      Type2::UTF8ByteString {
+        value: controller, ..
+      } => literals.push(concatenate_byte_literals(
+        value,
+        controller,
+        is_dedent,
+        ByteStringKind::Utf8,
+      )),
+      // 'testing' .cat h'313233'
+      Type2::B16ByteString {
+        value: controller, ..
+      } => literals.push(concatenate_byte_literals(
+        value,
+        controller,
+        is_dedent,
+        ByteStringKind::Utf8,
+      )),
+      // 'testing' .cat b64'MTIz'
+      Type2::B64ByteString {
+        value: controller, ..
+      } => literals.push(concatenate_byte_literals(
+        value,
+        controller,
+        is_dedent,
+        ByteStringKind::Utf8,
+      )),
+      // 'testing' .cat ( "123" / "1234" )
+      Type2::ParenthesizedType { pt: controller, .. } => {
+        for controller in controller.type_choices.iter() {
+          if controller.type1.operator.is_none() {
+            literals.append(&mut cat_operation(
+              cddl,
+              target,
+              &controller.type1.type2,
+              is_dedent,
+            )?);
           }
         }
-        Type2::Typename { ident, .. } => {
-          let sl = string_literals_from_ident(cddl, ident);
-          if sl.is_empty() {
-            return Err(format!(
-              "controller of type rule {} is not a string literal",
-              ident
-            ));
-          }
-          for controller in sl.iter() {
-            literals.append(&mut cat_operation(cddl, target, controller, is_dedent)?)
-          }
-        }
-        // 'testing' .cat '123
-        Type2::UTF8ByteString {
-          value: controller, ..
-        } => match std::str::from_utf8(controller) {
-          Ok(controller) => {
-            let value = value.trim_start_matches('\'').trim_end_matches('\'');
-            let controller = controller.trim_start_matches('\'').trim_end_matches('\'');
-
-            if is_dedent {
-              literals.push(format!("{}{}", dedent_str(value), dedent_str(controller)).into())
-            } else {
-              literals.push(format!("{}{}", value, controller).into())
-            }
-          }
-          Err(e) => return Err(format!("error parsing byte string: {}", e)),
-        },
-        // 'testing' .cat h'313233'
-        Type2::B16ByteString {
-          value: controller, ..
-        } => match base16::decode(controller) {
-          Ok(controller) => match String::from_utf8(controller) {
-            Ok(controller) => {
-              let value = value.trim_start_matches('\'').trim_end_matches('\'');
-
-              if is_dedent {
-                literals.push(format!("{}{}", dedent_str(value), dedent_str(&controller)).into())
-              } else {
-                literals.push(format!("{}{}", value, controller).into())
-              }
-            }
-            Err(e) => return Err(format!("error decoding utf-8: {}", e)),
-          },
-          Err(e) => return Err(format!("error decoding base16 byte string literal: {}", e)),
-        },
-        // 'testing' .cat b64'MTIz'
-        Type2::B64ByteString {
-          value: controller, ..
-        } => match data_encoding::BASE64URL.decode(controller) {
-          Ok(controller) => match String::from_utf8(controller) {
-            Ok(controller) => {
-              let value = value.trim_start_matches('\'').trim_end_matches('\'');
-
-              if is_dedent {
-                literals.push(format!("{}{}", dedent_str(value), dedent_str(&controller)).into())
-              } else {
-                literals.push(format!("{}{}", value, controller).into())
-              }
-            }
-            Err(e) => return Err(format!("error decoding utf-8: {}", e)),
-          },
-          Err(e) => {
-            return Err(format!(
-              "error decoding base64 encoded byte string literal: {}",
-              e
-            ))
-          }
-        },
-        // 'testing' .cat ( "123" / "1234" )
-        Type2::ParenthesizedType { pt: controller, .. } => {
-          for controller in controller.type_choices.iter() {
-            if controller.type1.operator.is_none() {
-              literals.append(&mut cat_operation(
-                cddl,
-                target,
-                &controller.type1.type2,
-                is_dedent,
-              )?);
-            }
-          }
-        }
-        _ => return Err(format!("invalid controller used for {} operation", ctrl)),
-      },
-      Err(e) => return Err(format!("error parsing byte string: {}", e)),
+      }
+      _ => return Err(format!("invalid controller used for {} operation", ctrl)),
     },
     Type2::B16ByteString { value, .. } => match controller {
       // h'74657374696E67' .cat "123"
       Type2::TextValue {
         value: controller, ..
-      } => {
-        let controller = if is_dedent {
-          base16::encode_lower(dedent_str(controller).as_bytes())
-        } else {
-          base16::encode_lower(controller.as_bytes())
-        };
-
-        let concat = if is_dedent {
-          [&dedent_bytes(value, false)?[..], controller.as_bytes()].concat()
-        } else {
-          [&value[..], controller.as_bytes()].concat()
-        };
-        match base16::decode(&concat) {
-          // Ignore the decoded value
-          Ok(_) => literals.push(ByteValue::B16(concat.into()).into()),
-          Err(e) => return Err(format!("concatenated value is invalid base16: {}", e)),
-        }
-      }
+      } => literals.push(concatenate_byte_literals(
+        value,
+        controller.as_bytes(),
+        is_dedent,
+        ByteStringKind::B16,
+      )),
       // h'74657374696E67' .cat b
       Type2::Typename { ident, .. } => {
         let sl = string_literals_from_ident(cddl, ident);
@@ -341,67 +340,30 @@ pub fn cat_operation<'a>(
       // h'74657374696E67' .cat '123'
       Type2::UTF8ByteString {
         value: controller, ..
-      } => {
-        let controller = if is_dedent {
-          base16::encode_lower(&dedent_bytes(controller, true)?)
-        } else {
-          base16::encode_lower(&controller[..])
-        };
-
-        let concat = if is_dedent {
-          [&dedent_bytes(value, false)?[..], controller.as_bytes()].concat()
-        } else {
-          [&value[..], controller.as_bytes()].concat()
-        };
-
-        match base16::decode(&concat) {
-          // Ignore the decoded value
-          Ok(_) => literals.push(ByteValue::B16(concat.into()).into()),
-          Err(e) => return Err(format!("concatenated value is invalid base16: {}", e)),
-        }
-      }
+      } => literals.push(concatenate_byte_literals(
+        value,
+        controller,
+        is_dedent,
+        ByteStringKind::B16,
+      )),
       // h'74657374696E67' .cat h'313233'
       Type2::B16ByteString {
         value: controller, ..
-      } => {
-        let concat = if is_dedent {
-          [
-            &dedent_bytes(value, false)?[..],
-            &dedent_bytes(controller, false)?[..],
-          ]
-          .concat()
-        } else {
-          [&value[..], &controller[..]].concat()
-        };
-        match base16::decode(&concat) {
-          // Ignore the decoded value
-          Ok(_) => literals.push(ByteValue::B16(concat.into()).into()),
-          Err(e) => return Err(format!("concatenated value is invalid base16: {}", e)),
-        }
-      }
+      } => literals.push(concatenate_byte_literals(
+        value,
+        controller,
+        is_dedent,
+        ByteStringKind::B16,
+      )),
       // h'74657374696E67' .cat b64'MTIz'
       Type2::B64ByteString {
         value: controller, ..
-      } => match data_encoding::BASE64URL.decode(controller) {
-        Ok(controller) => {
-          let controller = base16::encode_lower(&controller);
-          let concat = if is_dedent {
-            [
-              &dedent_bytes(value, false)?[..],
-              dedent_str(&controller).as_bytes(),
-            ]
-            .concat()
-          } else {
-            [&value[..], controller.as_bytes()].concat()
-          };
-          match base16::decode(&concat) {
-            // Ignore the decoded value
-            Ok(_) => literals.push(ByteValue::B16(concat.into()).into()),
-            Err(e) => return Err(format!("concatenated value is invalid base16: {}", e)),
-          }
-        }
-        Err(e) => return Err(format!("controller is invalid base64: {}", e)),
-      },
+      } => literals.push(concatenate_byte_literals(
+        value,
+        controller,
+        is_dedent,
+        ByteStringKind::B16,
+      )),
       // h'74657374696E67' .cat ( "123" / "1234" )
       Type2::ParenthesizedType { pt: controller, .. } => {
         for controller in controller.type_choices.iter() {
@@ -421,24 +383,12 @@ pub fn cat_operation<'a>(
       // b64'dGVzdGluZw==' .cat "123"
       Type2::TextValue {
         value: controller, ..
-      } => match data_encoding::BASE64URL.decode(value) {
-        Ok(value) => {
-          let concat = if is_dedent {
-            [
-              &dedent_bytes(&value, false)?[..],
-              dedent_str(controller).as_bytes(),
-            ]
-            .concat()
-          } else {
-            [&value[..], controller.as_bytes()].concat()
-          };
-
-          literals.push(
-            ByteValue::B64(data_encoding::BASE64URL.encode(&concat).into_bytes().into()).into(),
-          )
-        }
-        Err(e) => return Err(format!("target is invalid base64: {}", e)),
-      },
+      } => literals.push(concatenate_byte_literals(
+        value,
+        controller.as_bytes(),
+        is_dedent,
+        ByteStringKind::B64,
+      )),
       // b64'dGVzdGluZw==' .cat b
       Type2::Typename { ident, .. } => {
         let sl = string_literals_from_ident(cddl, ident);
@@ -455,70 +405,30 @@ pub fn cat_operation<'a>(
       // b64'dGVzdGluZw==' .cat '123'
       Type2::UTF8ByteString {
         value: controller, ..
-      } => match data_encoding::BASE64URL.decode(value) {
-        Ok(value) => {
-          let concat = if is_dedent {
-            [
-              &dedent_bytes(&value, false)?[..],
-              &dedent_bytes(controller, true)?[..],
-            ]
-            .concat()
-          } else {
-            [&value[..], &controller[..]].concat()
-          };
-
-          literals.push(
-            ByteValue::B64(data_encoding::BASE64URL.encode(&concat).into_bytes().into()).into(),
-          )
-        }
-        Err(e) => return Err(format!("target is invalid base64: {}", e)),
-      },
+      } => literals.push(concatenate_byte_literals(
+        value,
+        controller,
+        is_dedent,
+        ByteStringKind::B64,
+      )),
       // b64'dGVzdGluZw==' .cat h'313233'
       Type2::B16ByteString {
         value: controller, ..
-      } => match data_encoding::BASE64URL.decode(value) {
-        Ok(value) => match base16::decode(controller) {
-          Ok(controller) => {
-            let concat = if is_dedent {
-              [
-                &dedent_bytes(&value, false)?[..],
-                &dedent_bytes(&controller, false)?[..],
-              ]
-              .concat()
-            } else {
-              [&value[..], &controller[..]].concat()
-            };
-            literals.push(
-              ByteValue::B64(data_encoding::BASE64URL.encode(&concat).into_bytes().into()).into(),
-            )
-          }
-          Err(e) => return Err(format!("controller is invalid base16: {}", e)),
-        },
-        Err(e) => return Err(format!("target is invalid base64: {}", e)),
-      },
+      } => literals.push(concatenate_byte_literals(
+        value,
+        controller,
+        is_dedent,
+        ByteStringKind::B64,
+      )),
       // b64'dGVzdGluZw==' .cat b64'MTIz'
       Type2::B64ByteString {
         value: controller, ..
-      } => match data_encoding::BASE64URL.decode(value) {
-        Ok(value) => match data_encoding::BASE64URL.decode(controller) {
-          Ok(controller) => {
-            let concat = if is_dedent {
-              [
-                &dedent_bytes(&value, false)?[..],
-                &dedent_bytes(&controller, false)?[..],
-              ]
-              .concat()
-            } else {
-              [&value[..], &controller[..]].concat()
-            };
-            literals.push(
-              ByteValue::B64(data_encoding::BASE64URL.encode(&concat).into_bytes().into()).into(),
-            )
-          }
-          Err(e) => return Err(format!("controller is invalid base64: {}", e)),
-        },
-        Err(e) => return Err(format!("target is invalid base64: {}", e)),
-      },
+      } => literals.push(concatenate_byte_literals(
+        value,
+        controller,
+        is_dedent,
+        ByteStringKind::B64,
+      )),
       // b64'dGVzdGluZw==' .cat ( "123" / "1234" )
       Type2::ParenthesizedType { pt: controller, .. } => {
         for controller in controller.type_choices.iter() {
@@ -559,33 +469,20 @@ fn dedent_str(source: &str) -> String {
 }
 
 #[cfg(feature = "additional-controls")]
-fn dedent_bytes(source: &[u8], is_utf8_byte_string: bool) -> Result<Vec<u8>, String> {
-  #[cfg(windows)]
-  let line_ending = "\r\n";
-  #[cfg(not(windows))]
-  let line_ending = "\n";
-
-  if is_utf8_byte_string {
-    return Ok(
-      std::str::from_utf8(source)
-        .map_err(|e| e.to_string())?
-        .trim_start_matches('\'')
-        .trim_end_matches('\'')
-        .split(line_ending)
-        .map(|l| l.trim_start())
-        .join(line_ending)
-        .into_bytes(),
-    );
+fn dedent_bytes(source: &[u8]) -> Vec<u8> {
+  let mut dedented = Vec::with_capacity(source.len());
+  for (index, line) in source.split(|byte| *byte == b'\n').enumerate() {
+    if index > 0 {
+      dedented.push(b'\n');
+    }
+    let content = line
+      .iter()
+      .position(|byte| !byte.is_ascii_whitespace())
+      .map(|start| &line[start..])
+      .unwrap_or_default();
+    dedented.extend_from_slice(content);
   }
-
-  Ok(
-    std::str::from_utf8(source)
-      .map_err(|e| e.to_string())?
-      .split(line_ending)
-      .map(|l| l.trim_start())
-      .join(line_ending)
-      .into_bytes(),
-  )
+  dedented
 }
 
 /// Numeric addition of target and controller. The Vec return type is to
@@ -866,12 +763,9 @@ mod tests {
       cat_operation(
         &cddl,
         &Type2::from("foo".to_string()),
-        &Type2::from(indoc!(
-          r#"'
-            bar
-            baz
-          '"#,
-        )),
+        // The byte-string payload holds decoded bytes, without the source
+        // literal's surrounding apostrophes.
+        &Type2::from("\n  bar\n  baz\n"),
         false,
       )?,
       vec![Type2::TextValue {
@@ -916,6 +810,31 @@ mod tests {
         #[cfg(feature = "ast-span")]
         span: Span::default(),
       }]
+    );
+
+    Ok(())
+  }
+
+  #[cfg(feature = "additional-controls")]
+  #[test]
+  fn test_cat_preserves_apostrophes_in_decoded_byte_controllers(
+  ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let cddl = cddl_from_str("a = \"x\" .cat 'y'", true)?;
+
+    // Byte-string payloads hold decoded bytes; apostrophes in them are
+    // content, not source quoting.
+    assert_eq!(
+      cat_operation(
+        &cddl,
+        &Type2::from("x".to_string()),
+        &Type2::from("'y'"),
+        false,
+      )?,
+      vec![Type2::TextValue {
+        value: "x'y'".into(),
+        #[cfg(feature = "ast-span")]
+        span: Span::default(),
+      }],
     );
 
     Ok(())
@@ -976,8 +895,20 @@ mod tests {
     };
 
     // "hello" in base64url is "aGVsbG8"
-    assert!(validate_b64u_text(&target, &controller, "aGVsbG8", false)?);
-    assert!(!validate_b64u_text(&target, &controller, "invalid", false)?);
+    assert!(validate_b64u_text(
+      &target,
+      &controller,
+      "aGVsbG8",
+      false,
+      None
+    )?);
+    assert!(!validate_b64u_text(
+      &target,
+      &controller,
+      "invalid",
+      false,
+      None
+    )?);
 
     Ok(())
   }
@@ -1005,31 +936,36 @@ mod tests {
       &target,
       &controller,
       "68656c6c6f",
-      HexCase::Any
+      HexCase::Any,
+      None
     )?);
     assert!(validate_hex_text(
       &target,
       &controller,
       "68656c6c6f",
-      HexCase::Lower
+      HexCase::Lower,
+      None
     )?);
     assert!(!validate_hex_text(
       &target,
       &controller,
       "68656C6C6F",
-      HexCase::Lower
+      HexCase::Lower,
+      None
     )?);
     assert!(validate_hex_text(
       &target,
       &controller,
       "68656C6C6F",
-      HexCase::Upper
+      HexCase::Upper,
+      None
     )?);
     assert!(!validate_hex_text(
       &target,
       &controller,
       "invalid",
-      HexCase::Any
+      HexCase::Any,
+      None
     )?);
 
     Ok(())
@@ -1261,55 +1197,180 @@ mod tests {
 }
 
 #[cfg(feature = "additional-controls")]
+fn byte_string_controller_matches<'a, F>(
+  cddl: Option<&'a CDDL<'a>>,
+  controller: &Type2<'a>,
+  predicate: &F,
+) -> Option<bool>
+where
+  F: Fn(&[u8]) -> bool,
+{
+  byte_string_controller_matches_impl(cddl, controller, predicate, &mut Vec::new())
+}
+
+#[cfg(feature = "additional-controls")]
+fn byte_string_controller_matches_impl<'a, F>(
+  cddl: Option<&'a CDDL<'a>>,
+  controller: &Type2<'a>,
+  predicate: &F,
+  visited: &mut Vec<&'a str>,
+) -> Option<bool>
+where
+  F: Fn(&[u8]) -> bool,
+{
+  match controller {
+    Type2::UTF8ByteString { value, .. }
+    | Type2::B16ByteString { value, .. }
+    | Type2::B64ByteString { value, .. } => Some(predicate(value)),
+    Type2::Typename { ident, .. } => {
+      let cddl = cddl?;
+      // Per-resolution cycle guard; `/=` choice-extension siblings share the
+      // rule name and must all be examined.
+      if visited.contains(&ident.ident) {
+        return None;
+      }
+      let mut found = false;
+      let mut pushed = false;
+      for r in cddl.rules.iter() {
+        if let Rule::Type { rule, .. } = r {
+          if rule.name == *ident {
+            if !pushed {
+              visited.push(rule.name.ident);
+              pushed = true;
+            }
+            if let Some(matches) =
+              byte_string_choices_match(Some(cddl), &rule.value.type_choices, predicate, visited)
+            {
+              found = true;
+              if matches {
+                return Some(true);
+              }
+            }
+          }
+        }
+      }
+      found.then_some(false)
+    }
+    Type2::ParenthesizedType { pt, .. } => {
+      byte_string_choices_match(cddl, &pt.type_choices, predicate, visited)
+    }
+    _ => None,
+  }
+}
+
+#[cfg(feature = "additional-controls")]
+fn byte_string_choices_match<'a, F>(
+  cddl: Option<&'a CDDL<'a>>,
+  choices: &[TypeChoice<'a>],
+  predicate: &F,
+  visited: &mut Vec<&'a str>,
+) -> Option<bool>
+where
+  F: Fn(&[u8]) -> bool,
+{
+  let mut found = false;
+  for choice in choices {
+    let result = match &choice.type1.operator {
+      None => byte_string_controller_matches_impl(cddl, &choice.type1.type2, predicate, visited),
+      // A .cat/.det choice matches through its computed value.
+      Some(operator) => match operator.operator {
+        RangeCtlOp::CtlOp {
+          ctrl: ControlOperator::CAT,
+          ..
+        }
+        | RangeCtlOp::CtlOp {
+          ctrl: ControlOperator::DET,
+          ..
+        } => cddl.and_then(|cddl| {
+          let is_dedent = matches!(
+            operator.operator,
+            RangeCtlOp::CtlOp {
+              ctrl: ControlOperator::DET,
+              ..
+            }
+          );
+          match cat_operation(cddl, &choice.type1.type2, &operator.type2, is_dedent) {
+            Ok(computed) => {
+              let mut found = false;
+              for value in &computed {
+                if let Some(matches) =
+                  byte_string_controller_matches_impl(Some(cddl), value, predicate, visited)
+                {
+                  found = true;
+                  if matches {
+                    return Some(true);
+                  }
+                }
+              }
+              found.then_some(false)
+            }
+            Err(_) => None,
+          }
+        }),
+        _ => None,
+      },
+    };
+    if let Some(matches) = result {
+      found = true;
+      if matches {
+        return Some(true);
+      }
+    }
+  }
+  found.then_some(false)
+}
+
+#[cfg(feature = "additional-controls")]
+/// Decode base64 text per the RFC 9741 "sloppy" variants: the alphabet and
+/// padding rules of the underlying RFC 4648 encoding still apply, but
+/// non-zero trailing (padding) bits are tolerated.
+fn sloppy_base64_decode(text_value: &str, is_classic: bool) -> Option<Vec<u8>> {
+  let mut spec = data_encoding::Specification::new();
+  spec
+    .symbols
+    .push_str("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
+  spec.symbols.push_str(if is_classic { "+/" } else { "-_" });
+  spec.check_trailing_bits = false;
+  if is_classic {
+    spec.padding = Some('=');
+  }
+
+  let encoding = spec.encoding().ok()?;
+  encoding.decode(text_value.as_bytes()).ok()
+}
+
+#[cfg(feature = "additional-controls")]
 /// Validate base64url encoded text string against byte string
 pub fn validate_b64u_text<'a>(
   __target: &Type2<'a>,
   controller: &Type2<'a>,
   text_value: &str,
   is_sloppy: bool,
+  cddl: Option<&'a CDDL<'a>>,
 ) -> Result<bool, String> {
-  match controller {
-    Type2::UTF8ByteString { value, .. }
-    | Type2::B16ByteString { value, .. }
-    | Type2::B64ByteString { value, .. } => {
-      // Try strict decoding first
-      let decoded = data_encoding::BASE64URL_NOPAD.decode(text_value.as_bytes());
+  if byte_string_controller_matches(cddl, controller, &|_| false).is_some() {
+    // Try strict decoding first
+    let decoded = data_encoding::BASE64URL_NOPAD.decode(text_value.as_bytes());
 
-      match decoded {
-        Ok(decoded_bytes) => Ok(decoded_bytes == value.as_ref()),
-        Err(_) if is_sloppy => {
-          // RFC 9741: Sloppy mode does not validate that additional trailing
-          // bits (beyond the encoded data) are zero. We try a more lenient
-          // decode that ignores trailing bit issues.
-          let cleaned = text_value.trim_end_matches('=');
-          match data_encoding::BASE64URL_NOPAD.decode(cleaned.as_bytes()) {
-            Ok(decoded_bytes) => Ok(decoded_bytes == value.as_ref()),
-            Err(_) => {
-              // Try with lenient decoding: strip last char if we have trailing
-              // bits that would be non-zero
-              if !cleaned.is_empty() {
-                let without_last = &cleaned[..cleaned.len() - 1];
-                if let Ok(decoded_bytes) =
-                  data_encoding::BASE64URL_NOPAD.decode(without_last.as_bytes())
-                {
-                  // In sloppy mode, if the byte prefix matches, accept it
-                  Ok(value.as_ref().starts_with(&decoded_bytes[..]))
-                } else {
-                  Ok(false)
-                }
-              } else {
-                Ok(false)
-              }
-            }
-          }
-        }
-        Err(_) => Ok(false),
-      }
+    match decoded {
+      Ok(decoded_bytes) => Ok(
+        byte_string_controller_matches(cddl, controller, &|value| decoded_bytes == value)
+          .unwrap_or(false),
+      ),
+      Err(_) if is_sloppy => match sloppy_base64_decode(text_value, false) {
+        Some(decoded_bytes) => Ok(
+          byte_string_controller_matches(cddl, controller, &|value| decoded_bytes == value)
+            .unwrap_or(false),
+        ),
+        None => Ok(false),
+      },
+      Err(_) => Ok(false),
     }
-    _ => Err(format!(
+  } else {
+    Err(format!(
       "invalid controller type for .b64u operation: {}",
       controller
-    )),
+    ))
   }
 }
 
@@ -1320,46 +1381,31 @@ pub fn validate_b64c_text<'a>(
   controller: &Type2<'a>,
   text_value: &str,
   is_sloppy: bool,
+  cddl: Option<&'a CDDL<'a>>,
 ) -> Result<bool, String> {
-  match controller {
-    Type2::UTF8ByteString { value, .. }
-    | Type2::B16ByteString { value, .. }
-    | Type2::B64ByteString { value, .. } => {
-      // Try strict decoding first
-      let decoded = data_encoding::BASE64.decode(text_value.as_bytes());
+  if byte_string_controller_matches(cddl, controller, &|_| false).is_some() {
+    // Try strict decoding first
+    let decoded = data_encoding::BASE64.decode(text_value.as_bytes());
 
-      match decoded {
-        Ok(decoded_bytes) => Ok(decoded_bytes == value.as_ref()),
-        Err(_) if is_sloppy => {
-          // RFC 9741: Sloppy mode does not validate that additional trailing
-          // bits are zero. Try without padding enforcement.
-          let cleaned = text_value.trim_end_matches('=');
-          match data_encoding::BASE64_NOPAD.decode(cleaned.as_bytes()) {
-            Ok(decoded_bytes) => Ok(decoded_bytes == value.as_ref()),
-            Err(_) => {
-              // Try lenient: strip last char for non-zero trailing bits
-              if !cleaned.is_empty() {
-                let without_last = &cleaned[..cleaned.len() - 1];
-                if let Ok(decoded_bytes) =
-                  data_encoding::BASE64_NOPAD.decode(without_last.as_bytes())
-                {
-                  Ok(value.as_ref().starts_with(&decoded_bytes[..]))
-                } else {
-                  Ok(false)
-                }
-              } else {
-                Ok(false)
-              }
-            }
-          }
-        }
-        Err(_) => Ok(false),
-      }
+    match decoded {
+      Ok(decoded_bytes) => Ok(
+        byte_string_controller_matches(cddl, controller, &|value| decoded_bytes == value)
+          .unwrap_or(false),
+      ),
+      Err(_) if is_sloppy => match sloppy_base64_decode(text_value, true) {
+        Some(decoded_bytes) => Ok(
+          byte_string_controller_matches(cddl, controller, &|value| decoded_bytes == value)
+            .unwrap_or(false),
+        ),
+        None => Ok(false),
+      },
+      Err(_) => Ok(false),
     }
-    _ => Err(format!(
+  } else {
+    Err(format!(
       "invalid controller type for .b64c operation: {}",
       controller
-    )),
+    ))
   }
 }
 
@@ -1370,33 +1416,33 @@ pub fn validate_hex_text<'a>(
   controller: &Type2<'a>,
   text_value: &str,
   case_type: HexCase,
+  cddl: Option<&'a CDDL<'a>>,
 ) -> Result<bool, String> {
-  match controller {
-    Type2::UTF8ByteString { value, .. }
-    | Type2::B16ByteString { value, .. }
-    | Type2::B64ByteString { value, .. } => {
-      let decoded = hex::decode(text_value);
-      match decoded {
-        Ok(decoded_bytes) => {
-          let matches_bytes = decoded_bytes == value.as_ref();
-          let matches_case = match case_type {
-            HexCase::Any => true,
-            HexCase::Lower => text_value
-              .chars()
-              .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()),
-            HexCase::Upper => text_value
-              .chars()
-              .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit()),
-          };
-          Ok(matches_bytes && matches_case)
-        }
-        Err(_) => Ok(false),
+  if byte_string_controller_matches(cddl, controller, &|_| false).is_some() {
+    let decoded = hex::decode(text_value);
+    match decoded {
+      Ok(decoded_bytes) => {
+        let matches_bytes =
+          byte_string_controller_matches(cddl, controller, &|value| decoded_bytes == value)
+            .unwrap_or(false);
+        let matches_case = match case_type {
+          HexCase::Any => true,
+          HexCase::Lower => text_value
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()),
+          HexCase::Upper => text_value
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit()),
+        };
+        Ok(matches_bytes && matches_case)
       }
+      Err(_) => Ok(false),
     }
-    _ => Err(format!(
+  } else {
+    Err(format!(
       "invalid controller type for .hex operation: {}",
       controller
-    )),
+    ))
   }
 }
 
@@ -1415,26 +1461,27 @@ pub fn validate_b32_text<'a>(
   controller: &Type2<'a>,
   text_value: &str,
   is_hex_variant: bool,
+  cddl: Option<&'a CDDL<'a>>,
 ) -> Result<bool, String> {
-  match controller {
-    Type2::UTF8ByteString { value, .. }
-    | Type2::B16ByteString { value, .. }
-    | Type2::B64ByteString { value, .. } => {
-      let decoded = if is_hex_variant {
-        data_encoding::BASE32HEX_NOPAD.decode(text_value.as_bytes())
-      } else {
-        data_encoding::BASE32_NOPAD.decode(text_value.as_bytes())
-      };
+  if byte_string_controller_matches(cddl, controller, &|_| false).is_some() {
+    let decoded = if is_hex_variant {
+      data_encoding::BASE32HEX_NOPAD.decode(text_value.as_bytes())
+    } else {
+      data_encoding::BASE32_NOPAD.decode(text_value.as_bytes())
+    };
 
-      match decoded {
-        Ok(decoded_bytes) => Ok(decoded_bytes == value.as_ref()),
-        Err(_) => Ok(false),
-      }
+    match decoded {
+      Ok(decoded_bytes) => Ok(
+        byte_string_controller_matches(cddl, controller, &|value| decoded_bytes == value)
+          .unwrap_or(false),
+      ),
+      Err(_) => Ok(false),
     }
-    _ => Err(format!(
+  } else {
+    Err(format!(
       "invalid controller type for .b32/.h32 operation: {}",
       controller
-    )),
+    ))
   }
 }
 
@@ -1444,20 +1491,23 @@ pub fn validate_b45_text<'a>(
   _target: &Type2<'a>,
   controller: &Type2<'a>,
   text_value: &str,
+  cddl: Option<&'a CDDL<'a>>,
 ) -> Result<bool, String> {
   #[cfg(feature = "std")]
   {
-    match controller {
-      Type2::UTF8ByteString { value, .. }
-      | Type2::B16ByteString { value, .. }
-      | Type2::B64ByteString { value, .. } => match base45::decode(text_value) {
-        Ok(decoded_bytes) => Ok(decoded_bytes == value.as_ref()),
+    if byte_string_controller_matches(cddl, controller, &|_| false).is_some() {
+      match base45::decode(text_value) {
+        Ok(decoded_bytes) => Ok(
+          byte_string_controller_matches(cddl, controller, &|value| decoded_bytes == value)
+            .unwrap_or(false),
+        ),
         Err(_) => Ok(false),
-      },
-      _ => Err(format!(
+      }
+    } else {
+      Err(format!(
         "invalid controller type for .b45 operation: {}",
         controller
-      )),
+      ))
     }
   }
   #[cfg(not(feature = "std"))]

--- a/src/validator/json.rs
+++ b/src/validator/json.rs
@@ -390,110 +390,6 @@ impl<'a> JSONValidator<'a> {
   }
 
   #[cfg(feature = "additional-controls")]
-  fn validate_b64_control(
-    &mut self,
-    bytes: &[u8],
-    is_classic: bool,
-    is_sloppy: bool,
-  ) -> visitor::Result<Error> {
-    if let Value::String(s) = &self.json {
-      // Try strict decoding first
-      let decoded_result = if is_classic {
-        data_encoding::BASE64.decode(s.as_bytes())
-      } else {
-        data_encoding::BASE64URL_NOPAD.decode(s.as_bytes())
-      };
-
-      match decoded_result {
-        Ok(decoded_bytes) => {
-          if decoded_bytes == bytes {
-            // Validation succeeded
-          } else {
-            let expected_encoding = if is_classic {
-              data_encoding::BASE64.encode(bytes)
-            } else {
-              data_encoding::BASE64URL_NOPAD.encode(bytes)
-            };
-            self.add_error(format!(
-              "string \"{}\" does not match expected base64 encoding \"{}\"",
-              s, expected_encoding
-            ));
-          }
-        }
-        Err(e) => {
-          if is_sloppy {
-            // RFC 9741: Sloppy mode - try to decode without checking trailing bits
-            let cleaned = s.trim_end_matches('=');
-            let sloppy_result = if is_classic {
-              data_encoding::BASE64_NOPAD.decode(cleaned.as_bytes())
-            } else {
-              data_encoding::BASE64URL_NOPAD.decode(cleaned.as_bytes())
-            };
-            match sloppy_result {
-              Ok(decoded_bytes) => {
-                if decoded_bytes != bytes {
-                  let expected_encoding = if is_classic {
-                    data_encoding::BASE64.encode(bytes)
-                  } else {
-                    data_encoding::BASE64URL_NOPAD.encode(bytes)
-                  };
-                  self.add_error(format!(
-                    "string \"{}\" does not match expected base64 encoding \"{}\"",
-                    s, expected_encoding
-                  ));
-                }
-              }
-              Err(_) => {
-                self.add_error(format!("invalid base64 encoding: {}", e));
-              }
-            }
-          } else {
-            self.add_error(format!("invalid base64 encoding: {}", e));
-          }
-        }
-      }
-    } else {
-      self.add_error(format!(
-        "expected string for base64 validation, got {}",
-        self.json
-      ));
-    }
-    Ok(())
-  }
-
-  #[cfg(feature = "additional-controls")]
-  fn validate_hex_control(&mut self, bytes: &[u8], is_lowercase: bool) -> visitor::Result<Error> {
-    if let Value::String(s) = &self.json {
-      match hex::decode(s) {
-        Ok(decoded_bytes) => {
-          if decoded_bytes == bytes {
-            // Validation succeeded
-          } else {
-            let expected_encoding = if is_lowercase {
-              hex::encode(bytes)
-            } else {
-              hex::encode_upper(bytes)
-            };
-            self.add_error(format!(
-              "string \"{}\" does not match expected hex encoding \"{}\"",
-              s, expected_encoding
-            ));
-          }
-        }
-        Err(e) => {
-          self.add_error(format!("invalid hex encoding: {}", e));
-        }
-      }
-    } else {
-      self.add_error(format!(
-        "expected string for hex validation, got {}",
-        self.json
-      ));
-    }
-    Ok(())
-  }
-
-  #[cfg(feature = "additional-controls")]
   /// Substitute generic parameters in a Type2 expression.
   ///
   /// When validating generic rules, generic parameters need to be replaced with
@@ -1935,158 +1831,261 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
         self.state.ctrl = None;
       }
       #[cfg(feature = "additional-controls")]
-      #[cfg(feature = "additional-controls")]
-      ControlOperator::B64U => {
-        self.state.ctrl = Some(ctrl);
-        match target {
-          Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
-            match &self.json {
-              Value::String(_) => self.visit_type2(controller)?,
-              _ => self.add_error(format!(
-                ".b64u can only be matched against JSON string, got {}",
-                self.json
-              )),
+      ControlOperator::B64U => match target {
+        Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
+          match &self.json {
+            Value::String(s) => {
+              match crate::validator::control::validate_b64u_text(
+                target,
+                controller,
+                s,
+                false,
+                Some(self.state.cddl),
+              ) {
+                Ok(is_valid) => {
+                  if !is_valid {
+                    self.add_error(format!(
+                      "string \"{}\" does not match .b64u encoded bytes of {}",
+                      s, controller
+                    ));
+                  }
+                }
+                Err(e) => self.add_error(e),
+              }
             }
+            _ => self.add_error(format!(
+              ".b64u can only be matched against JSON string, got {}",
+              self.json
+            )),
           }
-          _ => self.add_error(format!(
-            ".b64u can only be matched against string data type, got {}",
-            target
-          )),
         }
-        self.state.ctrl = None;
-      }
+        _ => self.add_error(format!(
+          ".b64u can only be matched against string data type, got {}",
+          target
+        )),
+      },
       #[cfg(feature = "additional-controls")]
-      #[cfg(feature = "additional-controls")]
-      ControlOperator::B64C => {
-        self.state.ctrl = Some(ctrl);
-        match target {
-          Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
-            match &self.json {
-              Value::String(_) => self.visit_type2(controller)?,
-              _ => self.add_error(format!(
-                ".b64c can only be matched against JSON string, got {}",
-                self.json
-              )),
+      ControlOperator::B64C => match target {
+        Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
+          match &self.json {
+            Value::String(s) => {
+              match crate::validator::control::validate_b64c_text(
+                target,
+                controller,
+                s,
+                false,
+                Some(self.state.cddl),
+              ) {
+                Ok(is_valid) => {
+                  if !is_valid {
+                    self.add_error(format!(
+                      "string \"{}\" does not match .b64c encoded bytes of {}",
+                      s, controller
+                    ));
+                  }
+                }
+                Err(e) => self.add_error(e),
+              }
             }
+            _ => self.add_error(format!(
+              ".b64c can only be matched against JSON string, got {}",
+              self.json
+            )),
           }
-          _ => self.add_error(format!(
-            ".b64c can only be matched against string data type, got {}",
-            target
-          )),
         }
-        self.state.ctrl = None;
-      }
+        _ => self.add_error(format!(
+          ".b64c can only be matched against string data type, got {}",
+          target
+        )),
+      },
       #[cfg(feature = "additional-controls")]
-      ControlOperator::B64USLOPPY => {
-        self.state.ctrl = Some(ctrl);
-        match target {
-          Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
-            match &self.json {
-              Value::String(_) => self.visit_type2(controller)?,
-              _ => self.add_error(format!(
-                ".b64u-sloppy can only be matched against JSON string, got {}",
-                self.json
-              )),
+      ControlOperator::B64USLOPPY => match target {
+        Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
+          match &self.json {
+            Value::String(s) => {
+              match crate::validator::control::validate_b64u_text(
+                target,
+                controller,
+                s,
+                true,
+                Some(self.state.cddl),
+              ) {
+                Ok(is_valid) => {
+                  if !is_valid {
+                    self.add_error(format!(
+                      "string \"{}\" does not match .b64u-sloppy encoded bytes of {}",
+                      s, controller
+                    ));
+                  }
+                }
+                Err(e) => self.add_error(e),
+              }
             }
+            _ => self.add_error(format!(
+              ".b64u-sloppy can only be matched against JSON string, got {}",
+              self.json
+            )),
           }
-          _ => self.add_error(format!(
-            ".b64u-sloppy can only be matched against string data type, got {}",
-            target
-          )),
         }
-        self.state.ctrl = None;
-      }
+        _ => self.add_error(format!(
+          ".b64u-sloppy can only be matched against string data type, got {}",
+          target
+        )),
+      },
       #[cfg(feature = "additional-controls")]
-      ControlOperator::B64CSLOPPY => {
-        self.state.ctrl = Some(ctrl);
-        match target {
-          Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
-            match &self.json {
-              Value::String(_) => self.visit_type2(controller)?,
-              _ => self.add_error(format!(
-                ".b64c-sloppy can only be matched against JSON string, got {}",
-                self.json
-              )),
+      ControlOperator::B64CSLOPPY => match target {
+        Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
+          match &self.json {
+            Value::String(s) => {
+              match crate::validator::control::validate_b64c_text(
+                target,
+                controller,
+                s,
+                true,
+                Some(self.state.cddl),
+              ) {
+                Ok(is_valid) => {
+                  if !is_valid {
+                    self.add_error(format!(
+                      "string \"{}\" does not match .b64c-sloppy encoded bytes of {}",
+                      s, controller
+                    ));
+                  }
+                }
+                Err(e) => self.add_error(e),
+              }
             }
+            _ => self.add_error(format!(
+              ".b64c-sloppy can only be matched against JSON string, got {}",
+              self.json
+            )),
           }
-          _ => self.add_error(format!(
-            ".b64c-sloppy can only be matched against string data type, got {}",
-            target
-          )),
         }
-        self.state.ctrl = None;
-      }
+        _ => self.add_error(format!(
+          ".b64c-sloppy can only be matched against string data type, got {}",
+          target
+        )),
+      },
       #[cfg(feature = "additional-controls")]
-      ControlOperator::HEX => {
-        self.state.ctrl = Some(ctrl);
-        match target {
-          Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
-            match &self.json {
-              Value::String(_) => self.visit_type2(controller)?,
-              _ => self.add_error(format!(
-                ".hex can only be matched against JSON string, got {}",
-                self.json
-              )),
+      ControlOperator::HEX => match target {
+        Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
+          match &self.json {
+            Value::String(s) => {
+              match crate::validator::control::validate_hex_text(
+                target,
+                controller,
+                s,
+                crate::validator::control::HexCase::Any,
+                Some(self.state.cddl),
+              ) {
+                Ok(is_valid) => {
+                  if !is_valid {
+                    self.add_error(format!(
+                      "string \"{}\" does not match .hex encoded bytes of {}",
+                      s, controller
+                    ));
+                  }
+                }
+                Err(e) => self.add_error(e),
+              }
             }
+            _ => self.add_error(format!(
+              ".hex can only be matched against JSON string, got {}",
+              self.json
+            )),
           }
-          _ => self.add_error(format!(
-            ".hex can only be matched against string data type, got {}",
-            target
-          )),
         }
-        self.state.ctrl = None;
-      }
+        _ => self.add_error(format!(
+          ".hex can only be matched against string data type, got {}",
+          target
+        )),
+      },
+      // JSON .hexlc/.hexuc case enforcement is deliberately still HexCase::Any.
       #[cfg(feature = "additional-controls")]
-      ControlOperator::HEXLC => {
-        self.state.ctrl = Some(ctrl);
-        match target {
-          Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
-            match &self.json {
-              Value::String(_) => self.visit_type2(controller)?,
-              _ => self.add_error(format!(
-                ".hexlc can only be matched against JSON string, got {}",
-                self.json
-              )),
+      ControlOperator::HEXLC => match target {
+        Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
+          match &self.json {
+            Value::String(s) => {
+              match crate::validator::control::validate_hex_text(
+                target,
+                controller,
+                s,
+                crate::validator::control::HexCase::Any,
+                Some(self.state.cddl),
+              ) {
+                Ok(is_valid) => {
+                  if !is_valid {
+                    self.add_error(format!(
+                      "string \"{}\" does not match .hexlc encoded bytes of {}",
+                      s, controller
+                    ));
+                  }
+                }
+                Err(e) => self.add_error(e),
+              }
             }
+            _ => self.add_error(format!(
+              ".hexlc can only be matched against JSON string, got {}",
+              self.json
+            )),
           }
-          _ => self.add_error(format!(
-            ".hexlc can only be matched against string data type, got {}",
-            target
-          )),
         }
-        self.state.ctrl = None;
-      }
+        _ => self.add_error(format!(
+          ".hexlc can only be matched against string data type, got {}",
+          target
+        )),
+      },
       #[cfg(feature = "additional-controls")]
-      ControlOperator::HEXUC => {
-        self.state.ctrl = Some(ctrl);
-        match target {
-          Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
-            match &self.json {
-              Value::String(_) => self.visit_type2(controller)?,
-              _ => self.add_error(format!(
-                ".hexuc can only be matched against JSON string, got {}",
-                self.json
-              )),
+      ControlOperator::HEXUC => match target {
+        Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
+          match &self.json {
+            Value::String(s) => {
+              match crate::validator::control::validate_hex_text(
+                target,
+                controller,
+                s,
+                crate::validator::control::HexCase::Any,
+                Some(self.state.cddl),
+              ) {
+                Ok(is_valid) => {
+                  if !is_valid {
+                    self.add_error(format!(
+                      "string \"{}\" does not match .hexuc encoded bytes of {}",
+                      s, controller
+                    ));
+                  }
+                }
+                Err(e) => self.add_error(e),
+              }
             }
+            _ => self.add_error(format!(
+              ".hexuc can only be matched against JSON string, got {}",
+              self.json
+            )),
           }
-          _ => self.add_error(format!(
-            ".hexuc can only be matched against string data type, got {}",
-            target
-          )),
         }
-        self.state.ctrl = None;
-      }
+        _ => self.add_error(format!(
+          ".hexuc can only be matched against string data type, got {}",
+          target
+        )),
+      },
       #[cfg(feature = "additional-controls")]
       ControlOperator::B32 => match target {
         Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
           match &self.json {
             Value::String(s) => {
-              match crate::validator::control::validate_b32_text(target, controller, s, false) {
+              match crate::validator::control::validate_b32_text(
+                target,
+                controller,
+                s,
+                false,
+                Some(self.state.cddl),
+              ) {
                 Ok(is_valid) => {
                   if !is_valid {
                     self.add_error(format!(
-                      "string \"{}\" does not match .b32 encoded bytes",
-                      s
+                      "string \"{}\" does not match .b32 encoded bytes of {}",
+                      s, controller
                     ));
                   }
                 }
@@ -2109,12 +2108,18 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
         Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
           match &self.json {
             Value::String(s) => {
-              match crate::validator::control::validate_b32_text(target, controller, s, true) {
+              match crate::validator::control::validate_b32_text(
+                target,
+                controller,
+                s,
+                true,
+                Some(self.state.cddl),
+              ) {
                 Ok(is_valid) => {
                   if !is_valid {
                     self.add_error(format!(
-                      "string \"{}\" does not match .h32 encoded bytes",
-                      s
+                      "string \"{}\" does not match .h32 encoded bytes of {}",
+                      s, controller
                     ));
                   }
                 }
@@ -2137,12 +2142,17 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
         Type2::Typename { ident, .. } if is_ident_string_data_type(self.state.cddl, ident) => {
           match &self.json {
             Value::String(s) => {
-              match crate::validator::control::validate_b45_text(target, controller, s) {
+              match crate::validator::control::validate_b45_text(
+                target,
+                controller,
+                s,
+                Some(self.state.cddl),
+              ) {
                 Ok(is_valid) => {
                   if !is_valid {
                     self.add_error(format!(
-                      "string \"{}\" does not match .b45 encoded bytes",
-                      s
+                      "string \"{}\" does not match .b45 encoded bytes of {}",
+                      s, controller
                     ));
                   }
                 }
@@ -2589,101 +2599,22 @@ impl<'a> Visitor<'a, '_, Error> for JSONValidator<'a> {
       #[cfg(not(feature = "ast-span"))]
       Type2::Any {} => Ok(()),
       #[cfg(feature = "additional-controls")]
-      Type2::B16ByteString { value, .. } => {
+      Type2::B16ByteString { .. } | Type2::UTF8ByteString { .. } | Type2::B64ByteString { .. } => {
+        // The RFC 9741 encoding controls consume byte-string controllers
+        // before visitation, so a visited byte literal is unsupported in
+        // JSON regardless of the active control.
         if let Some(ctrl) = &self.state.ctrl {
-          // For B16ByteString, the value contains the hex string as bytes (ASCII representation)
-          // We need to decode it to get the actual bytes
-          let hex_str = match std::str::from_utf8(value) {
-            Ok(s) => s,
-            Err(_) => {
-              self.add_error("invalid UTF-8 in hex string".to_string());
-              return Ok(());
-            }
-          };
-
-          match hex::decode(hex_str.replace(' ', "")) {
-            Ok(actual_bytes) => match ctrl {
-              ControlOperator::B64U => self.validate_b64_control(&actual_bytes, false, false),
-              ControlOperator::B64C => self.validate_b64_control(&actual_bytes, true, false),
-              ControlOperator::B64USLOPPY => self.validate_b64_control(&actual_bytes, false, true),
-              ControlOperator::B64CSLOPPY => self.validate_b64_control(&actual_bytes, true, true),
-              ControlOperator::HEX => self.validate_hex_control(&actual_bytes, false),
-              ControlOperator::HEXLC => self.validate_hex_control(&actual_bytes, true),
-              ControlOperator::HEXUC => self.validate_hex_control(&actual_bytes, true),
-              _ => {
-                self.add_error(format!(
-                  "unsupported byte string data type for JSON validation with control {}, got {}",
-                  ctrl, t2
-                ));
-                Ok(())
-              }
-            },
-            Err(_) => {
-              self.add_error("invalid hex encoding in byte string".to_string());
-              Ok(())
-            }
-          }
+          self.add_error(format!(
+            "unsupported byte string data type for JSON validation with control {}, got {}",
+            ctrl, t2
+          ));
         } else {
           self.add_error(format!(
             "byte string data type not supported for JSON validation without control, got {}",
             t2
           ));
-          Ok(())
         }
-      }
-      #[cfg(feature = "additional-controls")]
-      Type2::UTF8ByteString { value, .. } => {
-        if let Some(ctrl) = &self.state.ctrl {
-          match ctrl {
-            ControlOperator::B64U => self.validate_b64_control(value, false, false),
-            ControlOperator::B64C => self.validate_b64_control(value, true, false),
-            ControlOperator::B64USLOPPY => self.validate_b64_control(value, false, true),
-            ControlOperator::B64CSLOPPY => self.validate_b64_control(value, true, true),
-            ControlOperator::HEX => self.validate_hex_control(value, false),
-            ControlOperator::HEXLC => self.validate_hex_control(value, true),
-            ControlOperator::HEXUC => self.validate_hex_control(value, true),
-            _ => {
-              self.add_error(format!(
-                "unsupported byte string data type for JSON validation with control {}, got {}",
-                ctrl, t2
-              ));
-              Ok(())
-            }
-          }
-        } else {
-          self.add_error(format!(
-            "byte string data type not supported for JSON validation without control, got {}",
-            t2
-          ));
-          Ok(())
-        }
-      }
-      #[cfg(feature = "additional-controls")]
-      Type2::B64ByteString { value, .. } => {
-        if let Some(ctrl) = &self.state.ctrl {
-          match ctrl {
-            ControlOperator::B64U => self.validate_b64_control(value, false, false),
-            ControlOperator::B64C => self.validate_b64_control(value, true, false),
-            ControlOperator::B64USLOPPY => self.validate_b64_control(value, false, true),
-            ControlOperator::B64CSLOPPY => self.validate_b64_control(value, true, true),
-            ControlOperator::HEX => self.validate_hex_control(value, false),
-            ControlOperator::HEXLC => self.validate_hex_control(value, true),
-            ControlOperator::HEXUC => self.validate_hex_control(value, true),
-            _ => {
-              self.add_error(format!(
-                "unsupported byte string data type for JSON validation with control {}, got {}",
-                ctrl, t2
-              ));
-              Ok(())
-            }
-          }
-        } else {
-          self.add_error(format!(
-            "byte string data type not supported for JSON validation without control, got {}",
-            t2
-          ));
-          Ok(())
-        }
+        Ok(())
       }
       _ => {
         self.add_error(format!(

--- a/tests/byte_string_literal_diagnostics.rs
+++ b/tests/byte_string_literal_diagnostics.rs
@@ -3,7 +3,6 @@
 #![cfg(not(target_arch = "wasm32"))]
 
 use std::borrow::Cow;
-use std::fmt::Write;
 
 #[cfg(feature = "json")]
 use cddl::validator::validate_json_from_str;
@@ -28,13 +27,21 @@ fn decoded_byte_values_and_ast_nodes_render_as_cddl_literals() {
 }
 
 #[test]
-fn invalid_unqualified_byte_string_state_remains_fallible() {
+fn non_utf8_unqualified_byte_strings_render_as_base16() {
+  // Display must be infallible: unqualified byte-string state whose bytes
+  // are not valid UTF-8 falls back to h'…' notation, which denotes the same
+  // byte string and reparses.
   let value = ByteValue::UTF8(Cow::Borrowed(&[0xff]));
-  let mut rendered = String::new();
-  assert!(write!(&mut rendered, "{}", value).is_err());
+  assert_eq!(value.to_string(), "h'ff'");
+  assert_eq!(Type2::from(value).to_string(), "h'ff'");
 
-  rendered.clear();
-  assert!(write!(&mut rendered, "{}", Type2::from(value)).is_err());
+  let mixed = ByteValue::UTF8(Cow::Borrowed(&[0x74, 0x65, 0xff]));
+  assert_eq!(mixed.to_string(), "h'7465ff'");
+
+  // Valid UTF-8 keeps the unqualified notation.
+  let utf8 = ByteValue::UTF8(Cow::Borrowed(b"te"));
+  assert_eq!(utf8.to_string(), "'te'");
+  assert_eq!(Type2::from(utf8).to_string(), "'te'");
 }
 
 #[test]

--- a/tests/decoded_byte_string_controls.rs
+++ b/tests/decoded_byte_string_controls.rs
@@ -1,0 +1,407 @@
+#![cfg(feature = "std")]
+#![cfg(feature = "cbor")]
+#![cfg(feature = "json")]
+#![cfg(feature = "additional-controls")]
+#![cfg(not(target_arch = "wasm32"))]
+
+use cddl::validator::{validate_cbor_from_slice, validate_json_from_str};
+
+fn cbor_string(major_type: u8, value: &[u8]) -> Vec<u8> {
+  let mut encoded = if value.len() < 24 {
+    vec![(major_type << 5) | value.len() as u8]
+  } else {
+    vec![(major_type << 5) | 24, value.len() as u8]
+  };
+  encoded.extend_from_slice(value);
+  encoded
+}
+
+fn cbor_bytes(value: &[u8]) -> Vec<u8> {
+  cbor_string(2, value)
+}
+
+fn cbor_text(value: &str) -> Vec<u8> {
+  cbor_string(3, value.as_bytes())
+}
+
+fn assert_cbor_verdict(schema: &str, encoded: &[u8], accept: bool) {
+  let result = validate_cbor_from_slice(schema, encoded, None);
+  assert_eq!(
+    result.is_ok(),
+    accept,
+    "schema {schema:?} with CBOR {encoded:02x?} should {}: {result:?}",
+    if accept { "accept" } else { "reject" },
+  );
+}
+
+fn assert_raw_json_verdict(schema: &str, json: &str, accept: bool) {
+  let result = validate_json_from_str(schema, json, None);
+  assert_eq!(
+    result.is_ok(),
+    accept,
+    "schema {schema:?} with JSON {json} should {}: {result:?}",
+    if accept { "accept" } else { "reject" },
+  );
+}
+
+fn assert_json_verdict(schema: &str, text: &str, accept: bool) {
+  assert_raw_json_verdict(schema, &format!("\"{}\"", text), accept);
+}
+
+#[test]
+fn cat_uses_decoded_bytes_and_keeps_the_target_string_type() {
+  let byte_claims = [
+    "m = h'74657374' .cat h'33'",
+    "m = b64'dGVzdA==' .cat b64'Mw=='",
+    "m = h'74657374' .cat b64'Mw=='",
+    "m = b64'dGVzdA==' .cat h'33'",
+    "m = lhs .cat rhs\nlhs = h'74657374'\nrhs = b64'Mw=='",
+  ];
+
+  for schema in byte_claims {
+    assert_cbor_verdict(schema, &cbor_bytes(b"test3"), true);
+    assert_cbor_verdict(schema, &cbor_bytes(b"test4"), false);
+  }
+
+  // The result type comes from the target, independent of whether its decoded
+  // bytes happen to be valid UTF-8.
+  assert_cbor_verdict("m = 'te' .cat h'7374'", &cbor_bytes(b"test"), true);
+  assert_cbor_verdict("m = \"te\" .cat h'7374'", &cbor_text("test"), true);
+  assert_cbor_verdict("m = \"te\" .cat h'7374'", &cbor_bytes(b"test"), false);
+  assert_cbor_verdict("m = h'ff' .cat b64'gA=='", &cbor_bytes(&[0xff, 0x80]), true);
+}
+
+#[test]
+fn det_operates_on_decoded_bytes_without_requiring_utf8() {
+  for schema in [
+    "m = h'ff' .det h'00'",
+    "m = b64'_w==' .det b64'AA=='",
+    "m = h'ff' .det b64'AA=='",
+    "m = b64'_w==' .det h'00'",
+  ] {
+    assert_cbor_verdict(schema, &cbor_bytes(&[0xff, 0x00]), true);
+    assert_cbor_verdict(schema, &cbor_bytes(&[0xff, 0x01]), false);
+  }
+}
+
+#[test]
+fn det_byte_targets_dedent_uniform_space_indentation() {
+  // With uniform space-only indentation the smallest common indent equals
+  // each non-blank line's own indent, so the current per-line strip and
+  // RFC 9165 Section 2.3's common-indent definition agree on these vectors;
+  // the claims hold through a conforming common-indent rewrite of `.det`.
+  // h'0a202074650a202073740a' is "\n  te\n  st\n".
+  let schema = "m = h'0a202074650a202073740a' .det h'ff'";
+  assert_cbor_verdict(schema, &cbor_bytes(b"\nte\nst\n\xff"), true);
+  assert_cbor_verdict(schema, &cbor_bytes(b"\n  te\n  st\n\xff"), false);
+
+  // Non-UTF-8 content dedents as bytes: h'0a2020ff0a202062' is
+  // "\n  \xff\n  b", which dedents to "\n\xff\nb".
+  let non_utf8 = "m = h'0a2020ff0a202062' .det h''";
+  assert_cbor_verdict(non_utf8, &cbor_bytes(&[0x0a, 0xff, 0x0a, 0x62]), true);
+  assert_cbor_verdict(
+    non_utf8,
+    &cbor_bytes(&[0x0a, 0x20, 0x20, 0xff, 0x0a, 0x20, 0x20, 0x62]),
+    false,
+  );
+}
+
+#[test]
+fn abnfb_reads_direct_aliased_and_composed_decoded_controllers() {
+  let h16 = "h'44494749540a4449474954203d20257833302d33390a'";
+  let b64 = "b64'RElHSVQKRElHSVQgPSAleDMwLTM5Cg=='";
+  let schemas = [
+    format!("m = bytes .abnfb {h16}"),
+    format!("m = bytes .abnfb {b64}"),
+    format!("m = bytes .abnfb grammar\ngrammar = {h16}"),
+    format!("m = bytes .abnfb grammar\ngrammar = {b64}"),
+    concat!(
+      "m = bytes .abnfb grammar\n",
+      "grammar = prefix .cat body\n",
+      "prefix = h'4449474954'\n",
+      "body = b64'CkRJR0lUID0gJXgzMC0zOQo='",
+    )
+    .to_string(),
+  ];
+
+  for schema in schemas {
+    assert_cbor_verdict(&schema, &cbor_bytes(b"7"), true);
+    assert_cbor_verdict(&schema, &cbor_bytes(b"x"), false);
+  }
+}
+
+#[test]
+fn sloppy_b64_variants_only_ignore_trailing_bits() {
+  // RFC 9741 Section 2.1: "sloppy" relaxes exactly one thing — the text is
+  // not validated for additional (trailing) bits being zero. The decoded
+  // value must still equal the controller bytes, .b64u still forbids
+  // padding, and .b64c still requires canonical padding.
+  let claims = [
+    // "AQZ" decodes to 01 06 with non-zero trailing bits; "AQY" is canonical.
+    ("m = tstr .b64u-sloppy h'0106'", "AQZ", true),
+    ("m = tstr .b64u-sloppy h'0106'", "AQY", true),
+    ("m = tstr .b64u-sloppy h'01ff'", "AQZ", false),
+    ("m = tstr .b64u-sloppy h'010c'", "AQZ", false),
+    ("m = tstr .b64u-sloppy h'01'", "AQZ", false),
+    // "QR" decodes to 41 with non-zero trailing bits.
+    ("m = tstr .b64u-sloppy h'41'", "QR", true),
+    ("m = tstr .b64u-sloppy h'01'", "AQ==", false),
+    ("m = tstr .b64c-sloppy h'41'", "QR==", true),
+    ("m = tstr .b64c-sloppy h'41'", "QQ==", true),
+    ("m = tstr .b64c-sloppy h'41'", "QQ", false),
+    // Strict variants keep rejecting non-zero trailing bits.
+    ("m = tstr .b64u h'0106'", "AQZ", false),
+    ("m = tstr .b64u h'0106'", "AQY", true),
+  ];
+
+  for (schema, text, accept) in claims {
+    assert_cbor_verdict(schema, &cbor_text(text), accept);
+    assert_json_verdict(schema, text, accept);
+  }
+}
+
+#[test]
+fn composed_controllers_resolve_to_computed_bytes() {
+  // A .cat/.det expression in controller position matches the concatenated
+  // bytes, both parenthesized in place and through a named rule.
+  let claims = [
+    ("m = tstr .b64u (h'ff' .cat h'00')", "_wA", true),
+    ("m = tstr .b64u (h'ff' .cat h'00')", "_w", false),
+    (
+      "m = tstr .b64u payload\npayload = h'ff' .cat h'00'",
+      "_wA",
+      true,
+    ),
+    (
+      "m = tstr .b64u payload\npayload = h'ff' .cat h'00'",
+      "_w",
+      false,
+    ),
+    ("m = tstr .hex (h'ff' .cat h'00')", "ff00", true),
+    ("m = tstr .hex (h'ff' .cat h'00')", "ff", false),
+    ("m = tstr .b32 (h'ff' .det h'00')", "74AA", true),
+    ("m = tstr .b32 (h'ff' .det h'00')", "74", false),
+    // Parenthesized single literals, without an operator.
+    ("m = tstr .b64u (h'ff')", "_w", true),
+    ("m = tstr .b64u (h'ff')", "_wA", false),
+  ];
+
+  for (schema, text, accept) in claims {
+    assert_cbor_verdict(schema, &cbor_text(text), accept);
+    assert_json_verdict(schema, text, accept);
+  }
+}
+
+#[test]
+fn cyclic_controller_rules_reject_without_crashing() {
+  // A self-referential controller rule must produce a validation error, not
+  // a stack overflow; a cycle alongside a usable literal is simply ignored.
+  let claims = [
+    ("m = tstr .b64u c\nc = c", "_w", false),
+    ("m = tstr .b64u c\nc = h'ff' / c", "_w", true),
+  ];
+
+  for (schema, text, accept) in claims {
+    assert_cbor_verdict(schema, &cbor_text(text), accept);
+    assert_json_verdict(schema, text, accept);
+  }
+
+  assert_cbor_verdict("m = \"a\" .cat c\nc = c", &cbor_text("a"), false);
+  assert_json_verdict("m = \"a\" .cat c\nc = c", "a", false);
+
+  // The cycle guard is per resolution: choice-extension siblings of an
+  // already-visited rule name still contribute their literals.
+  let extended_cat = "m = \"a\" .cat b\nb = \"x\"\nb /= \"y\"";
+  for (text, accept) in [("ax", true), ("ay", true), ("az", false)] {
+    assert_cbor_verdict(extended_cat, &cbor_text(text), accept);
+    assert_json_verdict(extended_cat, text, accept);
+  }
+
+  let extended_b64u = "m = tstr .b64u p\np = h'ff'\np /= h'00'";
+  for (text, accept) in [("_w", true), ("AA", true), ("_wA", false)] {
+    assert_cbor_verdict(extended_b64u, &cbor_text(text), accept);
+    assert_json_verdict(extended_b64u, text, accept);
+  }
+}
+
+#[test]
+fn non_utf8_computed_byte_values_reject_without_panicking() {
+  // RFC 9165 only requires the .cat/.det result to be valid UTF-8 when the
+  // target is a text string, so this byte-string target legitimately
+  // computes the non-UTF-8 bytes 74 65 ff. Every mismatching instance must
+  // produce a validation error; none may abort while rendering the expected
+  // value.
+  let schema = "m = 'te' .cat h'ff'";
+
+  assert_cbor_verdict(schema, &[0x43, 0x74, 0x65, 0xff], true);
+
+  for instance in [
+    &[0x41, 0x74][..],       // bytes "t"
+    &[0x62, 0x74, 0x65][..], // text "te"
+    &[0x01][..],             // int 1
+    &[0xf9, 0x3e, 0x00][..], // float 1.5
+    &[0xf5][..],             // true
+    &[0xf6][..],             // null
+    &[0xc1, 0x01][..],       // tag 1(1)
+    &[0x80][..],             // empty array
+    &[0xa0][..],             // empty map
+  ] {
+    assert_cbor_verdict(schema, instance, false);
+  }
+
+  assert_cbor_verdict("m = 'te' .det h'ff'", &[0x41, 0x74], false);
+  assert_cbor_verdict("m = { ('a' .cat h'ff') => int }", &[0xa0], false);
+
+  for json in ["\"te\"", "1", "[]"] {
+    assert_raw_json_verdict(schema, json, false);
+  }
+}
+
+#[test]
+fn composed_alias_operands_fail_closed() {
+  // A .cat/.det operand that is an alias for another composed rule is not
+  // computed yet: the literal accumulator must not contribute the alias's
+  // left operand alone, silently collapsing the computation. Until the
+  // nested value is computed, resolution fails closed with a validation
+  // error. The conforming instance for `c` below is h'ff0011' ("_wAR"), so
+  // BOTH instances reject for now.
+  // TODO(composed-operands): once nested composed operands are computed
+  // (RFC 9165 Section 2.2 applied to an operand that is itself composed),
+  // "_wAR" flips to accept; "_wA" must stay rejected.
+  let nested_alias = "m = tstr .b64u c\nc = h'ff' .cat d\nd = h'00' .cat h'11'";
+  for text in ["_wA", "_wAR"] {
+    assert_cbor_verdict(nested_alias, &cbor_text(text), false);
+    assert_json_verdict(nested_alias, text, false);
+  }
+
+  // The same guard closes the .cat route's silent collapse: `b` used to
+  // resolve to "x" alone, wrongly accepting "ax". RFC 9165 accepts "axy"
+  // only; until composed operands are computed, both instances reject.
+  // TODO(composed-operands): "axy" flips to accept; "ax" must stay rejected.
+  let nested_cat = "m = \"a\" .cat b\nb = \"x\" .cat \"y\"";
+  for text in ["ax", "axy"] {
+    assert_cbor_verdict(nested_cat, &cbor_text(text), false);
+    assert_json_verdict(nested_cat, text, false);
+  }
+
+  // A plain literal choice alongside a composed sibling still contributes:
+  // skipping the composed choice loses its value (under-acceptance until the
+  // nested operand is computed) but never invents one.
+  let mixed = "m = tstr .b64u c\nc = h'ff' .cat d\nd = h'aa' / h'00' .cat h'11'";
+  assert_cbor_verdict(mixed, &cbor_text("_6o"), true); // h'ffaa'
+  assert_json_verdict(mixed, "_6o", true);
+  // h'ff0011' through the composed sibling.
+  // TODO(composed-operands): this row flips to accept.
+  assert_cbor_verdict(mixed, &cbor_text("_wAR"), false);
+  assert_json_verdict(mixed, "_wAR", false);
+}
+
+#[test]
+fn mixed_string_kind_controller_rules_match_through_byte_choices() {
+  // RFC 9741 encoding controllers are byte strings. A controller rule that
+  // carries a text-string choice alongside a byte-string choice matches
+  // through its byte-string choices; the text choice contributes no
+  // controller value ("eA" is the base64url of the text choice's own bytes
+  // and must not match). Accept-direction change from the old base, which
+  // rejected the whole rule as an invalid controller.
+  let mixed = "m = tstr .b64u c\nc = \"x\" / h'ff'";
+  assert_cbor_verdict(mixed, &cbor_text("_w"), true);
+  assert_json_verdict(mixed, "_w", true);
+  assert_cbor_verdict(mixed, &cbor_text("eA"), false);
+  assert_json_verdict(mixed, "eA", false);
+
+  // A controller rule with no byte-string choice at all remains an
+  // invalid-controller error on every instance.
+  let text_only = "m = tstr .b64u c\nc = \"x\"";
+  for text in ["_w", "eA"] {
+    assert_cbor_verdict(text_only, &cbor_text(text), false);
+    assert_json_verdict(text_only, text, false);
+  }
+}
+
+struct EncodingClaim {
+  control: &'static str,
+  b16: &'static str,
+  b64: &'static str,
+  text: &'static str,
+}
+
+#[test]
+fn encoding_controls_compare_text_to_decoded_literal_bytes() {
+  let claims = [
+    EncodingClaim {
+      control: ".b64u",
+      b16: "h'ff'",
+      b64: "b64'_w=='",
+      text: "_w",
+    },
+    EncodingClaim {
+      control: ".b64c",
+      b16: "h'ff'",
+      b64: "b64'_w=='",
+      text: "/w==",
+    },
+    EncodingClaim {
+      control: ".b64u-sloppy",
+      b16: "h'ff'",
+      b64: "b64'_w=='",
+      text: "_w",
+    },
+    EncodingClaim {
+      control: ".b64c-sloppy",
+      b16: "h'ff'",
+      b64: "b64'_w=='",
+      text: "/w==",
+    },
+    EncodingClaim {
+      control: ".hex",
+      b16: "h'ab'",
+      b64: "b64'qw=='",
+      text: "aB",
+    },
+    EncodingClaim {
+      control: ".hexlc",
+      b16: "h'ab'",
+      b64: "b64'qw=='",
+      text: "ab",
+    },
+    EncodingClaim {
+      control: ".hexuc",
+      b16: "h'ab'",
+      b64: "b64'qw=='",
+      text: "AB",
+    },
+    EncodingClaim {
+      control: ".b32",
+      b16: "h'4142'",
+      b64: "b64'QUI='",
+      text: "IFBA",
+    },
+    EncodingClaim {
+      control: ".h32",
+      b16: "h'4142'",
+      b64: "b64'QUI='",
+      text: "8510",
+    },
+    EncodingClaim {
+      control: ".b45",
+      b16: "h'4142'",
+      b64: "b64'QUI='",
+      text: "BB8",
+    },
+  ];
+
+  for claim in claims {
+    for literal in [claim.b16, claim.b64] {
+      for schema in [
+        format!("m = tstr {} {}", claim.control, literal),
+        format!("m = tstr {} payload\npayload = {}", claim.control, literal),
+      ] {
+        assert_cbor_verdict(&schema, &cbor_text(claim.text), true);
+        assert_cbor_verdict(&schema, &cbor_text("not-the-encoding"), false);
+        assert_json_verdict(&schema, claim.text, true);
+        assert_json_verdict(&schema, "not-the-encoding", false);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR
- makes every RFC 9741 byte-encoding control resolve direct and aliased byte literals through one decoded-byte boundary.
- stops control evaluation from treating decoded bytes in B16 and B64 AST literals as hexadecimal/base64 source text and decoding them a second time
- fixes .cat, .det, and .abnfb
- removes JSON's duplicate B16 decode

**Note**: this PR is a draft, as it requires another PR to stack with it to avoid a regression

## Relevant RFC rules

<summary>section list</summary>
<details>

- RFC 8610 Appendices B and G define qualified byte-string syntax and its
  base16/base64 interpretation; normative Appendix C matches the resulting
  byte value.
- RFC 9165 Section 2.2 concatenates the bytes of both strings and gives the
  result the target's string type.
- RFC 9165 Section 2.3 applies the same operation after independently
  dedenting both operands.
- RFC 9165 Section 3 interprets a byte-string `.abnfb` controller as the UTF-8
  text with the same bytes.
- RFC 9741 Sections 1 and 2.1 define `.b64u`, `.b64c`, their sloppy variants,
  `.hex`, `.hexlc`, `.hexuc`, `.b32`, `.h32`, and `.b45` with a text target
  and byte-string controller.

</details>

## Rust and Ruby evidence

Note: there are two types of places we disagree with Ruby on:
1. Pre-existing issues (will be fixed in a follow-up PR; denoted in those specific rows)
2. Row 8: likely a bug in the Ruby gem based on RFC 9165 §2.2 and RFC 8610 Appendix E
3. Row 16: likely a bug in the Ruby gem based on RFC 9741 Section 2.1

| # | Schema and instance | RFC | Basis | `main` | Ruby | This branch |
| --- | --- | --- | --- | --- | --- | --- |
| | **A. Decoded-byte boundary for `.cat` / `.det` / `.abnfb` (round 1)** | | | | | |
| 1 | `m = h'74657374' .cat h'33'`; CBOR bytes `74 65 73 74 33` | accept | B/G+2.2: literals are already bytes; `test`∥`3` = `test3` | reject: invalid B16 length | accept | accept |
| 2 | `m = b64'dGVzdA==' .cat b64'Mw=='`; bytes `test3` | accept | B/G+2.2: b64 payloads decode to `test`∥`3` = `test3` | reject: invalid B64 length | accept | accept |
| 3 | Mixed B16/B64 `.cat`; bytes `test3` | accept | B/G+2.2: the literal's encoding is irrelevant once decoded | reject | accept | accept |
| 4 | `m = h'ff' .det b64'AA=='`; bytes `ff 00` | accept | B/G+2.3: neither operand has leading spaces, so dedent is identity; `ff`∥`00` | reject: controller is invalid base64, invalid length | accept | accept |
| 5 | `m = bytes .abnfb h'…'`; byte `7` | accept | §3: the controller's bytes *are* the ABNF text; no base decode | reject during second decode | accept | accept |
| 6 | `m = tstr .b64u h'ff'`; text `"_w"` | accept | 9741: `_w` is base64url of `ff`, unpadded per T2 | reject (JSON rejects before comparison) | accept | accept |
| 7 | Representative B16/B64 `.b64c`, `.hex`/`.hexlc`/`.hexuc`, `.b32`, `.h32`, `.b45` | accept | 9741: text must be that control's encoding of the controller bytes | representation-dependent | accept | accept |
| 8 | `m = 'te' .cat 'st'`; JSON `"test"` (byte-string result) | reject | 2.2: result takes the *target's* type, i.e. bytes; JSON has none | **accept** | **accept** | reject |
| 9 | `m = "te" .cat "st"`; JSON `"test"` (text result) | accept | 2.2: text target → text result `"test"` | accept | accept | accept |
| | **B. RFC 9741 sloppy base64 variants (round 2)** | | | | | |
| 10 | `tstr .b64u-sloppy h'0106'`; `"AQZ"` | accept | 9741§2.1: `AQZ`→`01 06` = ctrl; non-zero trailing bits relaxed | CBOR accept / JSON reject | accept | accept |
| 11 | `tstr .b64u-sloppy h'01ff'`; `"AQZ"` | reject | 9741§2.1: `AQZ`→`01 06` ≠ ctrl `01 ff`; sloppy relaxes bits, not value | CBOR **accept** / JSON reject | reject | reject |
| 12 | `tstr .b64u-sloppy h'01'`; `"AQZ"` | reject | 9741§2.1: `AQZ`→`01 06` ≠ ctrl `01` | CBOR **accept** / JSON reject | reject | reject |
| 13 | `tstr .b64u-sloppy h'41'`; `"QR"` | accept | 9741§2.1: `QR`→`41` = ctrl; unpadded per T2; trailing bits relaxed | reject | accept | accept |
| 14 | `tstr .b64u-sloppy h'01'`; `"AQ=="` | reject | 9741 T2: `.b64u` is unpadded, so padded `AQ==` is not that encoding (value would match) | CBOR **accept** / JSON reject | reject | reject |
| 15 | `tstr .b64c-sloppy h'41'`; `"QR=="` | accept | 9741 T2+§2.1: `.b64c` is padded; `QR==`→`41` = ctrl; bits relaxed | reject | accept | accept |
| 16 | `tstr .b64c-sloppy h'41'`; `"QQ"` | reject | 9741 T2: `.b64c` requires padding; `QQ` is unpadded (value would match) | CBOR **accept** / JSON reject | **accept** | reject |
| | **C. Composed controllers, composition at the top level (round 2)** | | | | | |
| 17 | `tstr .b64u (h'ff' .cat h'00')`; `"_wA"` | accept | 2.2→9741: ctrl `ff 00`; `_wA` is its base64url | reject | accept | accept |
| 18 | `tstr .b64u (h'ff' .cat h'00')`; `"_w"` | reject | 2.2→9741: `_w` encodes `ff` ≠ ctrl `ff 00` | reject | reject | reject |
| 19 | `tstr .b64u payload`, `payload = h'ff' .cat h'00'`; `"_wA"` | accept | §2+2.2: a rule name contributes its type's value, `ff 00` | reject | accept | accept |
| 20 | `tstr .hex (h'ff' .cat h'00')`; `"ff00"` | accept | 2.2→9741: ctrl `ff 00`; `.hex` is base16 of it | reject | accept | accept |
| 21 | `tstr .hex (h'ff' .cat h'00')`; `"ff"` | reject | 2.2→9741: `ff` encodes only the left operand, not `ff 00` | reject | reject | reject |
| 22 | `tstr .b32 (h'ff' .det h'00')`; `"74AA"` | accept | 2.3→9741: ctrl `ff 00`; `74AA` is its base32 | reject | accept | accept |
| | **D. Cyclic controller rules (round 2)** | | | | | |
| 23 | `m = tstr .b64u c`, `c = c`; any instance | reject | §2: a rule resolving to no type yields no controller value → undefined, fail closed | reject: invalid controller type | crash: deep-recursion RuntimeError | reject |
| 24 | `m = "a" .cat c`, `c = c`; any instance | reject | §2: same on the `.cat` route; a cycle is not a string literal | crash: stack overflow | crash | reject |
| 25 | `m = tstr .b64u c`, `c = h'ff' / c`; `"_w"` | accept | §2: matching ranges over the choices; `h'ff'` supplies `ff`, the cyclic choice none | reject: invalid controller / recursive rule | accept | accept |
| | **E. Nested composed operands, fail-closed (round 3)** | | | | | |
| 26 | `m = tstr .b64u c`, `c = h'ff' .cat d`, `d = h'00' .cat h'11'`; `"_wA"` (= `ff00`) | reject | 2.2 twice: ctrl `ff`∥(`00`∥`11`) = `ff 00 11`; `_wA` encodes only `ff 00` | reject: invalid controller | reject | reject |
| 27 | same; `"_wAR"` (= `ff0011`, the RFC controller value) | accept | 2.2 twice: ctrl `ff 00 11`; `_wAR` is its base64url | reject: invalid controller | accept | reject (fail-closed, future PR) |
| 28 | `d = h'aa' / h'00' .cat h'11'` (plain choice beside composed); `"_6o"` (= `ffaa`) | accept | §2+2.2: ctrl ∈ {`ff aa`, `ff 00 11`}; `_6o` = `ff aa` | reject: invalid controller | accept | accept |
| 29 | same; `"_wAR"` (= `ff0011`) | accept | §2+2.2: `_wAR` = `ff 00 11`, the composed choice | reject: invalid controller | accept | reject (fail-closed, future PR) |
| 30 | `m = "a" .cat b`, `b = "x" .cat "y"`; `"ax"` | reject | 2.2 twice: value is `"axy"`; `"ax"` is the left operand only | **accept** (collapse) | reject | reject |
| 31 | same; `"axy"` (the RFC value) | accept | 2.2 twice: `"a"`∥(`"x"`∥`"y"`) = `"axy"` | reject | accept | reject (fail-closed, future PR) |
| 32 | `tstr .b64u (h'ff' .cat (h'00' .cat h'11'))`; `"_wAR"` | accept | 2.2 nested→9741: ctrl `ff 00 11`; `_wAR` is its base64url | CBOR reject / JSON **accept-any** | accept | reject (fail-closed, future PR) |
| 33 | same; `"_wA"` | reject | 2.2 nested→9741: `_wA` encodes `ff 00` ≠ ctrl `ff 00 11` | CBOR reject / JSON **accept-any** | reject | reject |
| 34 | `m = "a" .cat ("x" .cat "y")`; `"axy"` | accept | 2.2 nested: value is `"axy"` | accept (vacuous) | accept | accept (vacuous) |
| 35 | same; text `"zzz"` or int `1` | reject | 2.2 nested: value is `"axy"`; neither other text nor an int matches | **accept** (vacuous) | reject | **accept** (pre-existing future PR) |
| | **F. Mixed text/byte controller rules (round 4)** | | | | | |
| 36 | `m = tstr .b64u c`, `c = "x" / h'ff'`; `"_w"` | accept | §2+9741: matching ranges over the choices; the byte choice `ff` encodes as `_w` | reject: invalid controller | accept | accept |
| 37 | same; `"eA"` | reject | §2+9741: the only byte choice is `ff`; `eA` encodes `78` (the text choice's bytes) | reject | reject | reject |
| 38 | `c = "x"` (no byte-string choice); `"_w"` or `"eA"` | reject | 9741: the control needs a byte-string controller; a text-only type has none | reject | reject | reject |
| | **G. Multi-line byte-target `.det` (round 4)** | | | | | |
| 39 | `m = h'0a202074650a202073740a' .det h'ff'`; bytes `0a 74 65 0a 73 74 0a ff` (dedented) | accept | 2.3: common indent of the non-blank lines is 2, removed from each, then ∥ `ff` | reject: invalid utf-8 | accept | accept |
| 40 | same; `0a 20 20 74 65 0a 20 20 73 74 0a ff` (non-dedented) | reject | 2.3: dedenting is mandatory, so the still-indented bytes are not the value | reject | reject | reject |
| 41 | `m = h'0a2020ff0a202062' .det h''`; `0a ff 0a 62` (dedented, non-UTF-8) | accept | 2.3: common indent 2 removed; dedenting counts space bytes, content needn't be UTF-8 | reject: invalid utf-8 | accept | accept |
| 42 | same; `0a 20 20 ff 0a 20 20 62` (non-dedented) | reject | 2.3: as row 40, with non-UTF-8 content | reject | reject | reject |
| | **H. Non-UTF-8 computed byte values in error paths (resolved review finding)** | | | | | |
| 43 | `m = 'te' .cat h'ff'`; CBOR `41 74` (bytes `74`) | reject | 2.2: value `74 65 ff`; instance `74` differs | reject | reject | reject |
| 44 | same; CBOR `43 74 65 ff` (bytes `74 65 ff`) | accept | 2.2: `'te'`∥`ff` = `74 65 ff`; only *text* targets must stay valid UTF-8 | reject | accept | accept |
| 45 | same; CBOR `62 74 65` (text `"te"`) | reject | 2.2: value `74 65 ff` ≠ the instance's `74 65` | reject | reject | reject |
| 46 | same; CBOR `01` (int `1`) | reject | 2.2: a computed byte string does not match an int | reject | reject | reject |
| 47 | same; CBOR `f9 3e00` (float `1.5`) | reject | 2.2: likewise for a float | reject | reject | reject |
| 48 | same; CBOR `f5` / `f6` / `c1 01` (bool, null, tag) | reject | 2.2: likewise for bool, null, and tag heads | reject | reject | reject |
| 49 | same; CBOR `80` (empty array) | reject | 2.2: likewise for an array | reject | reject | reject |
| 50 | `m = { ('a' .cat h'ff') => int }`; CBOR `a0` (empty map) | reject | 8610 §3.5: the required member key `61 ff` is absent from `{}` | reject | reject | reject |
| 51 | `m = 'te' .det h'ff'`; CBOR `41 74` (bytes `74`) | reject | 2.3: no indentation to strip, so value `74 65 ff` ≠ `74` | reject | reject | reject |
| 52 | `m = 'te' .cat h'ff'`; any JSON value (`"te"`, `1`, `[]`) | reject | 2.2: result is a byte string; JSON cannot represent one | reject | reject | reject |
| | **I. Byte literals against equal-byte CBOR text (out of scope, #693)** | | | | | |
| 53 | `m = h'7465' .cat h'7374'`; CBOR text `"test"` | reject | 2.2+major types: result is a byte string; CBOR text is a distinct type | reject (misattributed decode) | **accept** | **accept** (fixed in #693) |
| 54 | `m = h'74657374'` (plain literal); CBOR text `"test"` | reject | major types: `h'…'` denotes a byte string; equal-byte text is a distinct type | **accept** | reject | **accept** (inherited; fixed in #693) |