### PR TITLE
Fix(validator) cbor byte literal major type

### DIFF
--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -4676,9 +4676,17 @@ where
           }
           _ => Some(format!("expected {}, got {}", u, s)),
         },
-        token::Value::BYTE(token::ByteValue::UTF8(b)) if s.as_bytes() == b.as_ref() => None,
-        token::Value::BYTE(token::ByteValue::B16(b)) if s.as_bytes() == b.as_ref() => None,
-        token::Value::BYTE(token::ByteValue::B64(b)) if s.as_bytes() == b.as_ref() => None,
+        // RFC 8610 Section 3.8.6: a text string is never equal to a byte
+        // string, so .ne (and .default, its variant) is always satisfied by
+        // a byte-string controller here.
+        token::Value::BYTE(_)
+          if matches!(
+            self.state.ctrl,
+            Some(ControlOperator::NE) | Some(ControlOperator::DEFAULT)
+          ) =>
+        {
+          None
+        }
         _ => Some(format!("expected {}, got \"{}\"", value, s)),
       },
       Value::Bytes(b) => match value {
@@ -4784,12 +4792,8 @@ where
                 )
               })
           }
-          _ => Some(format!(
-            "expected value {} {}, got {:?}",
-            self.state.ctrl.unwrap(),
-            t,
-            b
-          )),
+          Some(ctrl) => Some(format!("expected value {} {}, got {:?}", ctrl, t, b)),
+          None => Some(format!("expected value {}, got {:?}", t, b)),
         },
         #[cfg(feature = "additional-controls")]
         token::Value::BYTE(bv) => match &self.state.ctrl {

--- a/tests/cbor_byte_literal_major_type.rs
+++ b/tests/cbor_byte_literal_major_type.rs
@@ -26,6 +26,12 @@ fn cbor_map(key: &[u8]) -> Vec<u8> {
   encoded
 }
 
+fn cbor_array(item: &[u8]) -> Vec<u8> {
+  let mut encoded = vec![0x81];
+  encoded.extend_from_slice(item);
+  encoded
+}
+
 fn assert_verdict(schema: &str, encoded: &[u8], accept: bool) {
   let result = validate_cbor_from_slice(schema, encoded, None);
   assert_eq!(
@@ -46,9 +52,16 @@ fn decoded_byte_literals_require_the_byte_string_major_type() {
     assert_verdict(&schema, &bytes, true);
     assert_verdict(&schema, &text, false);
   }
+}
 
-  assert_verdict("m = \"AA\"", &text, true);
-  assert_verdict("m = \"AA\"", &bytes, false);
+#[test]
+fn text_literals_reject_equal_bytes_without_panicking() {
+  // Reverse control for the major-type boundary. The rejecting row is the
+  // former absent-control unwrap panic: a text literal against CBOR bytes
+  // must return a normal mismatch, not abort the process. Kept standalone
+  // so it fails on its own on the pre-fix tree.
+  assert_verdict("m = \"AA\"", &cbor_text("AA"), true);
+  assert_verdict("m = \"AA\"", &cbor_bytes(b"AA"), false);
 }
 
 #[test]
@@ -76,6 +89,23 @@ fn decoded_byte_literal_map_keys_keep_their_major_type() {
 }
 
 #[test]
+fn decoded_byte_literal_array_elements_keep_their_major_type() {
+  let byte_item = cbor_array(&cbor_bytes(b"AA"));
+  let text_item = cbor_array(&cbor_text("AA"));
+
+  for literal in ["'AA'", "h'4141'", "b64'QUE='"] {
+    let schema = format!("m = [{literal}]");
+    assert_verdict(&schema, &byte_item, true);
+    assert_verdict(&schema, &text_item, false);
+  }
+
+  // Text-literal element controls; the rejecting row is the array route of
+  // the former absent-control unwrap panic.
+  assert_verdict("m = [\"AA\"]", &text_item, true);
+  assert_verdict("m = [\"AA\"]", &byte_item, false);
+}
+
+#[test]
 fn ne_byte_string_controllers_accept_every_text_string() {
   // RFC 8610 Section 3.8.6: "All other cases are not equal (e.g., comparing
   // a text string with a byte string)", so a text instance always satisfies
@@ -92,6 +122,19 @@ fn ne_byte_string_controllers_accept_every_text_string() {
 }
 
 #[test]
+fn ne_mixed_choice_controllers_accept_text_through_the_byte_branch() {
+  // A choice controller applies per element of the controller type (the
+  // cross-product reading of RFC 9165 Section 2), so the byte-string branch
+  // satisfies .ne for every text instance under RFC 8610 Section 3.8.6's
+  // cross-kind rule, whichever branch order is written. The all-text choice
+  // control pins the pre-existing any-branch choice semantics these rows
+  // inherit.
+  assert_verdict("m = tstr .ne (\"AA\" / 'BB')", &cbor_text("AA"), true);
+  assert_verdict("m = tstr .ne ('BB' / \"AA\")", &cbor_text("AA"), true);
+  assert_verdict("m = tstr .ne (\"AA\" / \"BB\")", &cbor_text("AA"), true);
+}
+
+#[test]
 fn eq_byte_string_controllers_match_no_text_string() {
   // The same RFC 8610 Section 3.8.6 cross-kind rule: equal bytes in a text
   // string do not satisfy .eq against a byte-string controller.
@@ -102,4 +145,17 @@ fn eq_byte_string_controllers_match_no_text_string() {
 
   assert_verdict("m = tstr .eq \"AA\"", &cbor_text("AA"), true);
   assert_verdict("m = tstr .eq \"AA\"", &cbor_text("AB"), false);
+}
+
+#[test]
+fn composite_array_eq_ne_byte_literal_elements_follow_the_cross_kind_rule() {
+  // RFC 8610 Section 3.8.6: arrays are equal only when their elements are
+  // equal pairwise, and a text element is never equal to a byte-string
+  // element, so .ne is satisfied and .eq is not regardless of the octets.
+  let text_item = cbor_array(&cbor_text("AA"));
+
+  assert_verdict("m = [\"AA\"] .ne ['BB']", &text_item, true);
+  assert_verdict("m = [\"AA\"] .ne ['AA']", &text_item, true);
+  assert_verdict("m = [tstr] .eq ['AA']", &text_item, false);
+  assert_verdict("m = [tstr] .eq [\"AA\"]", &text_item, true);
 }

--- a/tests/cbor_byte_literal_major_type.rs
+++ b/tests/cbor_byte_literal_major_type.rs
@@ -1,0 +1,105 @@
+#![cfg(feature = "std")]
+#![cfg(feature = "cbor")]
+#![cfg(feature = "additional-controls")]
+#![cfg(not(target_arch = "wasm32"))]
+
+use cddl::validator::validate_cbor_from_slice;
+
+fn cbor_string(major_type: u8, value: &[u8]) -> Vec<u8> {
+  let mut encoded = vec![(major_type << 5) | value.len() as u8];
+  encoded.extend_from_slice(value);
+  encoded
+}
+
+fn cbor_bytes(value: &[u8]) -> Vec<u8> {
+  cbor_string(2, value)
+}
+
+fn cbor_text(value: &str) -> Vec<u8> {
+  cbor_string(3, value.as_bytes())
+}
+
+fn cbor_map(key: &[u8]) -> Vec<u8> {
+  let mut encoded = vec![0xa1];
+  encoded.extend_from_slice(key);
+  encoded.push(0x01);
+  encoded
+}
+
+fn assert_verdict(schema: &str, encoded: &[u8], accept: bool) {
+  let result = validate_cbor_from_slice(schema, encoded, None);
+  assert_eq!(
+    result.is_ok(),
+    accept,
+    "schema {schema:?} with CBOR {encoded:02x?} should {}: {result:?}",
+    if accept { "accept" } else { "reject" },
+  );
+}
+
+#[test]
+fn decoded_byte_literals_require_the_byte_string_major_type() {
+  let bytes = cbor_bytes(b"AA");
+  let text = cbor_text("AA");
+
+  for literal in ["'AA'", "h'4141'", "b64'QUE='"] {
+    let schema = format!("m = {literal}");
+    assert_verdict(&schema, &bytes, true);
+    assert_verdict(&schema, &text, false);
+  }
+
+  assert_verdict("m = \"AA\"", &text, true);
+  assert_verdict("m = \"AA\"", &bytes, false);
+}
+
+#[test]
+fn aliased_decoded_byte_literals_keep_their_major_type() {
+  let bytes = cbor_bytes(b"AA");
+  let text = cbor_text("AA");
+
+  for literal in ["'AA'", "h'4141'", "b64'QUE='"] {
+    let schema = format!("m = payload\npayload = {literal}");
+    assert_verdict(&schema, &bytes, true);
+    assert_verdict(&schema, &text, false);
+  }
+}
+
+#[test]
+fn decoded_byte_literal_map_keys_keep_their_major_type() {
+  let byte_key_map = cbor_map(&cbor_bytes(b"AA"));
+  let text_key_map = cbor_map(&cbor_text("AA"));
+
+  for literal in ["'AA'", "h'4141'", "b64'QUE='"] {
+    let schema = format!("m = {{ {literal} => uint }}");
+    assert_verdict(&schema, &byte_key_map, true);
+    assert_verdict(&schema, &text_key_map, false);
+  }
+}
+
+#[test]
+fn ne_byte_string_controllers_accept_every_text_string() {
+  // RFC 8610 Section 3.8.6: "All other cases are not equal (e.g., comparing
+  // a text string with a byte string)", so a text instance always satisfies
+  // .ne against a byte-string controller, byte-equal or not.
+  for literal in ["'AA'", "h'4141'", "b64'QUE='"] {
+    let schema = format!("m = tstr .ne {literal}");
+    assert_verdict(&schema, &cbor_text("AA"), true);
+    assert_verdict(&schema, &cbor_text("AB"), true);
+  }
+
+  // Text controllers keep exact .ne semantics.
+  assert_verdict("m = tstr .ne \"AA\"", &cbor_text("AA"), false);
+  assert_verdict("m = tstr .ne \"AA\"", &cbor_text("AB"), true);
+}
+
+#[test]
+fn eq_byte_string_controllers_match_no_text_string() {
+  // The same RFC 8610 Section 3.8.6 cross-kind rule: equal bytes in a text
+  // string do not satisfy .eq against a byte-string controller.
+  for literal in ["'AA'", "h'4141'", "b64'QUE='"] {
+    let schema = format!("m = tstr .eq {literal}");
+    assert_verdict(&schema, &cbor_text("AA"), false);
+  }
+
+  assert_verdict("m = tstr .eq \"AA\"", &cbor_text("AA"), true);
+  assert_verdict("m = tstr .eq \"AA\"", &cbor_text("AB"), false);
+}

--- a/tests/decoded_byte_string_controls.rs
+++ b/tests/decoded_byte_string_controls.rs
@@ -60,6 +60,7 @@ fn cat_uses_decoded_bytes_and_keeps_the_target_string_type() {
 
   for schema in byte_claims {
     assert_cbor_verdict(schema, &cbor_bytes(b"test3"), true);
+    assert_cbor_verdict(schema, &cbor_text("test3"), false);
     assert_cbor_verdict(schema, &cbor_bytes(b"test4"), false);
   }
 


### PR DESCRIPTION
- Decoded UTF8, B16, and B64 literals now match CBOR byte strings only
- Equal UTF-8 octets in a CBOR text string no longer bypass the byte/text data-model boundary.
- The same rule applies to computed byte results from #692's .cat/.det path.

Decoded bytes remain authoritative; this PR changes only which CBOR major type can contain them.

**Note**: This PR is draft because it's blocked on the `.ne` fix (future PR)

## Relevant RFC rules

<summary>section list</summary>
<details>

- RFC 8610 Appendix B defines qualified and unqualified byte-string literal
  syntax.
- RFC 8610 Appendix G defines the UTF8, hexadecimal, and base64 interpretation
  of those literals.
- RFC 8610 normative Appendix C matches a literal against its resulting value.
- RFC 8949 Section 3 defines byte strings and text strings as distinct major
  types 2 and 3.
- RFC 9165 Section 2.2 says `.cat` retains the target operand's string type;
  Section 2.3 gives `.det` the same result-kind rule after dedenting.

</details>

## Rust and Ruby evidence

| Schema and CBOR value | #692 | Ruby 0.12.14 | This PR | RFC rationale |
| --- | ---: | ---: | ---: | ---: |
| same direct literals; text `"AA"` | accept | reject | reject | - |
| aliased B16 literal; bytes/text `AA` | accept both | accept bytes, reject text | accept bytes, reject text | - |
| direct B16 map key; equal text-key map | reject | accept³ | reject | - |
| byte `.cat`; text `"test3"` | accept | accept³ | reject | - |
| text literal `"AA"`; bytes `AA` | panic | reject | reject normally | - |
| `tstr .ne 'AA'`; text `"AA"` | accept | reject³ | accept | - |
| `tstr .ne 'AA'`; text `"AB"` | reject | accept³ | accept | - |
| `tstr .eq 'AA'`; text `"AA"` | accept | accept | reject | - |
| `['AA']` element; text-element array | accept | reject | reject | - |
| `[h'4141']` element; byte/text-element array | accept both | gem crash¹ | accept bytes, reject text | - |
| text element `["AA"]`; byte-element array | panic | reject | reject normally | - |
| `["AA"] .ne ['BB']`; text-element array | reject | parse error | accept² | - |
| `["AA"] .ne ['AA']`; text-element array | accept | parse error | accept² | - |
| `[tstr] .eq ['AA']`; text-element array | accept | parse error | reject | - |
| `tstr .ne ("AA" / "BB")`; text `"AA"` | accept | reject | accept² | - |

¹ Ruby 0.12.14 aborts with a `NoMethodError` in `type1` when `h'…'` appears as an array member, independent of the instance, so it has no verdict on those rows; the unprefixed `['AA']` rows are its working equivalents and agree with this PR.
² this is blocked on a future PR getting merged
³ Ruby's String equality ignores the byte/text distinction for ASCII-only data. In Ruby, a BINARY string and a UTF-8 string compare equal, and hash equal, whenever both are 7-bit clean:
```
  "AA".b == "AA"          # => true
  "AA".b.hash == "AA".hash # => true
  "éé".b == "éé"          # => false   (not ASCII-only)
```