### PR TITLE
ci: auto-merge Dependabot patch and minor updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,46 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: enable auto-merge
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Auto-merge waits on the required status checks enforced by the "CDDL
+      # Core Library CI" and "VSCode Extension / LSP CI" rulesets, so a bump
+      # that breaks the build stays open instead of merging.
+      - name: Enable squash auto-merge for patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Leave major updates for manual review
+        if: |
+          github.event.action == 'opened' &&
+          steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: gh pr comment "$PR_URL" --body "Major version update (\`$DEPENDENCY\` $PREVIOUS to $NEW) — auto-merge intentionally not enabled. Merge manually after reviewing the upstream breaking changes."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPENDENCY: ${{ steps.metadata.outputs.dependency-names }}
+          PREVIOUS: ${{ steps.metadata.outputs.previous-version }}
+          NEW: ${{ steps.metadata.outputs.new-version }}


### PR DESCRIPTION
Enables squash auto-merge for future Dependabot PRs, so routine bumps land without manual intervention while risky ones still stop for review.

### Behavior

| Update type | Action |
| --- | --- |
| `semver-patch` | Squash auto-merge enabled |
| `semver-minor` | Squash auto-merge enabled |
| `semver-major` | Left open, comment added for manual review |

### Why this is safe

Auto-merge is *queued*, not immediate — GitHub holds the PR until required status checks pass. `main` is protected by two active rulesets, `CDDL Core Library CI` (12 required checks) and `VSCode Extension / LSP CI` (1 required check), so a bump that breaks the build stays open rather than merging.

#690 is the motivating example: a major `typescript` 6 → 7 bump that could not pass `build and test LSP extension`. Under this workflow it would have been left open with a review comment on both counts — major version, and failing required checks.

Neither ruleset requires pull request reviews, so no auto-approve step is needed; required checks are the only gate.

### Implementation notes

- `pull_request_target` is required so the workflow runs with a writable `GITHUB_TOKEN` on Dependabot-authored PRs. It checks out no PR code and runs no PR-authored scripts — it only reads Dependabot metadata and calls the `gh` API, so it does not expose the token to untrusted input.
- Triggered on `opened`, `reopened`, and `ready_for_review` only. Auto-merge persists across Dependabot rebases, so re-running on every `synchronize` would add nothing and would duplicate the major-version comment.
- The job is gated on `github.event.pull_request.user.login == 'dependabot[bot]'`.
- Validated with `actionlint` locally.

### Related repo settings

`Allow auto-merge` was already enabled. I also turned on `Automatically delete head branches` so merged Dependabot branches are cleaned up.
