### PR TITLE
ci: harden Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,7 +2,7 @@ name: Dependabot auto-merge
 
 on:
   pull_request_target:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize]
 
 permissions:
   contents: write
@@ -12,35 +12,50 @@ jobs:
   auto-merge:
     name: enable auto-merge
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    if: |
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.draft == false
 
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Auto-merge waits on the required status checks enforced by the "CDDL
       # Core Library CI" and "VSCode Extension / LSP CI" rulesets, so a bump
       # that breaks the build stays open instead of merging.
-      - name: Enable squash auto-merge for patch and minor updates
+      #
+      # Pre-1.0 minor bumps are excluded: under both Cargo and npm range
+      # semantics a 0.x -> 0.(x+1) bump is breaking, even though Dependabot
+      # classifies it as semver-minor.
+      - name: Enable squash auto-merge for patch and compatible minor updates
         if: |
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr merge --auto --squash "$PR_URL"
+          (steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
+           !startsWith(steps.metadata.outputs.previous-version, '0.'))
+        run: |
+          if [ "$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest != null')" = "true" ]; then
+            echo "Auto-merge already enabled; nothing to do."
+          else
+            gh pr merge --auto --squash "$PR_URL"
+          fi
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Leave major updates for manual review
+      - name: Leave breaking updates for manual review
         if: |
           github.event.action == 'opened' &&
-          steps.metadata.outputs.update-type == 'version-update:semver-major'
-        run: gh pr comment "$PR_URL" --body "Major version update (\`$DEPENDENCY\` $PREVIOUS to $NEW) — auto-merge intentionally not enabled. Merge manually after reviewing the upstream breaking changes."
+          (steps.metadata.outputs.update-type == 'version-update:semver-major' ||
+           (steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
+            startsWith(steps.metadata.outputs.previous-version, '0.')))
+        run: gh pr comment "$PR_URL" --body "$KIND (\`$DEPENDENCY\` $PREVIOUS to $NEW) — auto-merge intentionally not enabled. Merge manually after reviewing the upstream breaking changes."
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KIND: ${{ steps.metadata.outputs.update-type == 'version-update:semver-major' && 'Major version update' || 'Pre-1.0 minor version update' }}
           DEPENDENCY: ${{ steps.metadata.outputs.dependency-names }}
           PREVIOUS: ${{ steps.metadata.outputs.previous-version }}
           NEW: ${{ steps.metadata.outputs.new-version }}


### PR DESCRIPTION
Fixes defects found in an adversarial review of #698. Four changes, in severity order.

### 1. Pin `fetch-metadata` to a commit SHA (security)

The job holds `contents: write`. A mutable `@v2` tag that is moved or compromised would therefore grant repository write access. Now pinned to `25dd0e34f4fe68f24cc83900b1fe3fe149efef98`, verified as the commit behind `v3.1.0`, which also moves the action from node20 to node24. CodeQL's `actions/unpinned-tag` query flags the previous form.

### 2. Re-enable auto-merge on `synchronize` (correctness)

GitHub disables auto-merge when someone without write permission pushes to the head branch. The previous trigger set (`opened`, `reopened`, `ready_for_review`) could never recover from that, leaving a qualifying PR open indefinitely with all checks green.

`synchronize` is now included, guarded so repeat events are a no-op:

```bash
if [ "$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest != null')" = "true" ]; then
  echo "Auto-merge already enabled; nothing to do."
else
  gh pr merge --auto --squash "$PR_URL"
fi
```

The manual-review comment remains gated on `github.event.action == 'opened'`, so it is still posted exactly once.

### 3. Exclude pre-1.0 minor bumps (correctness — the real bug)

Dependabot classifies `0.1.x` → `0.2.0` as `version-update:semver-minor`, but under both Cargo and npm range semantics that is a **breaking** change — `^0.1.2` does not admit `0.2.0`. The previous condition would have auto-merged it.

Patch bumps on `0.x` remain eligible, since `^0.1.2` does admit `0.1.3`. This matters for the `cargo` ecosystem entry in particular, where pre-1.0 dependencies are common.

### 4. Skip draft PRs

Auto-merge cannot be enabled on a draft, so `gh pr merge --auto` would exit non-zero and redden the job.

### Deliberately not changed

Both rulesets have `strict_required_status_checks_policy: false`, so a bump can go green against an older `main` and auto-merge without retesting the combined state. Enabling "require branches to be up to date" would close that window, but it applies repo-wide and would add friction to the open community PRs, so it is a judgment call for @anweiss rather than something to fold into this PR:

```bash
gh api -X PUT repos/anweiss/cddl/rulesets/12702053 ...  # strict_required_status_checks_policy: true
```

Dependabot rebases its own PRs when the base branch moves, which narrows the window in practice.

### Validation

`actionlint` passes. The `autoMergeRequest` guard was smoke-tested against a real PR. The workflow has still never fired end to end — there are currently no open Dependabot PRs — so first real proof will come from the next weekly Dependabot run.
