### PR TITLE
feat(www): validate JSON/CBOR instances, plus outline, share, file I/O and sample generation

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -38,10 +38,14 @@
       --radius-lg: 12px;
       --shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
       --shadow-lg: 0 10px 25px rgba(0, 0, 0, 0.4);
+      --modal-backdrop: rgba(15, 17, 23, 0.72);
+      --overlay-scrim: rgba(15, 17, 23, 0.82);
       --transition: 150ms cubic-bezier(0.4, 0, 0.2, 1);
     }
 
     body.light {
+      --modal-backdrop: rgba(15, 17, 23, 0.35);
+      --overlay-scrim: rgba(248, 249, 252, 0.78);
       --bg: #f8f9fc;
       --bg-elevated: #ffffff;
       --bg-surface: #f0f1f5;
@@ -88,18 +92,22 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
+      gap: 0.75rem;
       padding: 0 1.25rem;
       height: 48px;
       background: var(--bg-elevated);
       border-bottom: 1px solid var(--border);
       flex-shrink: 0;
       z-index: 10;
+      overflow: hidden;
     }
 
     .topbar-left {
       display: flex;
       align-items: center;
       gap: 0.75rem;
+      min-width: 0;
+      flex-shrink: 0;
     }
 
     .logo {
@@ -191,7 +199,12 @@
     .topbar-right {
       display: flex;
       align-items: center;
+      justify-content: flex-end;
       gap: 0.5rem;
+      min-width: 0;
+      flex: 1 1 auto;
+      overflow: hidden;
+      white-space: nowrap;
     }
 
     /* ── Ref-check toggle ── */
@@ -400,6 +413,57 @@
       height: 16px;
     }
 
+    .topbar-action {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      flex: 0 0 auto;
+      gap: 0.35rem;
+      min-width: 30px;
+      height: 30px;
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      color: var(--text-muted);
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 0.78rem;
+      padding: 0 0.55rem;
+      transition: color var(--transition), background var(--transition), border-color var(--transition);
+    }
+
+    .topbar-action:hover {
+      color: var(--text);
+      background: var(--bg-hover);
+      border-color: var(--accent);
+    }
+
+    .topbar-action.active {
+      color: var(--accent);
+      background: var(--accent-subtle);
+      border-color: var(--accent);
+    }
+
+    .topbar-action svg {
+      width: 15px;
+      height: 15px;
+      flex-shrink: 0;
+    }
+
+    .topbar-action-label {
+      flex: 0 0 auto;
+      white-space: nowrap;
+    }
+
+    button:focus-visible,
+    a:focus-visible,
+    input:focus-visible,
+    select:focus-visible,
+    .toggle-group:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+
     .theme-btn .icon-sun {
       display: none;
     }
@@ -422,18 +486,451 @@
       display: flex;
       flex-direction: column;
       overflow: hidden;
+      min-height: 0;
+    }
+
+    .workspace-row {
+      flex: 1;
+      display: flex;
+      flex-direction: row;
+      min-height: 0;
+      min-width: 0;
+      overflow: hidden;
+    }
+
+    /* ── Outline pane ── */
+    .outline-pane {
+      position: relative;
+      width: 220px;
+      min-width: 160px;
+      max-width: 40vw;
+      flex: 0 0 220px;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+      background: var(--bg-elevated);
+      border-right: 1px solid var(--border);
+      overflow: hidden;
+    }
+
+    .outline-pane.collapsed {
+      display: none;
+    }
+
+    .pane-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      padding: 0.65rem 0.75rem;
+      border-bottom: 1px solid var(--border);
+      min-height: 42px;
+      flex-shrink: 0;
+    }
+
+    .pane-title {
+      min-width: 0;
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: var(--text-secondary);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .outline-filter-wrap {
+      padding: 0.65rem 0.75rem;
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+
+    .outline-filter {
+      width: 100%;
+      min-width: 0;
+      height: 30px;
+      padding: 0 0.6rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      background: var(--bg-surface);
+      color: var(--text);
+      font: inherit;
+      font-size: 0.78rem;
+      outline: none;
+      transition: border-color var(--transition), background var(--transition);
+    }
+
+    .outline-filter::placeholder {
+      color: var(--text-muted);
+    }
+
+    .outline-filter:focus {
+      border-color: var(--accent);
+      background: var(--bg-elevated);
+    }
+
+    .outline-list {
+      flex: 1;
+      min-height: 0;
+      overflow-y: auto;
+      padding: 0.45rem;
+    }
+
+    .outline-item {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr);
+      gap: 0.15rem 0.45rem;
+      align-items: start;
+      padding: 0.45rem 0.5rem;
+      border-radius: var(--radius-sm);
+      color: var(--text-secondary);
+      cursor: pointer;
+      transition: background var(--transition), color var(--transition);
+    }
+
+    .outline-item:hover,
+    .outline-item.active {
+      background: var(--bg-hover);
+      color: var(--text);
+    }
+
+    .outline-item.active {
+      box-shadow: inset 2px 0 0 var(--accent);
+    }
+
+    .outline-item-kind {
+      grid-row: span 2;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 20px;
+      max-width: 56px;
+      padding: 0.08rem 0.28rem;
+      border-radius: 9999px;
+      border: 1px solid var(--border);
+      background: var(--bg-surface);
+      color: var(--text-muted);
+      font-size: 0.58rem;
+      font-weight: 700;
+      line-height: 1.2;
+      text-transform: uppercase;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .outline-item-kind.type {
+      background: var(--accent-subtle);
+      border-color: var(--accent);
+      color: var(--accent);
+    }
+
+    .outline-item-kind.group {
+      background: var(--success-subtle);
+      border-color: var(--success-border);
+      color: var(--success);
+    }
+
+    .outline-item-kind.socket {
+      background: var(--warning-subtle);
+      border-color: var(--warning);
+      color: var(--warning);
+    }
+
+    .outline-item-kind.extension {
+      background: var(--error-subtle);
+      border-color: var(--error-border);
+      color: var(--error);
+    }
+
+    .outline-item-name {
+      min-width: 0;
+      font-size: 0.78rem;
+      font-weight: 500;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .outline-item-preview {
+      min-width: 0;
+      font-family: 'JetBrains Mono', 'Monaco', 'Menlo', monospace;
+      font-size: 0.68rem;
+      color: var(--text-muted);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .outline-empty {
+      padding: 1.5rem 0.75rem;
+      color: var(--text-muted);
+      font-size: 0.78rem;
+      text-align: center;
+      overflow-wrap: anywhere;
+    }
+
+    .outline-resize-handle,
+    .instance-split-handle {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      width: 6px;
+      z-index: 6;
+      cursor: ew-resize;
+    }
+
+    .outline-resize-handle {
+      right: -3px;
+    }
+
+    .instance-split-handle {
+      left: -3px;
+    }
+
+    .outline-resize-handle::after,
+    .instance-split-handle::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 2px;
+      width: 2px;
+      background: transparent;
+      transition: background var(--transition);
+    }
+
+    .outline-resize-handle:hover::after,
+    .outline-resize-handle.active::after,
+    .instance-split-handle:hover::after,
+    .instance-split-handle.active::after {
+      background: var(--accent);
     }
 
     /* ── Editor ── */
     .editor-area {
-      flex: 1;
+      flex: 1 1 auto;
       position: relative;
       min-height: 0;
+      min-width: 0;
     }
 
     .editor-container {
       position: absolute;
       inset: 0;
+    }
+
+    /* ── Instance pane ── */
+    .instance-pane {
+      position: relative;
+      width: 380px;
+      min-width: 260px;
+      max-width: 50vw;
+      flex: 0 0 380px;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+      min-width: 0;
+      background: var(--bg-elevated);
+      border-left: 1px solid var(--border);
+      overflow: hidden;
+    }
+
+    .instance-pane.collapsed {
+      display: none;
+    }
+
+    .pane-close-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 26px;
+      height: 26px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      background: transparent;
+      color: var(--text-muted);
+      cursor: pointer;
+      transition: color var(--transition), background var(--transition), border-color var(--transition);
+    }
+
+    .pane-close-btn:hover {
+      color: var(--text);
+      background: var(--bg-hover);
+      border-color: var(--accent);
+    }
+
+    .pane-close-btn svg {
+      width: 14px;
+      height: 14px;
+    }
+
+    .instance-tabs {
+      display: flex;
+      padding: 0.55rem 0.75rem 0;
+      gap: 0.35rem;
+      flex-shrink: 0;
+    }
+
+    .instance-tab {
+      flex: 1;
+      min-width: 0;
+      height: 30px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+      background: var(--bg-surface);
+      color: var(--text-muted);
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 0.76rem;
+      font-weight: 500;
+      transition: background var(--transition), color var(--transition), border-color var(--transition);
+    }
+
+    .instance-tab:hover,
+    .instance-tab.active {
+      color: var(--text);
+      background: var(--bg-hover);
+      border-color: var(--accent);
+    }
+
+    .instance-controls {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto auto;
+      gap: 0.5rem;
+      padding: 0.65rem 0.75rem;
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+
+    .instance-select {
+      min-width: 0;
+      height: 32px;
+      padding: 0 0.55rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      background: var(--bg-surface);
+      color: var(--text);
+      font: inherit;
+      font-size: 0.76rem;
+      outline: none;
+    }
+
+    .instance-select:focus {
+      border-color: var(--accent);
+    }
+
+    .instance-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 0;
+      height: 32px;
+      padding: 0 0.65rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      background: transparent;
+      color: var(--text-secondary);
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 0.76rem;
+      font-weight: 500;
+      transition: color var(--transition), background var(--transition), border-color var(--transition);
+      white-space: nowrap;
+    }
+
+    .instance-btn:hover {
+      color: var(--text);
+      background: var(--bg-hover);
+      border-color: var(--accent);
+    }
+
+    .instance-btn.primary {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: white;
+    }
+
+    .instance-btn.primary:hover {
+      background: var(--accent-hover);
+      border-color: var(--accent-hover);
+    }
+
+    .instance-hint {
+      padding: 0 0.75rem 0.55rem;
+      color: var(--text-muted);
+      font-size: 0.72rem;
+      flex-shrink: 0;
+      overflow-wrap: anywhere;
+    }
+
+    .instance-editor-shell {
+      flex: 1 1 auto;
+      min-height: 0;
+      min-width: 0;
+      display: flex;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .instance-editor {
+      flex: 1 1 auto;
+      min-height: 0;
+      min-width: 0;
+    }
+
+    .instance-result {
+      flex: 0 0 150px;
+      max-height: 35%;
+      min-height: 88px;
+      overflow-y: auto;
+      padding: 0.7rem 0.75rem;
+      background: var(--bg-surface);
+      color: var(--text-secondary);
+      font-size: 0.78rem;
+      overflow-wrap: anywhere;
+    }
+
+    .instance-result.ok {
+      background: var(--success-subtle);
+      color: var(--success);
+    }
+
+    .instance-result.fail {
+      background: var(--error-subtle);
+      color: var(--error);
+    }
+
+    .instance-result-title {
+      font-weight: 600;
+      margin-bottom: 0.4rem;
+      color: var(--text);
+    }
+
+    .instance-result.ok .instance-result-title {
+      color: var(--success);
+    }
+
+    .instance-result.fail .instance-result-title {
+      color: var(--error);
+    }
+
+    .instance-result-list {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+      list-style: none;
+    }
+
+    .instance-result-item {
+      color: inherit;
+      line-height: 1.45;
+      overflow-wrap: anywhere;
+    }
+
+    .instance-result-empty {
+      color: var(--text-muted);
+      font-style: italic;
     }
 
     /* ── Problems Panel ── */
@@ -655,28 +1152,383 @@
       height: 12px;
     }
 
+    /* ── Drop overlay ── */
+    .drop-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 1000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+      background: var(--overlay-scrim);
+      opacity: 0;
+      visibility: hidden;
+      pointer-events: none;
+      transition: opacity var(--transition), visibility var(--transition);
+    }
+
+    .drop-overlay.visible {
+      opacity: 1;
+      visibility: visible;
+      pointer-events: none;
+    }
+
+    .drop-overlay-card {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.85rem;
+      width: min(440px, 100%);
+      padding: 2rem;
+      border: 2px dashed var(--accent);
+      border-radius: var(--radius-lg);
+      background: var(--bg-elevated);
+      box-shadow: var(--shadow-lg);
+      color: var(--text);
+      text-align: center;
+    }
+
+    .drop-overlay-card svg {
+      width: 42px;
+      height: 42px;
+      color: var(--accent);
+    }
+
+    .drop-overlay-title {
+      font-size: 1rem;
+      font-weight: 600;
+      overflow-wrap: anywhere;
+    }
+
+    /* ── Toasts ── */
+    .toast-container {
+      position: fixed;
+      right: 1rem;
+      bottom: calc(24px + 1rem);
+      z-index: 1100;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 0.6rem;
+      width: min(360px, calc(100vw - 2rem));
+      pointer-events: none;
+    }
+
+    .toast {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      gap: 0.55rem;
+      align-items: start;
+      width: 100%;
+      padding: 0.7rem 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--bg-elevated);
+      box-shadow: var(--shadow-lg);
+      color: var(--text-secondary);
+      pointer-events: auto;
+      opacity: 0;
+      transform: translateY(8px) scale(0.98);
+      transition: opacity var(--transition), transform var(--transition);
+      overflow-wrap: anywhere;
+    }
+
+    .toast.visible {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+
+    .toast-icon {
+      width: 18px;
+      height: 18px;
+      margin-top: 1px;
+      color: var(--accent);
+      flex-shrink: 0;
+    }
+
+    .toast-info {
+      border-color: var(--accent);
+    }
+
+    .toast-success {
+      border-color: var(--success-border);
+      background: var(--success-subtle);
+    }
+
+    .toast-success .toast-icon {
+      color: var(--success);
+    }
+
+    .toast-error {
+      border-color: var(--error-border);
+      background: var(--error-subtle);
+    }
+
+    .toast-error .toast-icon {
+      color: var(--error);
+    }
+
+    .toast-warning {
+      border-color: var(--warning);
+      background: var(--warning-subtle);
+    }
+
+    .toast-warning .toast-icon {
+      color: var(--warning);
+    }
+
+    .toast-close {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border: 0;
+      border-radius: var(--radius-sm);
+      background: transparent;
+      color: var(--text-muted);
+      cursor: pointer;
+      transition: color var(--transition), background var(--transition);
+    }
+
+    .toast-close:hover {
+      color: var(--text);
+      background: var(--bg-hover);
+    }
+
+    /* ── Shortcuts modal ── */
+    .shortcuts-modal {
+      position: fixed;
+      inset: 0;
+      z-index: 1200;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1.5rem;
+      background: var(--modal-backdrop);
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity var(--transition), visibility var(--transition);
+    }
+
+    .shortcuts-modal.visible {
+      opacity: 1;
+      visibility: visible;
+    }
+
+    .shortcuts-dialog {
+      width: min(560px, 100%);
+      max-height: min(680px, calc(100vh - 3rem));
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      background: var(--bg-elevated);
+      box-shadow: var(--shadow-lg);
+      overflow: hidden;
+      transform: translateY(8px) scale(0.98);
+      transition: transform var(--transition);
+    }
+
+    .shortcuts-modal.visible .shortcuts-dialog {
+      transform: translateY(0) scale(1);
+    }
+
+    .shortcuts-body {
+      flex: 1;
+      min-height: 0;
+      overflow-y: auto;
+      padding: 0.85rem;
+    }
+
+    .shortcuts-group-title {
+      margin: 0.75rem 0 0.35rem;
+      color: var(--text-muted);
+      font-size: 0.68rem;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .shortcuts-group-title:first-child {
+      margin-top: 0;
+    }
+
+    .shortcut-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      padding: 0.55rem 0;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .shortcut-row:last-child {
+      border-bottom: none;
+    }
+
+    .shortcut-desc {
+      min-width: 0;
+      color: var(--text-secondary);
+      font-size: 0.82rem;
+      overflow-wrap: anywhere;
+    }
+
+    .shortcut-keys {
+      display: inline-flex;
+      align-items: center;
+      justify-content: flex-end;
+      flex-wrap: wrap;
+      gap: 0.25rem;
+      min-width: 0;
+    }
+
+    kbd.shortcut-key {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 1.55rem;
+      min-height: 1.45rem;
+      padding: 0.12rem 0.4rem;
+      border: 1px solid var(--border);
+      border-bottom-width: 2px;
+      border-radius: var(--radius-sm);
+      background: var(--bg-surface);
+      color: var(--text);
+      font-family: 'JetBrains Mono', 'Monaco', 'Menlo', monospace;
+      font-size: 0.72rem;
+      line-height: 1;
+      box-shadow: var(--shadow);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .toast,
+      .shortcuts-modal,
+      .shortcuts-dialog,
+      .drop-overlay {
+        transition: none;
+      }
+    }
+
     /* ── Scrollbar styling ── */
+    .outline-list::-webkit-scrollbar,
+    .instance-result::-webkit-scrollbar,
+    .shortcuts-body::-webkit-scrollbar,
     .problems-body::-webkit-scrollbar {
       width: 8px;
     }
 
+    .outline-list::-webkit-scrollbar-track,
+    .instance-result::-webkit-scrollbar-track,
+    .shortcuts-body::-webkit-scrollbar-track,
     .problems-body::-webkit-scrollbar-track {
       background: transparent;
     }
 
+    .outline-list::-webkit-scrollbar-thumb,
+    .instance-result::-webkit-scrollbar-thumb,
+    .shortcuts-body::-webkit-scrollbar-thumb,
     .problems-body::-webkit-scrollbar-thumb {
       background: var(--bg-hover);
       border-radius: 4px;
     }
 
+    .outline-list::-webkit-scrollbar-thumb:hover,
+    .instance-result::-webkit-scrollbar-thumb:hover,
+    .shortcuts-body::-webkit-scrollbar-thumb:hover,
     .problems-body::-webkit-scrollbar-thumb:hover {
       background: var(--text-muted);
     }
 
     /* ── Responsive ── */
-    @media (max-width: 640px) {
+    @media (max-width: 1279px) {
+      .topbar-action-label {
+        display: none;
+      }
+
+      .topbar-action {
+        width: 30px;
+        padding: 0;
+      }
+    }
+
+    @media (max-width: 1100px) {
+      .outline-pane:not(.pinned) {
+        display: none;
+      }
+
+      .topbar-right {
+        gap: 0.35rem;
+      }
+    }
+
+    @media (max-width: 860px) {
       .topbar {
         padding: 0 0.75rem;
+      }
+
+      .logo span,
+      .toggle-group span,
+      .topbar-action-label,
+      .topbar-link span {
+        display: none;
+      }
+
+      .topbar-left {
+        gap: 0.5rem;
+      }
+
+      .topbar-right {
+        gap: 0.25rem;
+      }
+
+      .toggle-group {
+        padding: 0.25rem;
+      }
+
+      .topbar-action,
+      .examples-btn {
+        width: 30px;
+        padding: 0;
+      }
+
+      .examples-btn .chevron,
+      .examples-btn span {
+        display: none;
+      }
+
+      .topbar-link {
+        width: 30px;
+        height: 30px;
+        justify-content: center;
+        padding: 0;
+      }
+
+      .instance-pane:not(.pinned) {
+        display: none;
+      }
+
+      .examples-dropdown {
+        right: -3rem;
+        width: min(320px, calc(100vw - 1rem));
+      }
+    }
+
+    @media (max-width: 640px) {
+      .status-pill {
+        max-width: 110px;
+      }
+
+      #statusText {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .separator {
+        display: none;
       }
 
       .problems-header {
@@ -689,6 +1541,12 @@
 
       .problem-category {
         display: none;
+      }
+
+      .shortcut-row {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 0.4rem;
       }
     }
   </style>
@@ -722,6 +1580,66 @@
           <div class="toggle-knob"></div>
         </div>
       </label>
+      <button class="topbar-action" id="outlineToggleBtn" title="Toggle outline (Ctrl/Cmd+B)" aria-label="Toggle outline">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <rect x="3" y="4" width="18" height="16" rx="2" />
+          <line x1="9" y1="4" x2="9" y2="20" />
+          <line x1="12" y1="8" x2="18" y2="8" />
+          <line x1="12" y1="12" x2="17" y2="12" />
+          <line x1="12" y1="16" x2="15" y2="16" />
+        </svg>
+        <span class="topbar-action-label">Outline</span>
+      </button>
+      <button class="topbar-action" id="instanceToggleBtn" title="Toggle instance pane (Ctrl/Cmd+I)" aria-label="Toggle instance pane">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <rect x="3" y="4" width="18" height="16" rx="2" />
+          <line x1="15" y1="4" x2="15" y2="20" />
+          <polyline points="8 9 5 12 8 15" />
+          <polyline points="19 9 22 12 19 15" />
+        </svg>
+        <span class="topbar-action-label">Instance</span>
+      </button>
+      <button class="topbar-action" id="openFileBtn" title="Open file (Ctrl/Cmd+O)" aria-label="Open file">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <path d="M3 7h5l2 3h11" />
+          <path d="M3 7v11a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-8" />
+        </svg>
+        <span class="topbar-action-label">Open</span>
+      </button>
+      <button class="topbar-action" id="saveFileBtn" title="Download schema (Ctrl/Cmd+Shift+S)" aria-label="Download schema">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+          <polyline points="7 10 12 15 17 10" />
+          <line x1="12" y1="15" x2="12" y2="3" />
+        </svg>
+        <span class="topbar-action-label">Save</span>
+      </button>
+      <button class="topbar-action" id="shareBtn" title="Copy shareable link (Ctrl/Cmd+Shift+C)" aria-label="Copy shareable link">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <circle cx="18" cy="5" r="3" />
+          <circle cx="6" cy="12" r="3" />
+          <circle cx="18" cy="19" r="3" />
+          <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+          <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+        </svg>
+        <span class="topbar-action-label">Share</span>
+      </button>
+      <button class="topbar-action" id="shortcutsBtn" title="Keyboard shortcuts (?)" aria-label="Keyboard shortcuts">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <rect x="3" y="5" width="18" height="14" rx="2" />
+          <line x1="7" y1="9" x2="7.01" y2="9" />
+          <line x1="11" y1="9" x2="11.01" y2="9" />
+          <line x1="15" y1="9" x2="15.01" y2="9" />
+          <line x1="8" y1="13" x2="16" y2="13" />
+        </svg>
+        <span class="topbar-action-label">Shortcuts</span>
+      </button>
       <div class="separator"></div>
       <div class="examples-wrapper" id="examplesWrapper">
         <button class="examples-btn" id="examplesBtn" title="Browse CDDL examples">
@@ -730,7 +1648,7 @@
             <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
             <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
           </svg>
-          Examples
+          <span>Examples</span>
           <svg class="chevron" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5">
             <polyline points="3 5 6 8 9 5" />
           </svg>
@@ -738,7 +1656,8 @@
         <div class="examples-dropdown" id="examplesDropdown"></div>
       </div>
       <div class="separator"></div>
-      <a href="https://tools.ietf.org/html/rfc8610" target="_blank" rel="noopener" class="topbar-link">
+      <a href="https://tools.ietf.org/html/rfc8610" target="_blank" rel="noopener" class="topbar-link"
+        title="Open RFC 8610" aria-label="Open RFC 8610">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
           stroke-linejoin="round">
           <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
@@ -747,16 +1666,17 @@
           <line x1="16" y1="17" x2="8" y2="17" />
           <polyline points="10 9 9 9 8 9" />
         </svg>
-        RFC 8610
+        <span>RFC 8610</span>
       </a>
-      <a href="https://github.com/anweiss/cddl" target="_blank" rel="noopener" class="topbar-link">
+      <a href="https://github.com/anweiss/cddl" target="_blank" rel="noopener" class="topbar-link"
+        title="Open project on GitHub" aria-label="Open project on GitHub">
         <svg viewBox="0 0 24 24" fill="currentColor">
           <path
             d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
         </svg>
-        GitHub
+        <span>GitHub</span>
       </a>
-      <button class="theme-btn" id="themeToggle" title="Toggle light/dark mode">
+      <button class="theme-btn" id="themeToggle" title="Toggle light/dark mode" aria-label="Toggle light/dark mode">
         <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
           stroke-linecap="round" stroke-linejoin="round">
           <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
@@ -779,9 +1699,59 @@
 
   <!-- Main workspace -->
   <div class="workspace">
-    <!-- Editor -->
-    <div class="editor-area">
-      <div class="editor-container" id="cddlEditor"></div>
+    <div class="workspace-row">
+      <!-- Outline sidebar -->
+      <aside class="outline-pane" id="outlinePane" aria-label="CDDL outline">
+        <div class="pane-header">
+          <span class="pane-title">Outline</span>
+        </div>
+        <div class="outline-filter-wrap">
+          <input class="outline-filter" id="outlineFilter" type="search" placeholder="Filter rules…" title="Filter outline rules"
+            aria-label="Filter outline rules">
+        </div>
+        <div class="outline-list" id="outlineList" role="tree">
+          <div class="outline-empty">No rules found</div>
+        </div>
+        <div class="outline-resize-handle" id="outlineResizeHandle" title="Resize outline pane" aria-hidden="true"></div>
+      </aside>
+
+      <!-- Editor -->
+      <div class="editor-area">
+        <div class="editor-container" id="cddlEditor"></div>
+      </div>
+
+      <!-- Instance pane -->
+      <aside class="instance-pane" id="instancePane" aria-label="Instance validation pane">
+        <div class="instance-split-handle" id="instanceSplitHandle" title="Resize instance pane" aria-hidden="true"></div>
+        <div class="pane-header">
+          <span class="pane-title">Instance</span>
+          <button class="pane-close-btn" id="instancePaneClose" title="Close instance pane" aria-label="Close instance pane">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+              stroke-linejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+        <div class="instance-tabs" role="tablist" aria-label="Instance format">
+          <button class="instance-tab active" id="instanceTabJson" title="JSON instance" role="tab" aria-selected="true">JSON</button>
+          <button class="instance-tab" id="instanceTabCbor" title="CBOR instance" role="tab" aria-selected="false">CBOR</button>
+        </div>
+        <div class="instance-controls">
+          <select class="instance-select" id="instanceRootRule" title="Root rule" aria-label="Root rule">
+            <option value="">Root rule</option>
+          </select>
+          <button class="instance-btn" id="instanceGenBtn" title="Generate sample">Generate sample</button>
+          <button class="instance-btn primary" id="instanceValidateBtn" title="Validate instance">Validate</button>
+        </div>
+        <div class="instance-hint" id="instanceCborHint">Paste hex or base64</div>
+        <div class="instance-editor-shell">
+          <div class="instance-editor" id="instanceEditor"></div>
+        </div>
+        <div class="instance-result" id="instanceResult">
+          <div class="instance-result-empty">Validation results will appear here.</div>
+        </div>
+      </aside>
     </div>
 
     <!-- Problems Panel (inline debugger) -->
@@ -807,6 +1777,37 @@
           No problems detected
         </div>
       </div>
+    </div>
+  </div>
+
+  <div class="drop-overlay" id="dropOverlay" aria-hidden="true">
+    <div class="drop-overlay-card">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+        stroke-linejoin="round">
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+        <polyline points="17 8 12 3 7 8" />
+        <line x1="12" y1="3" x2="12" y2="15" />
+      </svg>
+      <div class="drop-overlay-title">Drop a .cddl, .json or .cbor file</div>
+    </div>
+  </div>
+
+  <div class="toast-container" id="toastContainer" role="status" aria-live="polite"></div>
+
+  <div class="shortcuts-modal" id="shortcutsModal" aria-hidden="true" role="dialog" aria-modal="true"
+    aria-labelledby="shortcutsTitle">
+    <div class="shortcuts-dialog">
+      <div class="pane-header">
+        <h2 class="pane-title" id="shortcutsTitle">Keyboard shortcuts</h2>
+        <button class="pane-close-btn" id="shortcutsClose" title="Close keyboard shortcuts" aria-label="Close keyboard shortcuts">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+            stroke-linejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      </div>
+      <div class="shortcuts-body" id="shortcutsBody"></div>
     </div>
   </div>
 

--- a/www/index.html
+++ b/www/index.html
@@ -1455,10 +1455,6 @@
     }
 
     @media (max-width: 1100px) {
-      .outline-pane:not(.pinned) {
-        display: none;
-      }
-
       .topbar-right {
         gap: 0.35rem;
       }
@@ -1504,10 +1500,6 @@
         height: 30px;
         justify-content: center;
         padding: 0;
-      }
-
-      .instance-pane:not(.pinned) {
-        display: none;
       }
 
       .examples-dropdown {

--- a/www/index.js
+++ b/www/index.js
@@ -1258,7 +1258,7 @@ function toMarker(model, err) {
 // ─── Instance Validation ─────────────────────────────────────────────────────
 
 function loadInstanceText(sharedState) {
-  if (typeof sharedState?.instance === 'string') return sharedState.instance;
+  if (sharedState) return typeof sharedState.instance === 'string' ? sharedState.instance : '';
   try {
     return localStorage.getItem(INSTANCE_TEXT_CACHE_KEY) || '';
   } catch (_) {}

--- a/www/index.js
+++ b/www/index.js
@@ -1352,6 +1352,7 @@ function validateCurrentInstance() {
     cddl: editor.getValue(),
     kind: instanceKind,
     text: instanceEditor.getValue(),
+    rootRule: instanceRootRule?.value || undefined,
   });
   renderInstanceResult(result);
   toast(result.title, result.ok ? 'success' : 'error');

--- a/www/index.js
+++ b/www/index.js
@@ -1,4 +1,11 @@
 import * as monaco from 'monaco-editor';
+import { validateInstance, parseCborInput, isCborSupported } from './src/instance-validation.js';
+import { buildShareUrl, readStateFromLocation, clearLocationState, copyToClipboard, isTooLargeToShare } from './src/share.js';
+import { pickFile, downloadText, attachDropZone, classifyFile, bytesToHex } from './src/file-io.js';
+import { parseRules, renderOutline, registerNavigation } from './src/outline.js';
+import { generateSample, listRootCandidates } from './src/sample-gen.js';
+import { initToasts, toast } from './src/toast.js';
+import { initShortcutsModal } from './src/shortcuts.js';
 
 // ─── CDDL Language Registration ───────────────────────────────────────────────
 
@@ -862,9 +869,24 @@ function saveContent(content) {
 // ─── DOM References ────────────────────────────────────────────────────────────
 
 let editor;
+let instanceEditor;
 let statusPill, statusText;
 let problemsPanel, problemsBadge, problemsBody, problemsEmpty;
 let cursorPosition;
+
+const INSTANCE_TEXT_CACHE_KEY = 'cddl-playground-instance-text';
+const INSTANCE_KIND_CACHE_KEY = 'cddl-playground-instance-kind';
+const INSTANCE_PANE_CACHE_KEY = 'cddl-playground-instance-open';
+const OUTLINE_PANE_CACHE_KEY = 'cddl-playground-outline-open';
+
+let instanceKind = 'json';
+let instancePane, instanceToggleBtn, instanceResult, instanceRootRule;
+let instanceTabJson, instanceTabCbor, instanceCborHint;
+let outlinePane, outlineToggleBtn, outlineFilter, outlineList;
+let outlineRules = [];
+let schemaFeatureTimer;
+let shortcutsController;
+let navigationDisposer;
 
 // ─── Problems Panel ────────────────────────────────────────────────────────────
 
@@ -878,26 +900,30 @@ function updateProblems(errors) {
   }
 
   // Badge
-  problemsBadge.textContent = count;
-  problemsBadge.classList.toggle('zero', count === 0);
+  if (problemsBadge) {
+    problemsBadge.textContent = count;
+    problemsBadge.classList.toggle('zero', count === 0);
+  }
 
   // Status pill
-  statusPill.className = 'status-pill';
+  if (statusPill) statusPill.className = 'status-pill';
   if (errorCount > 0) {
-    statusPill.classList.add('invalid');
+    if (statusPill) statusPill.classList.add('invalid');
     const parts = [];
     parts.push(`${errorCount} error${errorCount > 1 ? 's' : ''}`);
     if (warningCount > 0) parts.push(`${warningCount} warning${warningCount > 1 ? 's' : ''}`);
-    statusText.textContent = parts.join(', ');
+    if (statusText) statusText.textContent = parts.join(', ');
   } else if (warningCount > 0) {
-    statusPill.classList.add('valid');
-    statusText.textContent = `Valid \u2022 ${warningCount} warning${warningCount > 1 ? 's' : ''}`;
+    if (statusPill) statusPill.classList.add('valid');
+    if (statusText) statusText.textContent = `Valid \u2022 ${warningCount} warning${warningCount > 1 ? 's' : ''}`;
   } else {
-    statusPill.classList.add('valid');
-    statusText.textContent = 'Valid';
+    if (statusPill) statusPill.classList.add('valid');
+    if (statusText) statusText.textContent = 'Valid';
   }
 
   // Body — batch DOM writes with a document fragment
+  if (!problemsBody) return;
+
   if (count === 0) {
     problemsBody.innerHTML = '';
     problemsBody.appendChild(createEmptyState());
@@ -905,7 +931,7 @@ function updateProblems(errors) {
   }
 
   // Auto-expand when errors appear
-  problemsPanel.classList.remove('collapsed');
+  if (problemsPanel) problemsPanel.classList.remove('collapsed');
 
   const frag = document.createDocumentFragment();
   for (let i = 0; i < count; i++) {
@@ -1037,6 +1063,7 @@ let saveTimer;
 function scheduleValidation() {
   clearTimeout(validationTimer);
   validationTimer = setTimeout(runValidation, 400);
+  scheduleSchemaFeatures();
 }
 
 function scheduleSave() {
@@ -1054,14 +1081,14 @@ function runValidation() {
   if (!input.trim()) {
     updateProblems([]);
     monaco.editor.setModelMarkers(editor.getModel(), 'cddl', []);
-    statusPill.className = 'status-pill';
-    statusText.textContent = 'Ready';
+    if (statusPill) statusPill.className = 'status-pill';
+    if (statusText) statusText.textContent = 'Ready';
     return;
   }
 
   // Show checking state briefly
-  statusPill.className = 'status-pill checking';
-  statusText.textContent = 'Checking\u2026';
+  if (statusPill) statusPill.className = 'status-pill checking';
+  if (statusText) statusText.textContent = 'Checking\u2026';
 
   const result = validateCDDLText(input);
   updateProblems(result.errors);
@@ -1227,6 +1254,434 @@ function toMarker(model, err) {
   };
 }
 
+
+// ─── Instance Validation ─────────────────────────────────────────────────────
+
+function loadInstanceText(sharedState) {
+  if (typeof sharedState?.instance === 'string') return sharedState.instance;
+  try {
+    return localStorage.getItem(INSTANCE_TEXT_CACHE_KEY) || '';
+  } catch (_) {}
+  return '';
+}
+
+function loadInstanceKind(sharedState) {
+  if (sharedState?.kind === 'json' || sharedState?.kind === 'cbor') return sharedState.kind;
+  try {
+    const saved = localStorage.getItem(INSTANCE_KIND_CACHE_KEY);
+    if (saved === 'json' || saved === 'cbor') return saved;
+  } catch (_) {}
+  return 'json';
+}
+
+function saveInstanceState() {
+  try {
+    if (instanceEditor) localStorage.setItem(INSTANCE_TEXT_CACHE_KEY, instanceEditor.getValue());
+    localStorage.setItem(INSTANCE_KIND_CACHE_KEY, instanceKind);
+    if (instancePane) localStorage.setItem(INSTANCE_PANE_CACHE_KEY, String(!instancePane.classList.contains('collapsed')));
+  } catch (_) {}
+}
+
+function layoutInstanceNextFrame() {
+  if (!instanceEditor || (instancePane && instancePane.classList.contains('collapsed'))) return;
+  requestAnimationFrame(() => instanceEditor.layout());
+}
+
+function layoutPlaygroundEditors() {
+  if (editor) editor.layout();
+  if (instanceEditor && (!instancePane || !instancePane.classList.contains('collapsed'))) instanceEditor.layout();
+}
+
+function setInstanceKind(kind) {
+  instanceKind = kind === 'cbor' ? 'cbor' : 'json';
+  if (instanceTabJson) instanceTabJson.classList.toggle('active', instanceKind === 'json');
+  if (instanceTabCbor) instanceTabCbor.classList.toggle('active', instanceKind === 'cbor');
+  if (instanceCborHint) {
+    instanceCborHint.hidden = instanceKind !== 'cbor';
+    instanceCborHint.style.display = instanceKind === 'cbor' ? '' : 'none';
+    if (instanceKind === 'cbor' && wasmModule && !isCborSupported(wasmModule)) {
+      instanceCborHint.textContent = 'CBOR validation is not available in this WASM build.';
+    }
+  }
+  if (instanceEditor?.getModel()) {
+    monaco.editor.setModelLanguage(instanceEditor.getModel(), instanceKind === 'json' ? 'json' : 'plaintext');
+  }
+  saveInstanceState();
+}
+
+function renderInstanceResult(result) {
+  if (!instanceResult) return;
+  instanceResult.textContent = '';
+  instanceResult.classList.remove('ok', 'fail');
+  instanceResult.classList.add(result.ok ? 'ok' : 'fail');
+
+  const title = document.createElement('div');
+  title.className = 'instance-result-title';
+  title.textContent = result.title || (result.ok ? 'Instance is valid' : 'Instance validation failed');
+  instanceResult.appendChild(title);
+
+  const list = document.createElement('div');
+  list.className = 'instance-result-list';
+  const failures = Array.isArray(result.failures) ? result.failures : [];
+  if (failures.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'instance-result-empty';
+    empty.textContent = result.ok ? 'No failures.' : (result.detail || 'Validation failed.');
+    list.appendChild(empty);
+  } else {
+    for (const failure of failures) {
+      const item = document.createElement('div');
+      item.className = 'instance-result-item';
+      item.textContent = String(failure);
+      list.appendChild(item);
+    }
+  }
+  instanceResult.appendChild(list);
+}
+
+function validateCurrentInstance() {
+  if (!editor || !instanceEditor) return;
+  const result = validateInstance({
+    wasmModule,
+    cddl: editor.getValue(),
+    kind: instanceKind,
+    text: instanceEditor.getValue(),
+  });
+  renderInstanceResult(result);
+  toast(result.title, result.ok ? 'success' : 'error');
+}
+
+function toggleInstancePane(forceOpen) {
+  if (!instancePane) return;
+  const open = typeof forceOpen === 'boolean' ? forceOpen : instancePane.classList.contains('collapsed');
+  instancePane.classList.toggle('collapsed', !open);
+  if (instanceToggleBtn) instanceToggleBtn.classList.toggle('active', open);
+  saveInstanceState();
+  if (editor) editor.layout();
+  if (open) layoutInstanceNextFrame();
+}
+
+function refreshRootCandidates() {
+  if (!instanceRootRule || !editor) return;
+  const previous = instanceRootRule.value;
+  const roots = listRootCandidates(editor.getValue());
+  instanceRootRule.textContent = '';
+  for (const root of roots) {
+    const option = document.createElement('option');
+    option.value = root;
+    option.textContent = root;
+    instanceRootRule.appendChild(option);
+  }
+  if (previous && roots.includes(previous)) {
+    instanceRootRule.value = previous;
+  } else if (roots.length > 0) {
+    instanceRootRule.value = roots[0];
+  }
+}
+
+function generateCurrentSample() {
+  if (!editor || !instanceEditor) return;
+  const selectedRoot = instanceRootRule?.value || undefined;
+  const result = generateSample(editor.getValue(), selectedRoot);
+  if (result.error) {
+    toast(result.error, 'error');
+    return;
+  }
+  if (result.json !== null) {
+    setInstanceKind('json');
+    instanceEditor.setValue(result.json);
+    saveInstanceState();
+    toggleInstancePane(true);
+    if (result.jsonRepresentable === false) {
+      toast(
+        'This schema uses CBOR-only features (integer keys, byte strings, or tags) — the generated JSON is a shape reference and won\'t validate as JSON. Switch to the CBOR tab for this one.',
+        'warning',
+        7000,
+      );
+    } else {
+      toast('Generated sample instance', 'success');
+    }
+  }
+  if (result.warnings && result.warnings.length > 0) {
+    toast(`Generated with ${result.warnings.length} caveat(s): ${result.warnings[0]}`, 'warning');
+  }
+}
+
+function initInstanceFeature(sharedState) {
+  try {
+    instancePane = document.getElementById('instancePane');
+    instanceToggleBtn = document.getElementById('instanceToggleBtn');
+    instanceTabJson = document.getElementById('instanceTabJson');
+    instanceTabCbor = document.getElementById('instanceTabCbor');
+    instanceRootRule = document.getElementById('instanceRootRule');
+    instanceResult = document.getElementById('instanceResult');
+    instanceCborHint = document.getElementById('instanceCborHint');
+    const container = document.getElementById('instanceEditor');
+    if (!container) return;
+
+    instanceKind = loadInstanceKind(sharedState);
+    instanceEditor = monaco.editor.create(container, {
+      value: loadInstanceText(sharedState),
+      language: instanceKind === 'json' ? 'json' : 'plaintext',
+      theme: isDark ? 'cddl-dark' : 'cddl-light',
+      fontSize: 14,
+      lineHeight: 22,
+      fontFamily: "'JetBrains Mono', 'Monaco', 'Menlo', 'Consolas', monospace",
+      fontLigatures: true,
+      minimap: { enabled: false },
+      scrollBeyondLastLine: false,
+      automaticLayout: false,
+      wordWrap: 'on',
+      wrappingIndent: 'indent',
+      lineNumbers: 'on',
+      renderLineHighlight: 'line',
+      cursorBlinking: 'smooth',
+      cursorSmoothCaretAnimation: 'on',
+      smoothScrolling: true,
+      bracketPairColorization: { enabled: true },
+      guides: { bracketPairs: 'active', indentation: true },
+      padding: { top: 12, bottom: 12 },
+      hover: { enabled: true, delay: 300, sticky: true },
+    });
+    instanceEditor.onDidChangeModelContent(saveInstanceState);
+
+    let open = false;
+    try { open = localStorage.getItem(INSTANCE_PANE_CACHE_KEY) === 'true'; } catch (_) {}
+    if (sharedState?.instance) open = true;
+    toggleInstancePane(open);
+    setInstanceKind(instanceKind);
+
+    if (instanceToggleBtn) instanceToggleBtn.addEventListener('click', () => toggleInstancePane());
+    const closeBtn = document.getElementById('instancePaneClose');
+    if (closeBtn) closeBtn.addEventListener('click', () => toggleInstancePane(false));
+    if (instanceTabJson) instanceTabJson.addEventListener('click', () => setInstanceKind('json'));
+    if (instanceTabCbor) instanceTabCbor.addEventListener('click', () => setInstanceKind('cbor'));
+    const validateBtn = document.getElementById('instanceValidateBtn');
+    if (validateBtn) validateBtn.addEventListener('click', validateCurrentInstance);
+    const genBtn = document.getElementById('instanceGenBtn');
+    if (genBtn) genBtn.addEventListener('click', generateCurrentSample);
+
+    const splitHandle = document.getElementById('instanceSplitHandle');
+    if (splitHandle && instancePane) wireHorizontalResize(splitHandle, instancePane, 'ew-resize', 260, 720, -1);
+  } catch (err) {
+    console.error('Failed to initialize instance validation:', err);
+  }
+}
+
+// ─── Outline ─────────────────────────────────────────────────────────────────
+
+function renderOutlineNow() {
+  if (!outlineList) return;
+  renderOutline(outlineList, outlineRules, {
+    filter: outlineFilter?.value || '',
+    onSelect: (rule) => {
+      jumpTo(rule.line, rule.column);
+      if (editor) editor.focus();
+    },
+  });
+}
+
+function refreshOutline() {
+  if (!editor) return;
+  outlineRules = parseRules(editor.getValue());
+  renderOutlineNow();
+}
+
+function refreshSchemaFeatures() {
+  try { refreshOutline(); } catch (err) { console.error('Failed to refresh outline:', err); }
+  try { refreshRootCandidates(); } catch (err) { console.error('Failed to refresh root rules:', err); }
+}
+
+function scheduleSchemaFeatures() {
+  clearTimeout(schemaFeatureTimer);
+  schemaFeatureTimer = setTimeout(refreshSchemaFeatures, 400);
+}
+
+function toggleOutlinePane(forceOpen) {
+  if (!outlinePane) return;
+  const open = typeof forceOpen === 'boolean' ? forceOpen : outlinePane.classList.contains('collapsed');
+  outlinePane.classList.toggle('collapsed', !open);
+  if (outlineToggleBtn) outlineToggleBtn.classList.toggle('active', open);
+  try { localStorage.setItem(OUTLINE_PANE_CACHE_KEY, String(open)); } catch (_) {}
+  if (editor) editor.layout();
+}
+
+function wireHorizontalResize(handle, pane, cursor, minWidth, maxWidth, direction) {
+  handle.addEventListener('mousedown', (e) => {
+    if (pane.classList.contains('collapsed')) return;
+    e.preventDefault();
+    handle.classList.add('active');
+    document.body.style.cursor = cursor;
+    document.body.style.userSelect = 'none';
+
+    const startX = e.clientX;
+    const startWidth = pane.offsetWidth;
+    let rafId;
+
+    function onMouseMove(ev) {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => {
+        const delta = (ev.clientX - startX) * direction;
+        const newWidth = Math.max(minWidth, Math.min(startWidth + delta, maxWidth));
+        pane.style.width = newWidth + 'px';
+        layoutPlaygroundEditors();
+      });
+    }
+
+    function onMouseUp() {
+      handle.classList.remove('active');
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    }
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  });
+}
+
+function initOutlineFeature() {
+  try {
+    outlinePane = document.getElementById('outlinePane');
+    outlineToggleBtn = document.getElementById('outlineToggleBtn');
+    outlineFilter = document.getElementById('outlineFilter');
+    outlineList = document.getElementById('outlineList');
+
+    let open = true;
+    try {
+      const saved = localStorage.getItem(OUTLINE_PANE_CACHE_KEY);
+      if (saved === 'false') open = false;
+    } catch (_) {}
+    toggleOutlinePane(open);
+
+    if (outlineToggleBtn) outlineToggleBtn.addEventListener('click', () => toggleOutlinePane());
+    if (outlineFilter) outlineFilter.addEventListener('input', renderOutlineNow);
+    const resizeHandle = document.getElementById('outlineResizeHandle');
+    if (resizeHandle && outlinePane) wireHorizontalResize(resizeHandle, outlinePane, 'ew-resize', 160, 420, 1);
+    navigationDisposer = registerNavigation(monaco, () => editor?.getValue() || '');
+  } catch (err) {
+    console.error('Failed to initialize outline:', err);
+  }
+}
+
+// ─── File I/O ────────────────────────────────────────────────────────────────
+
+function setMainEditorContent(source) {
+  if (!editor) return;
+  editor.setValue(source);
+  lastInput = '';
+  runValidation();
+  refreshSchemaFeatures();
+}
+
+function routeLoadedFile(file) {
+  if (!file) return;
+  const kind = file.kind || classifyFile(file.name);
+  if (kind === 'json') {
+    if (!instanceEditor) return;
+    setInstanceKind('json');
+    instanceEditor.setValue(file.text || '');
+    toggleInstancePane(true);
+    toast(`Loaded ${file.name || 'JSON file'} into instance editor`, 'success');
+  } else if (kind === 'cbor') {
+    if (!instanceEditor) return;
+    setInstanceKind('cbor');
+    instanceEditor.setValue(file.text || bytesToHex(file.bytes));
+    toggleInstancePane(true);
+    toast(`Loaded ${file.name || 'CBOR file'} into instance editor`, 'success');
+  } else {
+    setMainEditorContent(file.text || '');
+    toast(`Loaded ${file.name || 'schema file'}`, 'success');
+  }
+}
+
+async function openFile() {
+  const file = await pickFile({ accept: '.cddl,.json,.cbor,application/json,application/cbor' });
+  if (!file) return;
+  routeLoadedFile(file);
+}
+
+function saveSchemaFile() {
+  if (!editor) return;
+  downloadText('schema.cddl', editor.getValue(), 'text/cddl;charset=utf-8');
+  toast('Downloaded schema.cddl', 'success');
+}
+
+function initFileIoFeature() {
+  try {
+    const openBtn = document.getElementById('openFileBtn');
+    const saveBtn = document.getElementById('saveFileBtn');
+    const dropOverlay = document.getElementById('dropOverlay');
+    if (openBtn) openBtn.addEventListener('click', openFile);
+    if (saveBtn) saveBtn.addEventListener('click', saveSchemaFile);
+    if (document.body) attachDropZone(document.body, dropOverlay, routeLoadedFile);
+  } catch (err) {
+    console.error('Failed to initialize file I/O:', err);
+  }
+}
+
+// ─── Share ──────────────────────────────────────────────────────────────────
+
+function currentShareState() {
+  return {
+    cddl: editor?.getValue() || '',
+    instance: instanceEditor?.getValue() || '',
+    kind: instanceKind,
+  };
+}
+
+async function sharePlayground() {
+  const state = currentShareState();
+  if (isTooLargeToShare(state)) {
+    toast('Playground state is too large to share as a URL.', 'warning');
+    return;
+  }
+  const url = buildShareUrl(state);
+  const copied = await copyToClipboard(url);
+  toast(copied ? 'Copied share link' : 'Could not copy share link', copied ? 'success' : 'error');
+}
+
+function initShareFeature() {
+  try {
+    const shareBtn = document.getElementById('shareBtn');
+    if (shareBtn) shareBtn.addEventListener('click', sharePlayground);
+  } catch (err) {
+    console.error('Failed to initialize sharing:', err);
+  }
+}
+
+// ─── Toasts + Shortcuts ──────────────────────────────────────────────────────
+
+function shortcutsModalOpen() {
+  const modal = document.getElementById('shortcutsModal');
+  return Boolean(modal && modal.classList.contains('visible'));
+}
+
+function toggleProblemsPanel() {
+  if (!problemsPanel) return;
+  problemsPanel.classList.toggle('collapsed');
+  if (!problemsPanel.classList.contains('collapsed')) layoutPlaygroundEditors();
+}
+
+function toggleExamplesMenu() {
+  const examplesWrapper = document.getElementById('examplesWrapper');
+  if (examplesWrapper) examplesWrapper.classList.toggle('open');
+}
+
+function initShortcutFeature() {
+  try {
+    shortcutsController = initShortcutsModal({
+      btn: document.getElementById('shortcutsBtn'),
+      modal: document.getElementById('shortcutsModal'),
+      closeBtn: document.getElementById('shortcutsClose'),
+      bodyEl: document.getElementById('shortcutsBody'),
+    });
+  } catch (err) {
+    console.error('Failed to initialize shortcuts:', err);
+  }
+}
+
 // ─── Initialisation ────────────────────────────────────────────────────────────
 
 function boot() {
@@ -1239,16 +1694,27 @@ function boot() {
   problemsEmpty = document.getElementById('problemsEmpty');
   cursorPosition = document.getElementById('cursorPosition');
 
+  try { initToasts(document.getElementById('toastContainer')); } catch (err) { console.error('Failed to initialize toasts:', err); }
+
+  let sharedState = null;
+  try {
+    sharedState = readStateFromLocation();
+    if (sharedState) clearLocationState();
+  } catch (err) {
+    console.error('Failed to read shared state:', err);
+  }
+
   // Ref-check toggle
   const refCheckTrack = document.getElementById('refCheckTrack');
   try {
     checkRefs = localStorage.getItem(REFS_CACHE_KEY) === 'true';
   } catch (_) {}
-  if (checkRefs) refCheckTrack.classList.add('active');
+  if (checkRefs && refCheckTrack) refCheckTrack.classList.add('active');
 
-  document.getElementById('refCheckToggle').addEventListener('click', () => {
+  const refCheckToggle = document.getElementById('refCheckToggle');
+  if (refCheckToggle) refCheckToggle.addEventListener('click', () => {
     checkRefs = !checkRefs;
-    refCheckTrack.classList.toggle('active', checkRefs);
+    if (refCheckTrack) refCheckTrack.classList.toggle('active', checkRefs);
     try { localStorage.setItem(REFS_CACHE_KEY, checkRefs); } catch (_) {}
     if (editor) { lastInput = ''; runValidation(); }
   });
@@ -1258,11 +1724,12 @@ function boot() {
   try {
     formatOnSave = localStorage.getItem(FORMAT_CACHE_KEY) === 'true';
   } catch (_) {}
-  if (formatOnSave) formatTrack.classList.add('active');
+  if (formatOnSave && formatTrack) formatTrack.classList.add('active');
 
-  document.getElementById('formatToggle').addEventListener('click', () => {
+  const formatToggle = document.getElementById('formatToggle');
+  if (formatToggle) formatToggle.addEventListener('click', () => {
     formatOnSave = !formatOnSave;
-    formatTrack.classList.toggle('active', formatOnSave);
+    if (formatTrack) formatTrack.classList.toggle('active', formatOnSave);
     try { localStorage.setItem(FORMAT_CACHE_KEY, formatOnSave); } catch (_) {}
   });
 
@@ -1287,20 +1754,20 @@ function boot() {
           lastInput = '';
           runValidation();
         }
-        examplesWrapper.classList.remove('open');
+        if (examplesWrapper) examplesWrapper.classList.remove('open');
       });
       ddFrag.appendChild(item);
     }
   }
-  examplesDropdown.appendChild(ddFrag);
+  if (examplesDropdown) examplesDropdown.appendChild(ddFrag);
 
-  examplesBtn.addEventListener('click', (e) => {
+  if (examplesBtn && examplesWrapper) examplesBtn.addEventListener('click', (e) => {
     e.stopPropagation();
     examplesWrapper.classList.toggle('open');
   });
 
   document.addEventListener('click', (e) => {
-    if (!examplesWrapper.contains(e.target)) {
+    if (examplesWrapper && !examplesWrapper.contains(e.target)) {
       examplesWrapper.classList.remove('open');
     }
   });
@@ -1312,7 +1779,8 @@ function boot() {
   } catch (_) {}
   if (!isDark) document.body.classList.add('light');
 
-  document.getElementById('themeToggle').addEventListener('click', () => {
+  const themeToggle = document.getElementById('themeToggle');
+  if (themeToggle) themeToggle.addEventListener('click', () => {
     isDark = !isDark;
     document.body.classList.toggle('light', !isDark);
     if (editor) {
@@ -1326,7 +1794,7 @@ function boot() {
 
   // Create editor
   editor = monaco.editor.create(container, {
-    value: loadContent(),
+    value: typeof sharedState?.cddl === 'string' ? sharedState.cddl : loadContent(),
     language: 'cddl',
     theme: isDark ? 'cddl-dark' : 'cddl-light',
     fontSize: 14,
@@ -1354,17 +1822,56 @@ function boot() {
   // Expose globally for convenience
   window.editor = editor;
 
+  initInstanceFeature(sharedState);
+  initOutlineFeature();
+  initFileIoFeature();
+  initShareFeature();
+  initShortcutFeature();
+  refreshSchemaFeatures();
+  if (sharedState) toast('Loaded shared playground', 'success');
+
   // Cursor position in status bar
   editor.onDidChangeCursorPosition((e) => {
-    cursorPosition.textContent = `Ln ${e.position.lineNumber}, Col ${e.position.column}`;
+    if (cursorPosition) cursorPosition.textContent = `Ln ${e.position.lineNumber}, Col ${e.position.column}`;
   });
 
-  // Intercept Ctrl/Cmd+S globally — always prevent browser save,
-  // and format when the option is enabled.
+  // Intercept playground shortcuts globally. Keep Mod+S single-handled here.
   window.addEventListener('keydown', (e) => {
-    if ((e.ctrlKey || e.metaKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === 's') {
+    const key = e.key.toLowerCase();
+    const mod = e.ctrlKey || e.metaKey;
+
+    if (mod && !e.shiftKey && !e.altKey && key === 's') {
       e.preventDefault();
       if (formatOnSave) applyFormat();
+      return;
+    }
+
+    if (shortcutsModalOpen()) return;
+
+    if (mod && !e.shiftKey && !e.altKey && key === 'enter') {
+      e.preventDefault();
+      validateCurrentInstance();
+    } else if (mod && !e.shiftKey && !e.altKey && key === 'k') {
+      e.preventDefault();
+      toggleExamplesMenu();
+    } else if (mod && !e.shiftKey && !e.altKey && key === 'o') {
+      e.preventDefault();
+      openFile();
+    } else if (mod && e.shiftKey && !e.altKey && key === 's') {
+      e.preventDefault();
+      saveSchemaFile();
+    } else if (mod && e.shiftKey && !e.altKey && key === 'c') {
+      e.preventDefault();
+      sharePlayground();
+    } else if (mod && !e.shiftKey && !e.altKey && key === 'b') {
+      e.preventDefault();
+      toggleOutlinePane();
+    } else if (mod && !e.shiftKey && !e.altKey && key === 'i') {
+      e.preventDefault();
+      toggleInstancePane();
+    } else if (mod && !e.shiftKey && !e.altKey && key === 'j') {
+      e.preventDefault();
+      toggleProblemsPanel();
     }
   });
 
@@ -1372,19 +1879,15 @@ function boot() {
   editor.onDidChangeModelContent(scheduleValidation);
 
   // Problems panel toggle
-  document.getElementById('problemsHeader').addEventListener('click', () => {
-    problemsPanel.classList.toggle('collapsed');
-    if (!problemsPanel.classList.contains('collapsed')) {
-      editor.layout();
-    }
-  });
+  const problemsHeader = document.getElementById('problemsHeader');
+  if (problemsHeader) problemsHeader.addEventListener('click', toggleProblemsPanel);
 
   // Problems panel resize
   const resizeHandle = document.getElementById('resizeHandle');
   let resizing = false;
 
-  resizeHandle.addEventListener('mousedown', (e) => {
-    if (problemsPanel.classList.contains('collapsed')) return;
+  if (resizeHandle) resizeHandle.addEventListener('mousedown', (e) => {
+    if (problemsPanel && problemsPanel.classList.contains('collapsed')) return;
     e.preventDefault();
     resizing = true;
     resizeHandle.classList.add('active');
@@ -1392,7 +1895,7 @@ function boot() {
     document.body.style.userSelect = 'none';
 
     const startY = e.clientY;
-    const startHeight = problemsPanel.offsetHeight;
+    const startHeight = problemsPanel ? problemsPanel.offsetHeight : 0;
 
     let rafId;
     function onMouseMove(ev) {
@@ -1400,8 +1903,8 @@ function boot() {
       rafId = requestAnimationFrame(() => {
         const delta = startY - ev.clientY;
         const newHeight = Math.max(33, Math.min(startHeight + delta, window.innerHeight * 0.7));
-        problemsPanel.style.height = newHeight + 'px';
-        editor.layout();
+        if (problemsPanel) problemsPanel.style.height = newHeight + 'px';
+        layoutPlaygroundEditors();
       });
     }
 
@@ -1422,20 +1925,21 @@ function boot() {
   let resizeRaf;
   window.addEventListener('resize', () => {
     cancelAnimationFrame(resizeRaf);
-    resizeRaf = requestAnimationFrame(() => editor.layout());
+    resizeRaf = requestAnimationFrame(layoutPlaygroundEditors);
   });
 
   // Initial layout + focus so keyboard shortcuts work immediately
-  editor.layout();
+  layoutPlaygroundEditors();
   editor.focus();
 
   // Init WASM then validate
   initWasm().then((ok) => {
     if (ok) {
+      setInstanceKind(instanceKind);
       runValidation();
     } else {
-      statusPill.className = 'status-pill invalid';
-      statusText.textContent = 'WASM failed';
+      if (statusPill) statusPill.className = 'status-pill invalid';
+      if (statusText) statusText.textContent = 'WASM failed';
     }
   });
 }
@@ -1448,3 +1952,4 @@ if (document.readyState === 'loading') {
 
 // Expose jump helper globally (used by inline onclick)
 window.jumpToError = jumpTo;
+window.editor = editor;

--- a/www/index.js
+++ b/www/index.js
@@ -1529,7 +1529,7 @@ function wireHorizontalResize(handle, pane, cursor, minWidth, maxWidth, directio
       rafId = requestAnimationFrame(() => {
         const delta = (ev.clientX - startX) * direction;
         const newWidth = Math.max(minWidth, Math.min(startWidth + delta, maxWidth));
-        pane.style.width = newWidth + 'px';
+        pane.style.flexBasis = newWidth + 'px';
         layoutPlaygroundEditors();
       });
     }

--- a/www/index.js
+++ b/www/index.js
@@ -1294,8 +1294,14 @@ function layoutPlaygroundEditors() {
 
 function setInstanceKind(kind) {
   instanceKind = kind === 'cbor' ? 'cbor' : 'json';
-  if (instanceTabJson) instanceTabJson.classList.toggle('active', instanceKind === 'json');
-  if (instanceTabCbor) instanceTabCbor.classList.toggle('active', instanceKind === 'cbor');
+  if (instanceTabJson) {
+    instanceTabJson.classList.toggle('active', instanceKind === 'json');
+    instanceTabJson.setAttribute('aria-selected', String(instanceKind === 'json'));
+  }
+  if (instanceTabCbor) {
+    instanceTabCbor.classList.toggle('active', instanceKind === 'cbor');
+    instanceTabCbor.setAttribute('aria-selected', String(instanceKind === 'cbor'));
+  }
   if (instanceCborHint) {
     instanceCborHint.hidden = instanceKind !== 'cbor';
     instanceCborHint.style.display = instanceKind === 'cbor' ? '' : 'none';

--- a/www/index.js
+++ b/www/index.js
@@ -1405,6 +1405,12 @@ function generateCurrentSample() {
         'warning',
         7000,
       );
+    } else if (result.constraintsSatisfied === false) {
+      toast(
+        'Some control operator constraints could not be applied — the generated sample is a shape reference and may not validate. Adjust the highlighted values manually.',
+        'warning',
+        7000,
+      );
     } else {
       toast('Generated sample instance', 'success');
     }

--- a/www/src/file-io.js
+++ b/www/src/file-io.js
@@ -1,0 +1,294 @@
+/**
+ * @typedef {{ name: string, text: string|null, bytes: Uint8Array|null, kind: 'cddl'|'json'|'cbor'|'unknown' }} LoadedFile
+ */
+
+// ─── Classification ──────────────────────────────────────────────────────────
+
+/** Classify a filename into a kind. */
+export function classifyFile(name) {
+  const lowerName = String(name || '').toLowerCase();
+
+  if (lowerName.endsWith('.cddl')) {
+    return 'cddl';
+  }
+  if (lowerName.endsWith('.json')) {
+    return 'json';
+  }
+  if (lowerName.endsWith('.cbor')) {
+    return 'cbor';
+  }
+
+  return 'unknown';
+}
+
+/** Convert bytes to a lowercase hex string (used to show a dropped .cbor file in the editor). */
+export function bytesToHex(bytes) {
+  return Array.from(bytes || [], (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+// ─── Reading ─────────────────────────────────────────────────────────────────
+
+function shouldReadBinary(file, binary) {
+  if (typeof binary === 'boolean') {
+    return binary;
+  }
+
+  return classifyFile(file.name) === 'cbor';
+}
+
+/**
+ * Read a File into the LoadedFile shape. FileReader errors resolve to null
+ * instead of rejecting so callers can show one consistent user-facing message.
+ * @param {File} file
+ * @param {boolean|undefined} binary
+ * @returns {Promise<LoadedFile|null>}
+ */
+function readLoadedFile(file, binary) {
+  const kind = classifyFile(file.name);
+  const readBinary = shouldReadBinary(file, binary);
+
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+
+    reader.onerror = () => resolve(null);
+    reader.onabort = () => resolve(null);
+    reader.onload = () => {
+      if (readBinary) {
+        const bytes = new Uint8Array(reader.result || new ArrayBuffer(0));
+        resolve({
+          name: file.name,
+          text: bytesToHex(bytes),
+          bytes,
+          kind,
+        });
+        return;
+      }
+
+      resolve({
+        name: file.name,
+        text: String(reader.result || ''),
+        bytes: null,
+        kind,
+      });
+    };
+
+    try {
+      if (readBinary) {
+        reader.readAsArrayBuffer(file);
+      } else {
+        reader.readAsText(file);
+      }
+    } catch (err) {
+      console.error('Failed to read file:', err);
+      resolve(null);
+    }
+  });
+}
+
+// ─── Picker ──────────────────────────────────────────────────────────────────
+
+/**
+ * Open the native file picker. Resolves null if the user cancels. FileReader
+ * errors also resolve null instead of rejecting so callers can show a toast.
+ * @param {{ accept?: string, binary?: boolean }} [opts]
+ * @returns {Promise<LoadedFile|null>}
+ */
+export function pickFile(opts = {}) {
+  return new Promise((resolve) => {
+    if (typeof document === 'undefined' || typeof window === 'undefined') {
+      resolve(null);
+      return;
+    }
+
+    const input = document.createElement('input');
+    let settled = false;
+
+    input.type = 'file';
+    if (opts.accept) {
+      input.accept = opts.accept;
+    }
+
+    const cleanup = () => {
+      input.removeEventListener('change', onChange);
+      input.removeEventListener('cancel', onCancel);
+      window.removeEventListener('focus', onWindowFocus);
+      input.remove();
+    };
+
+    const settle = (value) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+
+    const readAndSettle = async (file) => {
+      settle(await readLoadedFile(file, opts.binary));
+    };
+
+    function onChange() {
+      const file = input.files && input.files[0];
+      if (!file) {
+        settle(null);
+        return;
+      }
+
+      readAndSettle(file);
+    }
+
+    function onCancel() {
+      settle(null);
+    }
+
+    function onWindowFocus() {
+      setTimeout(() => {
+        if (!settled && (!input.files || input.files.length === 0)) {
+          settle(null);
+        }
+      }, 0);
+    }
+
+    input.addEventListener('change', onChange);
+    input.addEventListener('cancel', onCancel);
+    window.addEventListener('focus', onWindowFocus);
+
+    try {
+      input.click();
+    } catch (err) {
+      console.error('Failed to open file picker:', err);
+      settle(null);
+    }
+  });
+}
+
+// ─── Downloads ───────────────────────────────────────────────────────────────
+
+function sanitizeFilename(filename) {
+  const safeName = String(filename || 'download').replace(/[\\/\x00-\x1f\x7f]/g, '').trim();
+  return safeName || 'download';
+}
+
+function downloadBlob(filename, blob) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+
+  link.href = url;
+  link.download = sanitizeFilename(filename);
+  link.click();
+
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+/** Trigger a download of text content. */
+export function downloadText(filename, text, mimeType = 'text/plain;charset=utf-8') {
+  downloadBlob(filename, new Blob([String(text ?? '')], { type: mimeType }));
+}
+
+/** Trigger a download of binary content. */
+export function downloadBytes(filename, bytes, mimeType = 'application/octet-stream') {
+  downloadBlob(filename, new Blob([bytes || new Uint8Array(0)], { type: mimeType }));
+}
+
+// ─── Drag And Drop ───────────────────────────────────────────────────────────
+
+function dragHasFiles(event) {
+  const types = event.dataTransfer && event.dataTransfer.types;
+  return !!types && Array.from(types).includes('Files');
+}
+
+function showOverlay(overlayEl) {
+  if (overlayEl) {
+    overlayEl.classList.add('visible');
+  }
+}
+
+function hideOverlay(overlayEl) {
+  if (overlayEl) {
+    overlayEl.classList.remove('visible');
+  }
+}
+
+/**
+ * Wire drag-and-drop on an element.
+ * @param {HTMLElement} target        element to listen on (usually document.body)
+ * @param {HTMLElement|null} overlayEl element to show/hide via the 'visible' class during a drag
+ * @param {(file: LoadedFile) => void} onFile  called once per dropped file
+ * @returns {() => void} a teardown function that removes all listeners
+ */
+export function attachDropZone(target, overlayEl, onFile) {
+  let depth = 0;
+
+  const reset = () => {
+    depth = 0;
+    hideOverlay(overlayEl);
+  };
+
+  const onDragEnter = (event) => {
+    if (!dragHasFiles(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    depth += 1;
+    showOverlay(overlayEl);
+  };
+
+  const onDragOver = (event) => {
+    if (!dragHasFiles(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'copy';
+    }
+  };
+
+  const onDragLeave = (event) => {
+    if (!dragHasFiles(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    depth = Math.max(0, depth - 1);
+    if (depth === 0) {
+      hideOverlay(overlayEl);
+    }
+  };
+
+  const onDrop = (event) => {
+    if (!dragHasFiles(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    reset();
+
+    const files = Array.from((event.dataTransfer && event.dataTransfer.files) || []);
+    for (const file of files) {
+      readLoadedFile(file).then((loadedFile) => {
+        if (loadedFile) {
+          onFile(loadedFile);
+        }
+      });
+    }
+  };
+
+  target.addEventListener('dragenter', onDragEnter);
+  target.addEventListener('dragover', onDragOver);
+  target.addEventListener('dragleave', onDragLeave);
+  target.addEventListener('drop', onDrop);
+  target.addEventListener('dragend', reset);
+
+  return () => {
+    target.removeEventListener('dragenter', onDragEnter);
+    target.removeEventListener('dragover', onDragOver);
+    target.removeEventListener('dragleave', onDragLeave);
+    target.removeEventListener('drop', onDrop);
+    target.removeEventListener('dragend', reset);
+    reset();
+  };
+}

--- a/www/src/instance-validation.js
+++ b/www/src/instance-validation.js
@@ -73,6 +73,71 @@ export function isCborSupported(wasmModule) {
   return typeof wasmModule?.validate_cbor_from_slice === 'function';
 }
 
+const SYNTHETIC_ROOT_RULE = '__cddl_playground_root';
+const RULE_START = /^[ \t]*([A-Za-z@_$][\w@\-.$]*)[ \t]*(<[^>\n]*>)?[ \t]*(\/\/=|\/=|=)[ \t]*(.*)$/;
+
+/**
+ * Rewrite `cddl` so the validators use `rootRule` as the root rule.
+ * The WASM validators always validate against the first non-generic type rule,
+ * so a synthetic alias to the selected rule is prepended when it is not already
+ * the root.
+ * @returns {{ cddl: string, error: string|null }}
+ */
+export function applyRootRule(cddl, rootRule) {
+  const source = String(cddl ?? '');
+  const name = String(rootRule ?? '').trim();
+  if (!name) return { cddl: source, error: null };
+
+  const rules = scanRules(source);
+  const definitions = rules.filter((rule) => rule.name === name);
+  if (definitions.length === 0) return { cddl: source, error: null };
+
+  const firstTypeRule = rules.find((rule) => rule.isRootable);
+  if (firstTypeRule && firstTypeRule.name === name) return { cddl: source, error: null };
+
+  if (!definitions.some((rule) => rule.isRootable)) {
+    return {
+      cddl: source,
+      error: `"${name}" is a group or generic rule and cannot be used as a validation root. Select a non-generic type rule.`,
+    };
+  }
+
+  return { cddl: `${SYNTHETIC_ROOT_RULE} = ${name}\n\n${source}`, error: null };
+}
+
+function scanRules(source) {
+  const rules = [];
+  for (const rawLine of source.split(/\r?\n/)) {
+    const line = stripComment(rawLine);
+    const match = RULE_START.exec(line);
+    if (!match) continue;
+
+    const [, name, generics, assign, rhs] = match;
+    rules.push({
+      name,
+      // Only plain `=` assignments of a non-generic, non-group rule can be a root.
+      isRootable: assign === '=' && !generics && !rhs.trimStart().startsWith('('),
+    });
+  }
+  return rules;
+}
+
+function stripComment(line) {
+  let inString = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (inString) {
+      if (ch === '\\') i += 1;
+      else if (ch === '"') inString = false;
+    } else if (ch === '"') {
+      inString = true;
+    } else if (ch === ';') {
+      return line.slice(0, i);
+    }
+  }
+  return line;
+}
+
 /**
  * Validate an instance document against a CDDL schema.
  * @param {object} opts
@@ -80,6 +145,7 @@ export function isCborSupported(wasmModule) {
  * @param {string} opts.cddl        the schema source
  * @param {'json'|'cbor'} opts.kind
  * @param {string} opts.text        JSON text, or hex/base64 CBOR
+ * @param {string} [opts.rootRule]  rule to validate against; defaults to the schema's first type rule
  * @returns {{ ok: boolean, title: string, detail: string, failures: string[], kind: string }}
  */
 export function validateInstance(opts) {
@@ -120,7 +186,12 @@ export function validateInstance(opts) {
       instance = parsed.bytes;
     }
 
-    invokeValidator(validate, cddl, instance);
+    const rooted = applyRootRule(cddl, opts?.rootRule);
+    if (rooted.error) {
+      return failure('Unsupported root rule', rooted.error, [rooted.error], kind);
+    }
+
+    invokeValidator(validate, rooted.cddl, instance);
     return { ok: true, title: 'Instance is valid', detail: '', failures: [], kind };
   } catch (err) {
     return normaliseValidationFailure(err, opts?.kind === 'cbor' ? 'cbor' : 'json');

--- a/www/src/instance-validation.js
+++ b/www/src/instance-validation.js
@@ -226,6 +226,11 @@ function normaliseValidationFailure(err, kind) {
   }
 
   const detail = (err instanceof Error ? err.message : String(err)).trimEnd();
+
+  if (kind === 'cbor' && isCborDecodeError(detail)) {
+    return failure('Invalid CBOR input', detail, [detail], kind);
+  }
+
   const failures = splitFailures(detail).map(formatConstraintFailure);
   const count = failures.length || 1;
   const plural = count === 1 ? '' : 's';
@@ -234,6 +239,14 @@ function normaliseValidationFailure(err, kind) {
 
 function isParserErrorLike(err) {
   return Boolean(err && typeof err === 'object' && err.position && err.msg);
+}
+
+// Decoding failures surfaced by the WASM CBOR decoder, which are reported
+// before any schema constraint is evaluated.
+const CBOR_DECODE_ERROR = /^(syntax error at offset\b|unexpected end of input\b|unexpected break\b|i\/o error:)/i;
+
+function isCborDecodeError(detail) {
+  return CBOR_DECODE_ERROR.test(String(detail ?? '').trim());
 }
 
 function formatParserError(err) {

--- a/www/src/instance-validation.js
+++ b/www/src/instance-validation.js
@@ -1,0 +1,206 @@
+// ─── CBOR Input Parsing ──────────────────────────────────────────────────────
+
+/**
+ * Parse a user-supplied CBOR string into bytes.
+ * Accepts: hex (with or without 0x prefix, whitespace/newlines tolerated,
+ * optional colon or space separators) OR base64. Auto-detects which.
+ * @returns {{ bytes: Uint8Array|null, error: string|null, encoding: 'hex'|'base64'|null }}
+ */
+export function parseCborInput(text) {
+  const input = String(text ?? '').trim();
+  if (!input) {
+    return { bytes: null, error: 'CBOR input is empty.', encoding: null };
+  }
+
+  const withoutHexPrefixes = input.replace(/(^|[\s:])0x/gi, '$1');
+  const hexCandidate = withoutHexPrefixes.replace(/[\s:]/g, '');
+  if (hexCandidate && /^[0-9a-fA-F]+$/.test(hexCandidate)) {
+    if (hexCandidate.length % 2 !== 0) {
+      return { bytes: null, error: 'Hex CBOR input must contain an even number of digits.', encoding: 'hex' };
+    }
+
+    const bytes = new Uint8Array(hexCandidate.length / 2);
+    for (let i = 0; i < hexCandidate.length; i += 2) {
+      bytes[i / 2] = parseInt(hexCandidate.slice(i, i + 2), 16);
+    }
+    return { bytes, error: null, encoding: 'hex' };
+  }
+
+  const base64Candidate = input.replace(/\s/g, '');
+  const base64Result = parseBase64(base64Candidate);
+  if (base64Result) {
+    return { bytes: base64Result, error: null, encoding: 'base64' };
+  }
+
+  return {
+    bytes: null,
+    error: 'CBOR input must be hex bytes or base64-encoded CBOR.',
+    encoding: null,
+  };
+}
+
+function parseBase64(input) {
+  if (!input || input.length % 4 === 1 || !/^[A-Za-z0-9+/]*={0,2}$/.test(input)) {
+    return null;
+  }
+
+  const firstPad = input.indexOf('=');
+  if (firstPad !== -1 && !/^=+$/.test(input.slice(firstPad))) {
+    return null;
+  }
+
+  const padded = input.padEnd(input.length + (4 - input.length % 4) % 4, '=');
+  try {
+    const binary = typeof globalThis.atob === 'function'
+      ? globalThis.atob(padded)
+      : globalThis.Buffer.from(padded, 'base64').toString('binary');
+    if (!binary) return null;
+
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  } catch (_) {
+    return null;
+  }
+}
+
+// ─── Instance Validation ─────────────────────────────────────────────────────
+
+/** @returns {boolean} whether CBOR validation is available in this build */
+export function isCborSupported(wasmModule) {
+  return typeof wasmModule?.validate_cbor_from_slice === 'function';
+}
+
+/**
+ * Validate an instance document against a CDDL schema.
+ * @param {object} opts
+ * @param {object} opts.wasmModule  the initialised wasm namespace object
+ * @param {string} opts.cddl        the schema source
+ * @param {'json'|'cbor'} opts.kind
+ * @param {string} opts.text        JSON text, or hex/base64 CBOR
+ * @returns {{ ok: boolean, title: string, detail: string, failures: string[], kind: string }}
+ */
+export function validateInstance(opts) {
+  try {
+    const wasmModule = opts?.wasmModule;
+    const cddl = String(opts?.cddl ?? '');
+    const kind = opts?.kind === 'cbor' ? 'cbor' : 'json';
+    const text = String(opts?.text ?? '');
+
+    if (!cddl.trim()) {
+      return failure('Schema is empty', 'Enter a CDDL schema before validating an instance.', [], kind);
+    }
+
+    if (!text.trim()) {
+      return failure('Nothing to validate', 'Enter a JSON or CBOR instance to validate.', [], kind);
+    }
+
+    const fnName = kind === 'cbor' ? 'validate_cbor_from_slice' : 'validate_json_from_str';
+    const validate = wasmModule?.[fnName];
+    if (typeof validate !== 'function') {
+      const detail = kind === 'cbor'
+        ? 'CBOR validation is not available in this WASM build.'
+        : 'The WASM module is not loaded or does not expose JSON validation.';
+      return failure('WASM module not ready', detail, [detail], kind);
+    }
+
+    let instance = text;
+    if (kind === 'json') {
+      const jsonError = validateJsonText(text);
+      if (jsonError) {
+        return failure(`Invalid JSON: ${jsonError}`, jsonError, [jsonError], kind);
+      }
+    } else {
+      const parsed = parseCborInput(text);
+      if (parsed.error) {
+        return failure('Invalid CBOR input', parsed.error, [parsed.error], kind);
+      }
+      instance = parsed.bytes;
+    }
+
+    invokeValidator(validate, cddl, instance);
+    return { ok: true, title: 'Instance is valid', detail: '', failures: [], kind };
+  } catch (err) {
+    return normaliseValidationFailure(err, opts?.kind === 'cbor' ? 'cbor' : 'json');
+  }
+}
+
+function invokeValidator(validate, cddl, instance) {
+  try {
+    return validate(cddl, instance, undefined);
+  } catch (err) {
+    if (err instanceof TypeError) {
+      return validate(cddl, instance);
+    }
+    throw err;
+  }
+}
+
+function validateJsonText(text) {
+  try {
+    JSON.parse(text);
+    return null;
+  } catch (err) {
+    return err?.message || String(err);
+  }
+}
+
+function normaliseValidationFailure(err, kind) {
+  if (Array.isArray(err) && err.length && err.every(isParserErrorLike)) {
+    const failures = err.map(formatParserError);
+    const detail = err.map(formatParserDetail).join('\n\n');
+    return failure('Schema failed to parse', detail, failures, kind);
+  }
+
+  const detail = (err instanceof Error ? err.message : String(err)).trimEnd();
+  const failures = splitFailures(detail).map(formatConstraintFailure);
+  const count = failures.length || 1;
+  const plural = count === 1 ? '' : 's';
+  return failure(`Instance does not conform (${count} error${plural})`, detail, failures, kind);
+}
+
+function isParserErrorLike(err) {
+  return Boolean(err && typeof err === 'object' && err.position && err.msg);
+}
+
+function formatParserError(err) {
+  const line = err.position?.line ?? 1;
+  const column = err.position?.column ?? 1;
+  const message = err.msg?.short || err.msg?.extended || 'Unknown parser error';
+  return `Ln ${line}, Col ${column}: ${message}`;
+}
+
+function formatParserDetail(err) {
+  const line = err.position?.line ?? 1;
+  const column = err.position?.column ?? 1;
+  const message = err.msg?.extended || err.msg?.short || 'Unknown parser error';
+  return `Ln ${line}, Col ${column}: ${message}`;
+}
+
+function formatConstraintFailure(line) {
+  return line
+    .replace(/^error validating at JSON location\s+/i, '')
+    .replace(/^error validating at the root of the JSON document:\s*/i, 'root of JSON document: ')
+    .replace(/^error validating at\s+/i, '');
+}
+
+function splitFailures(detail) {
+  const failures = String(detail ?? '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const fallback = String(detail ?? '').trim() || 'Unknown validation error';
+  return failures.length ? failures : [fallback];
+}
+
+function failure(title, detail, failures, kind) {
+  return {
+    ok: false,
+    title,
+    detail,
+    failures: failures.length ? failures : splitFailures(detail),
+    kind,
+  };
+}

--- a/www/src/outline.js
+++ b/www/src/outline.js
@@ -1,0 +1,378 @@
+/**
+ * @typedef {{ name: string, line: number, column: number, kind: 'type'|'group'|'socket'|'extension',
+ *             generic: string|null, preview: string, comment: string|null }} CddlRule
+ */
+
+const IDENT_RE = /[A-Za-z0-9_.@$-]/;
+const IDENT_START_RE = /[A-Za-z_@$]/;
+const _escapeMap = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+const _escapeRe = /[&<>"']/g;
+
+function escapeHtml(str) {
+  return String(str).replace(_escapeRe, (ch) => _escapeMap[ch]);
+}
+
+function isIdentChar(ch) {
+  return IDENT_RE.test(ch);
+}
+
+function isIdentStart(ch) {
+  return IDENT_START_RE.test(ch);
+}
+
+function lineStarts(source) {
+  const starts = [0];
+  for (let i = 0; i < source.length; i++) {
+    if (source[i] === '\n') starts.push(i + 1);
+  }
+  return starts;
+}
+
+function positionFromIndex(starts, index) {
+  let lo = 0;
+  let hi = starts.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (starts[mid] <= index) lo = mid + 1;
+    else hi = mid - 1;
+  }
+  return { line: hi + 1, column: index - starts[hi] + 1 };
+}
+
+function stripLineComment(line) {
+  let quote = null;
+  let escaped = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (ch === '\\' && quote === '"') escaped = true;
+      else if (ch === quote) quote = null;
+    } else if (ch === '"' || ch === "'") {
+      quote = ch;
+    } else if (ch === ';') {
+      return line.slice(0, i);
+    }
+  }
+  return line;
+}
+
+function isCommentOnly(line) {
+  return line.trimStart().startsWith(';');
+}
+
+function leadingComment(lines, ruleLineIndex) {
+  const parts = [];
+  for (let i = ruleLineIndex - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (!isCommentOnly(line)) break;
+    parts.unshift(line.trimStart().slice(1).trim());
+  }
+  return parts.length ? parts.join(' ') : null;
+}
+
+function skipSpacesAndComments(source, index) {
+  let i = index;
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === ' ' || ch === '\t' || ch === '\r' || ch === '\n') {
+      i++;
+    } else if (ch === ';') {
+      while (i < source.length && source[i] !== '\n') i++;
+    } else {
+      break;
+    }
+  }
+  return i;
+}
+
+function readGeneric(source, index) {
+  if (source[index] !== '<') return { generic: null, end: index };
+  let i = index;
+  let depth = 0;
+  let quote = null;
+  let escaped = false;
+  while (i < source.length) {
+    const ch = source[i];
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (ch === '\\' && quote === '"') escaped = true;
+      else if (ch === quote) quote = null;
+    } else if (ch === '"' || ch === "'") {
+      quote = ch;
+    } else if (ch === ';') {
+      while (i < source.length && source[i] !== '\n') i++;
+      continue;
+    } else if (ch === '<') {
+      depth++;
+    } else if (ch === '>') {
+      depth--;
+      if (depth === 0) return { generic: source.slice(index, i + 1), end: i + 1 };
+    }
+    i++;
+  }
+  return { generic: null, end: index };
+}
+
+function readAssignment(source, index) {
+  if (source.startsWith('//=', index)) return { op: '//=', end: index + 3 };
+  if (source.startsWith('/=', index)) return { op: '/=', end: index + 2 };
+  if (
+    source[index] === '=' &&
+    source[index + 1] !== '>' &&
+    source[index + 1] !== '=' &&
+    source[index - 1] !== '!' &&
+    source[index - 1] !== '/'
+  ) {
+    return { op: '=', end: index + 1 };
+  }
+  return null;
+}
+
+function endOfRule(source, index) {
+  let i = index;
+  let depth = 0;
+  let quote = null;
+  let escaped = false;
+  while (i < source.length) {
+    const ch = source[i];
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (ch === '\\' && quote === '"') escaped = true;
+      else if (ch === quote) quote = null;
+    } else if (ch === '"' || ch === "'") {
+      quote = ch;
+    } else if (ch === ';') {
+      while (i < source.length && source[i] !== '\n') i++;
+      continue;
+    } else if (ch === '{' || ch === '[' || ch === '(') {
+      depth++;
+    } else if (ch === '}' || ch === ']' || ch === ')') {
+      depth = Math.max(0, depth - 1);
+    } else if (ch === '\n' && depth === 0) {
+      let j = i + 1;
+      while (j < source.length && (source[j] === ' ' || source[j] === '\t' || source[j] === '\r')) j++;
+      if (j >= source.length || source[j] === '\n' || source[j] === ';') return i;
+      if (isIdentStart(source[j]) || source[j] === '$') {
+        const nameStart = j;
+        while (j < source.length && isIdentChar(source[j])) j++;
+        const generic = readGeneric(source, j);
+        j = skipSpacesAndComments(source, generic.end);
+        if (readAssignment(source, j)) return i;
+      }
+    }
+    i++;
+  }
+  return source.length;
+}
+
+function makePreview(source, start, end) {
+  const text = source
+    .slice(start, end)
+    .split('\n')
+    .map(stripLineComment)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return text.length > 60 ? `${text.slice(0, 59)}…` : text;
+}
+
+function firstSignificant(source, index) {
+  const i = skipSpacesAndComments(source, index);
+  return source[i] || '';
+}
+
+/** Parse all top-level rule definitions from CDDL source. 1-based line/column. */
+export function parseRules(source) {
+  const text = String(source || '');
+  const starts = lineStarts(text);
+  const lines = text.split(/\r?\n/);
+  const rules = [];
+  let depth = 0;
+  let quote = null;
+  let escaped = false;
+  let atLineStart = true;
+  let lineHasOnlySpace = true;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (ch === '\\' && quote === '"') escaped = true;
+      else if (ch === quote) quote = null;
+      if (ch === '\n') {
+        atLineStart = true;
+        lineHasOnlySpace = true;
+      }
+      continue;
+    }
+
+    if (ch === ';') {
+      while (i < text.length && text[i] !== '\n') i++;
+      atLineStart = true;
+      lineHasOnlySpace = true;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      lineHasOnlySpace = false;
+      continue;
+    }
+    if (ch === '\n') {
+      atLineStart = true;
+      lineHasOnlySpace = true;
+      continue;
+    }
+    if (atLineStart && (ch === ' ' || ch === '\t' || ch === '\r')) continue;
+
+    if (depth === 0 && atLineStart && lineHasOnlySpace && (isIdentStart(ch) || ch === '$')) {
+      const nameStart = i;
+      let j = i;
+      while (j < text.length && isIdentChar(text[j])) j++;
+      const name = text.slice(nameStart, j);
+      const generic = readGeneric(text, j);
+      j = skipSpacesAndComments(text, generic.end);
+      const assignment = readAssignment(text, j);
+      if (assignment) {
+        const rhsStart = skipSpacesAndComments(text, assignment.end);
+        const rhsEnd = endOfRule(text, rhsStart);
+        const pos = positionFromIndex(starts, nameStart);
+        const kind = name.startsWith('$')
+          ? 'socket'
+          : assignment.op !== '='
+            ? 'extension'
+            : firstSignificant(text, rhsStart) === '('
+              ? 'group'
+              : 'type';
+        rules.push({
+          name,
+          line: pos.line,
+          column: pos.column,
+          kind,
+          generic: generic.generic,
+          preview: makePreview(text, rhsStart, rhsEnd),
+          comment: leadingComment(lines, pos.line - 1),
+        });
+        i = Math.max(i, rhsEnd - 1);
+        atLineStart = false;
+        lineHasOnlySpace = false;
+        continue;
+      }
+    }
+
+    if (ch === '{' || ch === '[' || ch === '(') depth++;
+    else if (ch === '}' || ch === ']' || ch === ')') depth = Math.max(0, depth - 1);
+    atLineStart = false;
+    lineHasOnlySpace = false;
+  }
+  return rules;
+}
+
+/** Find the rule defining `name`, or null. */
+export function findRule(source, name) {
+  return parseRules(source).find((rule) => rule.name === name) || null;
+}
+
+/**
+ * Render the outline list into a container.
+ * @param {HTMLElement} listEl
+ * @param {CddlRule[]} rules
+ * @param {{ filter?: string, onSelect?: (rule: CddlRule) => void, activeName?: string }} [opts]
+ */
+export function renderOutline(listEl, rules, opts = {}) {
+  const filter = (opts.filter || '').toLowerCase();
+  const visible = filter ? rules.filter((rule) => rule.name.toLowerCase().includes(filter)) : rules;
+  const frag = document.createDocumentFragment();
+  listEl.textContent = '';
+
+  if (!visible.length) {
+    const empty = document.createElement('div');
+    empty.className = 'outline-empty';
+    empty.textContent = 'No matching rules';
+    frag.appendChild(empty);
+    listEl.appendChild(frag);
+    return;
+  }
+
+  for (const rule of visible) {
+    const item = document.createElement('div');
+    item.className = `outline-item${opts.activeName === rule.name ? ' active' : ''}`;
+    item.dataset.line = String(rule.line);
+    item.dataset.column = String(rule.column);
+    item.innerHTML = `
+      <span class="outline-item-kind">${escapeHtml(rule.kind)}</span>
+      <span class="outline-item-name">${escapeHtml(rule.name)}${escapeHtml(rule.generic || '')}</span>
+      <span class="outline-item-preview">${escapeHtml(rule.preview)}</span>
+    `;
+    item.addEventListener('click', () => {
+      if (opts.onSelect) opts.onSelect(rule);
+    });
+    frag.appendChild(item);
+  }
+  listEl.appendChild(frag);
+}
+
+function cddlWordAt(model, position) {
+  const line = model.getLineContent(position.lineNumber);
+  let start = position.column - 1;
+  let end = position.column - 1;
+  while (start > 0 && isIdentChar(line[start - 1])) start--;
+  while (end < line.length && isIdentChar(line[end])) end++;
+  const word = line.slice(start, end);
+  return word ? { word, startColumn: start + 1, endColumn: end + 1 } : model.getWordAtPosition(position);
+}
+
+function definitionLine(source, rule) {
+  return (source.split(/\r?\n/)[rule.line - 1] || '').trimEnd();
+}
+
+/**
+ * Register go-to-definition + hover providers for the 'cddl' language.
+ * @param {object} monaco the monaco namespace
+ * @param {() => string} getSource
+ * @returns {() => void} disposer that disposes both providers
+ */
+export function registerNavigation(monaco, getSource) {
+  const definitionProvider = monaco.languages.registerDefinitionProvider('cddl', {
+    provideDefinition(model, position) {
+      const word = cddlWordAt(model, position);
+      if (!word || !word.word) return null;
+      const rule = findRule(getSource(), word.word);
+      if (!rule) return null;
+      return {
+        uri: model.uri,
+        range: {
+          startLineNumber: rule.line,
+          startColumn: rule.column,
+          endLineNumber: rule.line,
+          endColumn: rule.column + rule.name.length,
+        },
+      };
+    },
+  });
+  const hoverProvider = monaco.languages.registerHoverProvider('cddl', {
+    provideHover(model, position) {
+      const word = cddlWordAt(model, position);
+      if (!word || !word.word) return null;
+      const source = getSource();
+      const rule = findRule(source, word.word);
+      if (!rule) return null;
+      const contents = [];
+      if (rule.comment) contents.push({ value: rule.comment });
+      contents.push({ value: `\`\`\`cddl\n${definitionLine(source, rule)}\n\`\`\`` });
+      return {
+        range: {
+          startLineNumber: position.lineNumber,
+          startColumn: word.startColumn,
+          endLineNumber: position.lineNumber,
+          endColumn: word.endColumn,
+        },
+        contents,
+      };
+    },
+  });
+  return () => {
+    definitionProvider.dispose();
+    hoverProvider.dispose();
+  };
+}

--- a/www/src/outline.js
+++ b/www/src/outline.js
@@ -294,21 +294,67 @@ export function renderOutline(listEl, rules, opts = {}) {
     return;
   }
 
-  for (const rule of visible) {
+  const items = [];
+  const activeIndex = visible.findIndex((rule) => rule.name === opts.activeName);
+  const tabbableIndex = activeIndex >= 0 ? activeIndex : 0;
+
+  const focusItem = (index) => {
+    const next = items[index];
+    if (!next) return;
+    for (const item of items) item.tabIndex = -1;
+    next.tabIndex = 0;
+    next.focus();
+  };
+
+  visible.forEach((rule, index) => {
     const item = document.createElement('div');
-    item.className = `outline-item${opts.activeName === rule.name ? ' active' : ''}`;
+    const isActive = opts.activeName === rule.name;
+    item.className = `outline-item${isActive ? ' active' : ''}`;
     item.dataset.line = String(rule.line);
     item.dataset.column = String(rule.column);
+    item.setAttribute('role', 'treeitem');
+    item.setAttribute('aria-level', '1');
+    item.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    item.tabIndex = index === tabbableIndex ? 0 : -1;
     item.innerHTML = `
       <span class="outline-item-kind ${escapeHtml(rule.kind)}">${escapeHtml(rule.kind)}</span>
       <span class="outline-item-name">${escapeHtml(rule.name)}${escapeHtml(rule.generic || '')}</span>
       <span class="outline-item-preview">${escapeHtml(rule.preview)}</span>
     `;
-    item.addEventListener('click', () => {
+    const select = () => {
       if (opts.onSelect) opts.onSelect(rule);
+    };
+    item.addEventListener('click', select);
+    item.addEventListener('keydown', (event) => {
+      switch (event.key) {
+        case 'Enter':
+        case ' ':
+          event.preventDefault();
+          select();
+          break;
+        case 'ArrowDown':
+          event.preventDefault();
+          focusItem(Math.min(index + 1, items.length - 1));
+          break;
+        case 'ArrowUp':
+          event.preventDefault();
+          focusItem(Math.max(index - 1, 0));
+          break;
+        case 'Home':
+          event.preventDefault();
+          focusItem(0);
+          break;
+        case 'End':
+          event.preventDefault();
+          focusItem(items.length - 1);
+          break;
+        default:
+          break;
+      }
     });
+    items.push(item);
     frag.appendChild(item);
-  }
+  });
   listEl.appendChild(frag);
 }
 

--- a/www/src/outline.js
+++ b/www/src/outline.js
@@ -300,7 +300,7 @@ export function renderOutline(listEl, rules, opts = {}) {
     item.dataset.line = String(rule.line);
     item.dataset.column = String(rule.column);
     item.innerHTML = `
-      <span class="outline-item-kind">${escapeHtml(rule.kind)}</span>
+      <span class="outline-item-kind ${escapeHtml(rule.kind)}">${escapeHtml(rule.kind)}</span>
       <span class="outline-item-name">${escapeHtml(rule.name)}${escapeHtml(rule.generic || '')}</span>
       <span class="outline-item-preview">${escapeHtml(rule.preview)}</span>
     `;

--- a/www/src/sample-gen.js
+++ b/www/src/sample-gen.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {{ json: string|null, warnings: string[], error: string|null, jsonRepresentable: boolean }} SampleResult
+ * @typedef {{ json: string|null, warnings: string[], error: string|null, jsonRepresentable: boolean, constraintsSatisfied: boolean }} SampleResult
  */
 
 const MAX_DEPTH = 32;
@@ -48,25 +48,40 @@ export function generateSample(source, rootRuleName) {
   try {
     const model = parseSource(source || '');
     if (model.order.length === 0) {
-      return { json: null, warnings: [], error: 'No rules found in schema', jsonRepresentable: false };
+      return { json: null, warnings: [], error: 'No rules found in schema', jsonRepresentable: false, constraintsSatisfied: false };
     }
 
     const roots = listRootCandidates(source);
     const root = rootRuleName || roots[0] || model.order[0];
     if (!root || !model.rules.has(root)) {
       warnings.push(`Unknown root rule "${root}"; emitted null.`);
-      return { json: JSON.stringify(null, null, 2), warnings, error: null, jsonRepresentable: true };
+      return { json: JSON.stringify(null, null, 2), warnings, error: null, jsonRepresentable: true, constraintsSatisfied: true };
     }
 
-    const ctx = { model, warnings, budget: MAX_NODES, jsonRepresentable: true, nonRepReasons: new Set() };
+    const ctx = {
+      model,
+      warnings,
+      budget: MAX_NODES,
+      jsonRepresentable: true,
+      nonRepReasons: new Set(),
+      constraintsSatisfied: true,
+      unappliedControls: new Set(),
+    };
     const value = generateRef(root, [], null, ctx, 0, new Set(), new Map());
-    return { json: JSON.stringify(value, null, 2), warnings, error: null, jsonRepresentable: ctx.jsonRepresentable };
+    return {
+      json: JSON.stringify(value, null, 2),
+      warnings,
+      error: null,
+      jsonRepresentable: ctx.jsonRepresentable,
+      constraintsSatisfied: ctx.constraintsSatisfied,
+    };
   } catch (err) {
     return {
       json: null,
       warnings,
       error: err && err.message ? err.message : String(err),
       jsonRepresentable: false,
+      constraintsSatisfied: false,
     };
   }
 }
@@ -561,10 +576,7 @@ function generateNode(node, key, ctx, depth, visiting, env, label) {
       if (option !== node.options[0]) ctx.warnings.push('Skipped an earlier choice alternative with a prelude-name map key that does not validate as a JSON object key.');
       return generateNode(option, key, ctx, depth + 1, visiting, env, label);
     }
-    case 'control':
-      if (node.op === '.default') return generateNode(node.controller, key, ctx, depth + 1, visiting, env, label);
-      ctx.warnings.push(`Control operator ${node.op} was not applied; generated from the base type.`);
-      return generateNode(node.base, key, ctx, depth + 1, visiting, env, label);
+    case 'control': return generateControl(node, key, ctx, depth, visiting, env, label);
     case 'tag':
       markNotJsonRepresentable(ctx, 'CBOR tags');
       ctx.warnings.push(`CBOR tag ${node.tag || ''} was dropped for JSON output.`.trim());
@@ -581,6 +593,87 @@ function generateNode(node, key, ctx, depth, visiting, env, label) {
     default:
       ctx.warnings.push(`Unsupported construct "${node.name || node.kind}"; emitted null.`);
       return null;
+  }
+}
+
+function generateControl(node, key, ctx, depth, visiting, env, label) {
+  const base = () => generateNode(node.base, key, ctx, depth + 1, visiting, env, label);
+  const controller = () => generateNode(node.controller, key, ctx, depth + 1, visiting, env, label);
+
+  switch (node.op) {
+    case '.default':
+    case '.eq':
+      return controller();
+    case '.within':
+      return base();
+    case '.size': {
+      const size = controlNumber(node.controller);
+      const value = base();
+      if (size == null || size < 0) return markControlUnapplied(ctx, node.op, value);
+      if (typeof value === 'string') return sizedString(value, size);
+      if (typeof value === 'number') return Number.isInteger(value) ? sizedInteger(value, size) : value;
+      return markControlUnapplied(ctx, node.op, value);
+    }
+    case '.lt':
+    case '.le':
+    case '.gt':
+    case '.ge': {
+      const limit = controlNumber(node.controller);
+      const value = base();
+      if (limit == null || typeof value !== 'number') return markControlUnapplied(ctx, node.op, value);
+      return boundedNumber(value, limit, node.op);
+    }
+    case '.ne': {
+      const value = base();
+      const excluded = controller();
+      if (value !== excluded) return value;
+      if (typeof value === 'number') return value + 1;
+      if (typeof value === 'string') return `${value}x`;
+      if (typeof value === 'boolean') return !value;
+      return markControlUnapplied(ctx, node.op, value);
+    }
+    default:
+      return markControlUnapplied(ctx, node.op, base());
+  }
+}
+
+function markControlUnapplied(ctx, op, value) {
+  ctx.constraintsSatisfied = false;
+  if (!ctx.unappliedControls.has(op)) {
+    ctx.unappliedControls.add(op);
+    ctx.warnings.push(`Control operator ${op} could not be applied; the generated value may not validate.`);
+  }
+  return value;
+}
+
+/** Numeric controller value, or null when it is not a plain number or numeric range. */
+function controlNumber(node) {
+  if (!node) return null;
+  if (node.kind === 'literal' && typeof node.value === 'number') return node.value;
+  if (node.kind === 'range') return controlNumber(node.lower);
+  return null;
+}
+
+function sizedString(value, size) {
+  if (value.length === size) return value;
+  if (value.length > size) return value.slice(0, size);
+  return value.padEnd(size, 'x');
+}
+
+/** Largest-fitting placeholder for `n .size b`, where b counts bytes of the encoded integer. */
+function sizedInteger(value, size) {
+  if (size === 0) return 0;
+  const max = 2 ** (Math.min(size, 6) * 8) - 1;
+  if (value >= 0) return value <= max ? value : max;
+  return value >= -max - 1 ? value : -max - 1;
+}
+
+function boundedNumber(value, limit, op) {
+  switch (op) {
+    case '.lt': return value < limit ? value : limit - 1;
+    case '.le': return value <= limit ? value : limit;
+    case '.gt': return value > limit ? value : limit + 1;
+    default: return value >= limit ? value : limit;
   }
 }
 

--- a/www/src/sample-gen.js
+++ b/www/src/sample-gen.js
@@ -1,0 +1,774 @@
+/**
+ * @typedef {{ json: string|null, warnings: string[], error: string|null, jsonRepresentable: boolean }} SampleResult
+ */
+
+const MAX_DEPTH = 32;
+const MAX_NODES = 5000;
+const BUILTINS = new Set([
+  'any', 'uint', 'nint', 'int', 'integer', 'unsigned', 'number', 'float', 'float16',
+  'float32', 'float64', 'float16-32', 'float32-64', 'bool', 'true', 'false', 'nil',
+  'null', 'tstr', 'text', 'uri', 'tdate', 'time', 'bstr', 'bytes', 'biguint',
+  'bignint', 'bigint', 'decfrac', 'bigfloat', 'eb64url', 'eb64legacy', 'eb16',
+  'encoded-cbor', 'b64url', 'b64legacy', 'regexp', 'mime-message', 'cbor-any',
+  'undefined',
+]);
+
+/** Rule names that are plausible entry points, best first. */
+export function listRootCandidates(source) {
+  try {
+    const model = parseSource(source || '');
+    if (model.order.length === 0) return [];
+
+    const candidates = model.order.filter((name) => !name.startsWith('$'));
+    const firstConcrete = candidates.find((name) => model.rules.get(name)?.params.length === 0);
+    const referenced = collectReferences(model);
+    const roots = candidates.filter((name) => !referenced.has(name));
+    const ranked = firstConcrete ? [firstConcrete] : [];
+
+    for (const name of roots) {
+      if (!ranked.includes(name)) ranked.push(name);
+    }
+    for (const name of candidates) {
+      if (!ranked.includes(name)) ranked.push(name);
+    }
+
+    return ranked;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Generate a sample JSON instance for `rootRuleName` (or the best candidate when omitted).
+ * @returns {SampleResult} json is pretty-printed with 2-space indent, or null on error.
+ */
+export function generateSample(source, rootRuleName) {
+  const warnings = [];
+
+  try {
+    const model = parseSource(source || '');
+    if (model.order.length === 0) {
+      return { json: null, warnings: [], error: 'No rules found in schema', jsonRepresentable: false };
+    }
+
+    const roots = listRootCandidates(source);
+    const root = rootRuleName || roots[0] || model.order[0];
+    if (!root || !model.rules.has(root)) {
+      warnings.push(`Unknown root rule "${root}"; emitted null.`);
+      return { json: JSON.stringify(null, null, 2), warnings, error: null, jsonRepresentable: true };
+    }
+
+    const ctx = { model, warnings, budget: MAX_NODES, jsonRepresentable: true, nonRepReasons: new Set() };
+    const value = generateRef(root, [], null, ctx, 0, new Set(), new Map());
+    return { json: JSON.stringify(value, null, 2), warnings, error: null, jsonRepresentable: ctx.jsonRepresentable };
+  } catch (err) {
+    return {
+      json: null,
+      warnings,
+      error: err && err.message ? err.message : String(err),
+      jsonRepresentable: false,
+    };
+  }
+}
+
+function parseSource(source) {
+  const tokens = tokenize(source);
+  const rules = new Map();
+  const order = [];
+  let pos = 0;
+
+  while (pos < tokens.length) {
+    const start = findNextRuleStart(tokens, pos);
+    if (start < 0) break;
+
+    const assign = findRuleAssign(tokens, start);
+    if (assign < 0) break;
+
+    const name = tokens[start].value;
+    const params = parseParams(tokens.slice(start + 1, assign));
+    const next = findNextRuleStart(tokens, assign + 1);
+    const rhsTokens = tokens.slice(assign + 1, next < 0 ? tokens.length : next);
+    const node = parseExpression(rhsTokens);
+    const op = tokens[assign].value;
+
+    if (!rules.has(name)) {
+      const initialNode = op === '//='
+        ? { kind: 'groupMerge', options: [node], label: name }
+        : op === '/='
+          ? { kind: 'choice', options: [node], label: name }
+          : node;
+      rules.set(name, { name, params, node: initialNode, choices: op === '=' ? [] : [node] });
+      order.push(name);
+      pos = next < 0 ? tokens.length : next;
+      continue;
+    }
+
+    const rule = rules.get(name);
+    if (op === '=') {
+      rule.params = params;
+      rule.node = node;
+      rule.choices = [];
+    } else if (op === '//=') {
+      rule.choices.push(node);
+      rule.node = rule.node.kind === 'groupMerge'
+        ? { ...rule.node, options: [...rule.node.options, node] }
+        : { kind: 'groupMerge', options: [rule.node, node], label: name };
+    } else {
+      rule.choices.push(node);
+      rule.node = rule.node.kind === 'choice'
+        ? { ...rule.node, options: [...rule.node.options, node] }
+        : { kind: 'choice', options: [rule.node, node], label: name };
+    }
+
+    pos = next < 0 ? tokens.length : next;
+  }
+
+  return { rules, order };
+}
+
+function tokenize(source) {
+  const tokens = [];
+  let i = 0;
+
+  while (i < source.length) {
+    const ch = source[i];
+
+    if (/\s/.test(ch)) { i++; continue; }
+    if (ch === ';') {
+      while (i < source.length && source[i] !== '\n') i++;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      const result = readQuoted(source, i, ch);
+      tokens.push(result.token);
+      i = result.next;
+      continue;
+    }
+
+    if ((source.startsWith("h'", i) || source.startsWith("b64'", i)) && /[hb]/.test(ch)) {
+      const prefix = source.startsWith("b64'", i) ? 'b64' : 'h';
+      const result = readQuoted(source, i + prefix.length, "'");
+      tokens.push({ type: 'bytes', value: source.slice(i, result.next), raw: source.slice(i, result.next) });
+      i = result.next;
+      continue;
+    }
+
+    const three = source.slice(i, i + 3);
+    const two = source.slice(i, i + 2);
+    if (['//=', '...', '=>'].includes(three)) {
+      tokens.push({ type: 'op', value: three, raw: three });
+      i += 3;
+      continue;
+    }
+    if (['/=', '=>', '..', '//'].includes(two)) {
+      tokens.push({ type: 'op', value: two, raw: two });
+      i += 2;
+      continue;
+    }
+
+    if (ch === '.' && /[A-Za-z]/.test(source[i + 1] || '')) {
+      let j = i + 1;
+      while (j < source.length && /[A-Za-z0-9_-]/.test(source[j])) j++;
+      tokens.push({ type: 'control', value: source.slice(i, j), raw: source.slice(i, j) });
+      i = j;
+      continue;
+    }
+
+    if (isNumberStart(source, i)) {
+      const match = source.slice(i).match(/^-?(?:0x[0-9a-fA-F]+(?:\.[0-9a-fA-F]+)?p[+-]?\d+|0x[0-9a-fA-F]+|0b[01]+|(?:[1-9]\d*|0)(?:\.\d+)?(?:[eE][+-]?\d+)?)/);
+      if (match) {
+        tokens.push({ type: 'number', value: match[0], raw: match[0] });
+        i += match[0].length;
+        continue;
+      }
+    }
+
+    if (isIdentStart(ch) || ch === '$') {
+      let j = i;
+      if (source.startsWith('$$', i)) j += 2;
+      else if (source[j] === '$') j++;
+      while (j < source.length && /[A-Za-z0-9_@$.\-]/.test(source[j])) j++;
+      tokens.push({ type: 'id', value: source.slice(i, j), raw: source.slice(i, j) });
+      i = j;
+      continue;
+    }
+
+    if ('={}[](),:<>/?*+~&#^'.includes(ch)) {
+      tokens.push({ type: 'op', value: ch, raw: ch });
+      i++;
+      continue;
+    }
+
+    i++;
+  }
+
+  return tokens;
+}
+
+function readQuoted(source, start, quote) {
+  let i = start + 1;
+  while (i < source.length) {
+    if (source[i] === '\\') { i += 2; continue; }
+    if (source[i] === quote) { i++; break; }
+    i++;
+  }
+  const raw = source.slice(start, i);
+  return { token: { type: quote === '"' ? 'string' : 'bytes', value: raw, raw }, next: i };
+}
+
+function isNumberStart(source, i) {
+  return /\d/.test(source[i]) || (source[i] === '-' && /\d/.test(source[i + 1] || ''));
+}
+
+function isIdentStart(ch) {
+  return /[A-Za-z_@]/.test(ch);
+}
+
+function findNextRuleStart(tokens, from) {
+  for (let i = from; i < tokens.length; i++) {
+    if (tokens[i].type === 'id' && findRuleAssign(tokens, i) >= 0) return i;
+  }
+  return -1;
+}
+
+function findRuleAssign(tokens, start) {
+  if (!tokens[start] || tokens[start].type !== 'id') return -1;
+  let i = start + 1;
+  if (tokens[i]?.value === '<') i = skipBalanced(tokens, i, '<', '>') + 1;
+  return ['=', '/=', '//='].includes(tokens[i]?.value) ? i : -1;
+}
+
+function skipBalanced(tokens, start, open, close) {
+  let depth = 0;
+  for (let i = start; i < tokens.length; i++) {
+    if (tokens[i].value === open) depth++;
+    else if (tokens[i].value === close && --depth === 0) return i;
+  }
+  return start;
+}
+
+function parseParams(tokens) {
+  const params = [];
+  if (tokens[0]?.value !== '<') return params;
+  for (const token of tokens) {
+    if (token.type === 'id') params.push(token.value);
+  }
+  return params;
+}
+
+function parseExpression(tokens) {
+  const trimmed = trimTokens(tokens);
+  if (trimmed.length === 0) return { kind: 'unknown', name: 'empty expression' };
+
+  const choiceParts = splitTopLevel(trimmed, '/');
+  if (choiceParts.length > 1) {
+    return { kind: 'choice', options: choiceParts.map(parseExpression), label: describeTokens(trimmed) };
+  }
+
+  const rangeIndex = findTopLevelOp(trimmed, ['..', '...']);
+  if (rangeIndex >= 0) {
+    return {
+      kind: 'range',
+      inclusive: trimmed[rangeIndex].value === '..',
+      lower: parseExpression(trimmed.slice(0, rangeIndex)),
+      upper: parseExpression(trimmed.slice(rangeIndex + 1)),
+    };
+  }
+
+  const controlIndex = findTopLevelControl(trimmed);
+  if (controlIndex >= 0) {
+    return {
+      kind: 'control',
+      op: trimmed[controlIndex].value,
+      base: parseExpression(trimmed.slice(0, controlIndex)),
+      controller: parseExpression(trimmed.slice(controlIndex + 1)),
+    };
+  }
+
+  if (isWrapped(trimmed, '(', ')')) {
+    const inner = trimmed.slice(1, -1);
+    if (findTopLevelOp(inner, [':', '=>']) >= 0) return { kind: 'map', entries: parseGroup(inner) };
+    return parseExpression(inner);
+  }
+  if (isWrapped(trimmed, '{', '}')) return { kind: 'map', entries: parseGroup(trimmed.slice(1, -1)) };
+  if (isWrapped(trimmed, '[', ']')) return { kind: 'array', entries: parseGroup(trimmed.slice(1, -1)) };
+
+  if (trimmed[0]?.value === '~') {
+    const ref = parseReference(trimmed.slice(1));
+    return { kind: 'unwrap', ref };
+  }
+
+  if (trimmed[0]?.value === '&') {
+    if (isWrapped(trimmed.slice(1), '(', ')')) {
+      return { kind: 'enum', entries: parseGroup(trimmed.slice(2, -1)) };
+    }
+    return { kind: 'enumRef', ref: parseReference(trimmed.slice(1)) };
+  }
+
+  if (trimmed[0]?.value === '#') {
+    const paren = trimmed.findIndex((token) => token.value === '(');
+    if (paren >= 0 && trimmed[trimmed.length - 1]?.value === ')') {
+      return { kind: 'tag', inner: parseExpression(trimmed.slice(paren + 1, -1)), tag: describeTokens(trimmed.slice(0, paren)) };
+    }
+    return { kind: 'tag', inner: { kind: 'ref', name: 'any', args: [] }, tag: describeTokens(trimmed) };
+  }
+
+  if (trimmed.length === 1) return parseAtom(trimmed[0]);
+  return parseReference(trimmed);
+}
+
+function trimTokens(tokens) {
+  return tokens.filter(Boolean);
+}
+
+function splitTopLevel(tokens, op) {
+  const parts = [];
+  let start = 0;
+  let depth = 0;
+  for (let i = 0; i < tokens.length; i++) {
+    const value = tokens[i].value;
+    if (['{', '[', '(', '<'].includes(value)) depth++;
+    else if (['}', ']', ')', '>'].includes(value)) depth--;
+    else if (depth === 0 && value === op) {
+      parts.push(tokens.slice(start, i));
+      start = i + 1;
+    }
+  }
+  if (parts.length > 0) parts.push(tokens.slice(start));
+  return parts.length > 0 ? parts : [tokens];
+}
+
+function findTopLevelOp(tokens, ops) {
+  let depth = 0;
+  for (let i = 0; i < tokens.length; i++) {
+    const value = tokens[i].value;
+    if (['{', '[', '(', '<'].includes(value)) depth++;
+    else if (['}', ']', ')', '>'].includes(value)) depth--;
+    else if (depth === 0 && ops.includes(value)) return i;
+  }
+  return -1;
+}
+
+function findTopLevelControl(tokens) {
+  let depth = 0;
+  for (let i = 0; i < tokens.length; i++) {
+    const value = tokens[i].value;
+    if (['{', '[', '(', '<'].includes(value)) depth++;
+    else if (['}', ']', ')', '>'].includes(value)) depth--;
+    else if (depth === 0 && tokens[i].type === 'control') return i;
+  }
+  return -1;
+}
+
+function isWrapped(tokens, open, close) {
+  return tokens[0]?.value === open && matchingCloseIndex(tokens, 0) === tokens.length - 1 && tokens.at(-1)?.value === close;
+}
+
+function matchingCloseIndex(tokens, start) {
+  const pairs = { '{': '}', '[': ']', '(': ')', '<': '>' };
+  const open = tokens[start]?.value;
+  const close = pairs[open];
+  let depth = 0;
+  for (let i = start; i < tokens.length; i++) {
+    if (tokens[i].value === open) depth++;
+    else if (tokens[i].value === close && --depth === 0) return i;
+  }
+  return -1;
+}
+
+function parseGroup(tokens) {
+  const choices = splitTopLevel(tokens, '//');
+  if (choices.length > 1) {
+    return [{ kind: 'groupChoice', options: choices.map(parseGroup) }];
+  }
+
+  return splitTopLevel(tokens, ',')
+    .flatMap(splitImplicitGroupEntries)
+    .map((entry) => parseGroupEntry(entry))
+    .filter(Boolean);
+}
+
+function splitImplicitGroupEntries(tokens) {
+  tokens = trimTokens(tokens);
+  if (tokens.length < 2 || findTopLevelOp(tokens, [':', '=>']) >= 0) return [tokens];
+  if (tokens[0].type === 'number' && tokens[1]?.value !== '*' && tokens[1]?.value !== '..' && tokens[1]?.value !== '...') {
+    return [tokens.slice(0, 1), ...splitImplicitGroupEntries(tokens.slice(1))];
+  }
+  return [tokens];
+}
+
+function parseGroupEntry(tokens) {
+  tokens = trimTokens(tokens);
+  if (tokens.length === 0) return null;
+
+  let occurrence = { min: 1, count: 1, optional: false, raw: '' };
+  const occ = readOccurrence(tokens);
+  if (occ) {
+    occurrence = occ.occurrence;
+    tokens = tokens.slice(occ.consumed);
+  }
+
+  if (isWrapped(tokens, '(', ')')) {
+    return { kind: 'group', occurrence, entries: parseGroup(tokens.slice(1, -1)) };
+  }
+
+  const opIndex = findTopLevelOp(tokens, [':', '=>']);
+  if (opIndex > 0) {
+    return {
+      kind: 'member',
+      occurrence,
+      key: parseKey(tokens.slice(0, opIndex)),
+      value: parseExpression(tokens.slice(opIndex + 1)),
+      arrow: tokens[opIndex].value === '=>',
+    };
+  }
+
+  return { kind: 'element', occurrence, value: parseExpression(tokens) };
+}
+
+function readOccurrence(tokens) {
+  const first = tokens[0];
+  if (!first) return null;
+  if (first.value === '?') return { consumed: 1, occurrence: { min: 0, count: 1, optional: true, raw: '?' } };
+  if (first.value === '*') return { consumed: 1, occurrence: { min: 0, count: 1, optional: false, raw: '*' } };
+  if (first.value === '+') return { consumed: 1, occurrence: { min: 1, count: 1, optional: false, raw: '+' } };
+
+  if (first.type === 'number' && tokens[1]?.value === '*' && tokens[2]?.type === 'number') {
+    return {
+      consumed: 3,
+      occurrence: { min: numberFromToken(first), count: Math.max(1, numberFromToken(first)), optional: false, raw: `${first.raw}*${tokens[2].raw}` },
+    };
+  }
+
+  if (first.type === 'number' && tokens[1]?.value === '*') {
+    return {
+      consumed: 2,
+      occurrence: { min: numberFromToken(first), count: Math.max(1, numberFromToken(first)), optional: false, raw: `${first.raw}*` },
+    };
+  }
+
+  if (first.value === '*' && tokens[1]?.type === 'number') {
+    return {
+      consumed: 2,
+      occurrence: { min: 0, count: 1, optional: false, raw: `*${tokens[1].raw}` },
+    };
+  }
+
+  return null;
+}
+
+function parseKey(tokens) {
+  tokens = trimTokens(tokens).filter((token) => token.value !== '^');
+  if (tokens.length === 1) {
+    const token = tokens[0];
+    if (token.type === 'string') return { kind: 'literal', value: parseStringToken(token), raw: token.raw };
+    if (token.type === 'number') return { kind: 'literal', value: numberFromToken(token), raw: token.raw };
+    if (token.type === 'id') return { kind: 'name', name: token.value };
+  }
+  return { kind: 'computed', node: parseExpression(tokens), text: describeTokens(tokens) };
+}
+
+function parseAtom(token) {
+  if (token.type === 'string') return { kind: 'literal', value: parseStringToken(token), raw: token.raw };
+  if (token.type === 'bytes') return { kind: 'bytesLiteral', raw: token.raw };
+  if (token.type === 'number') return { kind: 'literal', value: numberFromToken(token), raw: token.raw };
+  if (token.type === 'id') {
+    if (token.value === 'true') return { kind: 'literal', value: true, raw: 'true' };
+    if (token.value === 'false') return { kind: 'literal', value: false, raw: 'false' };
+    if (token.value === 'null' || token.value === 'nil') return { kind: 'literal', value: null, raw: token.value };
+    return { kind: 'ref', name: token.value, args: [] };
+  }
+  return { kind: 'unknown', name: token.raw };
+}
+
+function parseReference(tokens) {
+  tokens = trimTokens(tokens);
+  const name = tokens[0]?.type === 'id' ? tokens[0].value : describeTokens(tokens);
+  const args = [];
+  const angle = tokens.findIndex((token) => token.value === '<');
+  if (angle >= 0 && tokens.at(-1)?.value === '>') {
+    for (const part of splitTopLevel(tokens.slice(angle + 1, -1), ',')) {
+      args.push(parseExpression(part));
+    }
+  }
+  return { kind: 'ref', name, args };
+}
+
+function parseStringToken(token) {
+  try { return JSON.parse(token.raw); } catch { return token.raw.slice(1, -1); }
+}
+
+function numberFromToken(token) {
+  const raw = token.raw || token.value;
+  if (/^-?0x/i.test(raw)) return parseInt(raw, 16);
+  if (/^-?0b/i.test(raw)) return parseInt(raw.replace(/^-/i, '').slice(2), 2) * (raw.startsWith('-') ? -1 : 1);
+  const number = Number(raw);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function generateRef(name, args, key, ctx, depth, visiting, env) {
+  if (env.has(name)) return generateNode(env.get(name), key, ctx, depth + 1, visiting, env, name);
+  if (BUILTINS.has(name)) return generateBuiltin(name, key, ctx);
+  if (depth > MAX_DEPTH) {
+    ctx.warnings.push(`Recursion depth exceeded while resolving "${name}"; emitted null.`);
+    return null;
+  }
+  if (visiting.has(name)) {
+    ctx.warnings.push(`Cycle detected while resolving "${name}"; emitted null.`);
+    return null;
+  }
+
+  const rule = ctx.model.rules.get(name);
+  if (!rule) {
+    ctx.warnings.push(`Unknown rule "${name}"; emitted null.`);
+    return null;
+  }
+
+  const nextEnv = new Map(env);
+  rule.params.forEach((param, index) => {
+    if (args[index]) nextEnv.set(param, args[index]);
+  });
+
+  const nextVisiting = new Set(visiting);
+  nextVisiting.add(name);
+  return generateNode(rule.node, key, ctx, depth + 1, nextVisiting, nextEnv, name);
+}
+
+function generateNode(node, key, ctx, depth, visiting, env, label) {
+  if (!node) return null;
+  if (--ctx.budget < 0) {
+    ctx.warnings.push('Sample generation node budget exhausted; emitted null.');
+    return null;
+  }
+  if (depth > MAX_DEPTH) {
+    ctx.warnings.push(`Recursion depth exceeded${label ? ` at "${label}"` : ''}; emitted null.`);
+    return null;
+  }
+
+  switch (node.kind) {
+    case 'literal': return node.value;
+    case 'bytesLiteral':
+      markNotJsonRepresentable(ctx, 'byte strings');
+      ctx.warnings.push(`Byte string literal ${node.raw} represented as a JSON string.`);
+      return 'AQID';
+    case 'ref': return generateRef(node.name, node.args, key, ctx, depth, visiting, env);
+    case 'unwrap': return generateNode(node.ref, key, ctx, depth + 1, visiting, env, label);
+    case 'range': return generateNode(node.lower, key, ctx, depth + 1, visiting, env, label);
+    case 'choice': {
+      const option = chooseOption(node.options, ctx.model, env);
+      ctx.warnings.push(`Using ${option === node.options[0] ? 'first' : 'a later'} alternative of choice${node.label ? ` "${node.label}"` : ''}.`);
+      if (option !== node.options[0]) ctx.warnings.push('Skipped an earlier choice alternative with a prelude-name map key that does not validate as a JSON object key.');
+      return generateNode(option, key, ctx, depth + 1, visiting, env, label);
+    }
+    case 'control':
+      if (node.op === '.default') return generateNode(node.controller, key, ctx, depth + 1, visiting, env, label);
+      ctx.warnings.push(`Control operator ${node.op} was not applied; generated from the base type.`);
+      return generateNode(node.base, key, ctx, depth + 1, visiting, env, label);
+    case 'tag':
+      markNotJsonRepresentable(ctx, 'CBOR tags');
+      ctx.warnings.push(`CBOR tag ${node.tag || ''} was dropped for JSON output.`.trim());
+      return generateNode(node.inner, key, ctx, depth + 1, visiting, env, label);
+    case 'map': return generateMap(node.entries, ctx, depth + 1, visiting, env);
+    case 'array': return generateArray(node.entries, ctx, depth + 1, visiting, env);
+    case 'enum': return generateEnum(node.entries, ctx, depth + 1, visiting, env);
+    case 'groupMerge': return generateGroupMerge(node.options, ctx, depth + 1, visiting, env);
+    case 'enumRef': {
+      const value = generateNode(node.ref, key, ctx, depth + 1, visiting, env, label);
+      return value && typeof value === 'object' && !Array.isArray(value) ? Object.values(value)[0] ?? null : value;
+    }
+    case 'unknown':
+    default:
+      ctx.warnings.push(`Unsupported construct "${node.name || node.kind}"; emitted null.`);
+      return null;
+  }
+}
+
+function generateBuiltin(name, key, ctx) {
+  if (['text', 'tstr', 'uri', 'tdate', 'time', 'regexp', 'mime-message'].includes(name)) {
+    return stringForKey(key || name);
+  }
+  if (['uint', 'unsigned', 'biguint'].includes(name)) return 1;
+  if (['nint', 'bignint'].includes(name)) return -1;
+  if (['int', 'integer', 'bigint', 'number'].includes(name)) return 0;
+  if (['float', 'float16', 'float32', 'float64', 'float16-32', 'float32-64', 'decfrac', 'bigfloat'].includes(name)) return 1.5;
+  if (['bool', 'true', 'false'].includes(name)) return true;
+  if (['null', 'nil', 'undefined'].includes(name)) return null;
+  if (['bytes', 'bstr', 'eb64url', 'eb64legacy', 'eb16', 'encoded-cbor', 'b64url', 'b64legacy'].includes(name)) {
+    markNotJsonRepresentable(ctx, 'byte strings');
+    ctx.warnings.push(`JSON cannot represent CBOR byte strings natively; ${name} emitted as a base64-like string.`);
+    return 'AQID';
+  }
+  if (['any', 'cbor-any'].includes(name)) {
+    ctx.warnings.push(`${name} cannot be inferred; emitted a placeholder string.`);
+    return 'any';
+  }
+  ctx.warnings.push(`Unsupported prelude type "${name}"; emitted null.`);
+  return null;
+}
+
+function chooseOption(options, model, env) {
+  return options.find((option) => !hasPreludeNameKey(option, model, env, new Set())) || options[0];
+}
+
+function hasPreludeNameKey(node, model, env, seen) {
+  if (!node) return false;
+  if (node.kind === 'ref') {
+    if (env?.has(node.name)) return hasPreludeNameKey(env.get(node.name), model, env, seen);
+    if (seen.has(node.name)) return false;
+    seen.add(node.name);
+    const rule = model?.rules.get(node.name);
+    return rule ? hasPreludeNameKey(rule.node, model, env, seen) : false;
+  }
+  if (node.kind === 'map') return node.entries.some(hasPreludeEntryKey);
+  if (node.kind === 'choice' || node.kind === 'groupMerge') return node.options.some((option) => hasPreludeNameKey(option, model, env, seen));
+  return false;
+}
+
+function hasPreludeEntryKey(entry) {
+  if (!entry) return false;
+  if (entry.kind === 'member') return entry.key.kind === 'name' && BUILTINS.has(entry.key.name);
+  if (entry.kind === 'group') return entry.entries.some(hasPreludeEntryKey);
+  if (entry.kind === 'groupChoice') return entry.options.some((entries) => entries.some(hasPreludeEntryKey));
+  return false;
+}
+
+function markNotJsonRepresentable(ctx, reason) {
+  if (!ctx || !ctx.nonRepReasons || ctx.nonRepReasons.has(reason)) return;
+  ctx.nonRepReasons.add(reason);
+  ctx.jsonRepresentable = false;
+  ctx.warnings.push(`This schema uses ${reason}, which JSON cannot represent — generate and validate this one as CBOR.`);
+}
+
+function stringForKey(key) {
+  const normalized = String(key || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+  if (normalized.includes('email')) return 'user@example.com';
+  if (normalized.includes('url') || normalized.includes('uri') || normalized === 'href' || normalized.includes('regid')) return 'https://example.com';
+  if (normalized.includes('uuid')) return '123e4567-e89b-12d3-a456-426614174000';
+  if (normalized === 'id' || normalized.endsWith('id') || normalized.includes('identifier') || normalized.includes('jti')) return '123e4567-e89b-12d3-a456-426614174000';
+  if (normalized.includes('date') || normalized.includes('time') || normalized === 'iat' || normalized === 'nbf' || normalized === 'exp' || normalized.includes('expire')) return '2026-08-17T16:56:23Z';
+  if (normalized.includes('phone')) return '+1-555-0100';
+  if (normalized.includes('name')) return 'example name';
+  if (normalized.includes('address') || normalized.includes('street')) return '123 Example Street';
+  if (normalized.includes('city')) return 'Example City';
+  if (normalized.includes('country')) return 'Example Country';
+  if (normalized.includes('host')) return 'example.com';
+  if (normalized.includes('version')) return '1.0.0';
+  if (normalized.includes('type') || normalized.includes('fmt')) return 'example type';
+  return 'string';
+}
+
+function generateMap(entries, ctx, depth, visiting, env) {
+  const object = {};
+  for (const entry of entries) {
+    if (!entry) continue;
+    if (entry.kind === 'groupChoice') {
+      ctx.warnings.push('Using first alternative of group choice.');
+      Object.assign(object, generateMap(entry.options[0], ctx, depth + 1, visiting, env));
+      continue;
+    }
+
+    if (entry.kind === 'group') {
+      Object.assign(object, generateMap(entry.entries, ctx, depth + 1, visiting, env));
+      continue;
+    }
+    if (entry.kind === 'member') {
+      const key = keyToString(entry.key, ctx, depth, visiting, env, entry.arrow);
+      const before = ctx.warnings.length;
+      object[key] = generateNode(entry.value, key, ctx, depth + 1, visiting, env, key);
+      if (entry.occurrence.optional && ctx.warnings.length > before) {
+        ctx.warnings.push(`Optional member "${key}" was included using a heuristic value.`);
+      }
+      continue;
+    }
+    if (entry.kind === 'element') {
+      const value = generateNode(entry.value, null, ctx, depth + 1, visiting, env, null);
+      if (value && typeof value === 'object' && !Array.isArray(value)) Object.assign(object, value);
+      else if (value !== null) {
+        ctx.warnings.push('Group entry did not produce an object member; stored it under "value".');
+        object.value = value;
+      }
+    }
+  }
+  return object;
+}
+
+function generateGroupMerge(options, ctx, depth, visiting, env) {
+  if (options.length > 1) ctx.warnings.push('Using first alternative of group socket choices.');
+  const value = generateNode(options[0], null, ctx, depth + 1, visiting, env, null);
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function generateArray(entries, ctx, depth, visiting, env) {
+  const array = [];
+  for (const entry of entries) {
+    if (!entry) continue;
+    if (entry.kind === 'groupChoice') {
+      ctx.warnings.push('Using first alternative of array group choice.');
+      array.push(...generateArray(entry.options[0], ctx, depth + 1, visiting, env));
+      continue;
+    }
+    const count = Math.max(1, Math.min(entry.occurrence?.count ?? 1, 10));
+    for (let i = 0; i < count; i++) {
+      if (entry.kind === 'member') array.push(generateNode(entry.value, keyToString(entry.key, ctx, depth, visiting, env, entry.arrow), ctx, depth + 1, visiting, env, null));
+      else if (entry.kind === 'group') array.push(...generateArray(entry.entries, ctx, depth + 1, visiting, env));
+      else array.push(generateNode(entry.value, null, ctx, depth + 1, visiting, env, null));
+    }
+  }
+  return array;
+}
+
+function generateEnum(entries, ctx, depth, visiting, env) {
+  const first = entries.find(Boolean);
+  if (!first) {
+    ctx.warnings.push('Empty group-to-choice enumeration; emitted null.');
+    return null;
+  }
+  if (first.kind === 'groupChoice') {
+    ctx.warnings.push('Using first alternative of group-to-choice enumeration.');
+    return generateEnum(first.options[0], ctx, depth + 1, visiting, env);
+  }
+  if (first.kind === 'member') return generateNode(first.value, keyToString(first.key, ctx, depth, visiting, env, first.arrow), ctx, depth + 1, visiting, env, null);
+  return generateNode(first.value, null, ctx, depth + 1, visiting, env, null);
+}
+
+function keyToString(key, ctx, depth, visiting, env, arrow = false) {
+  if (!key) return 'key';
+  if (key.kind === 'literal') {
+    if (typeof key.value !== 'string') markNotJsonRepresentable(ctx, 'integer or non-text member keys');
+    return String(key.value);
+  }
+  if (key.kind === 'name' && arrow && (ctx.model.rules.has(key.name) || BUILTINS.has(key.name))) {
+    const value = generateRef(key.name, [], null, ctx, depth + 1, visiting, env);
+    if (typeof value !== 'string') markNotJsonRepresentable(ctx, 'integer or non-text member keys');
+    return value == null ? key.name : String(value);
+  }
+  if (key.kind === 'name') return key.name;
+  const value = generateNode(key.node, null, ctx, depth + 1, visiting, env, null);
+  if (typeof value !== 'string') markNotJsonRepresentable(ctx, 'integer or non-text member keys');
+  ctx.warnings.push(`Computed map key "${key.text}" approximated as a JSON object key.`);
+  return value == null ? 'key' : String(value);
+}
+
+function collectReferences(model) {
+  const refs = new Set();
+  for (const rule of model.rules.values()) collectNodeReferences(rule.node, refs);
+  return refs;
+}
+
+function collectNodeReferences(node, refs) {
+  if (!node) return;
+  if (node.kind === 'ref') {
+    refs.add(node.name);
+    node.args.forEach((arg) => collectNodeReferences(arg, refs));
+    return;
+  }
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) value.forEach((item) => collectNodeReferences(item, refs));
+    else if (value && typeof value === 'object') collectNodeReferences(value, refs);
+  }
+}
+
+function describeTokens(tokens) {
+  return tokens.map((token) => token.raw || token.value).join(' ').trim();
+}

--- a/www/src/sample-gen.js
+++ b/www/src/sample-gen.js
@@ -431,7 +431,7 @@ function readOccurrence(tokens) {
   const first = tokens[0];
   if (!first) return null;
   if (first.value === '?') return { consumed: 1, occurrence: { min: 0, count: 1, optional: true, raw: '?' } };
-  if (first.value === '*') return { consumed: 1, occurrence: { min: 0, count: 1, optional: false, raw: '*' } };
+  if (first.value === '*' && tokens[1]?.type !== 'number') return { consumed: 1, occurrence: { min: 0, count: 1, optional: false, raw: '*' } };
   if (first.value === '+') return { consumed: 1, occurrence: { min: 1, count: 1, optional: false, raw: '+' } };
 
   if (first.type === 'number' && tokens[1]?.value === '*' && tokens[2]?.type === 'number') {

--- a/www/src/share.js
+++ b/www/src/share.js
@@ -1,0 +1,197 @@
+/**
+ * @typedef {{ cddl: string, instance?: string, kind?: 'json'|'cbor' }} PlaygroundState
+ */
+
+export const MAX_SHARE_BYTES = 32000;
+
+const SHARE_PREFIX = 's1=';
+
+// ─── UTF-8 Base64url ─────────────────────────────────────────────────────────
+
+function bytesToBase64(bytes) {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+function base64ToBytes(base64) {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function toBase64Url(text) {
+  const bytes = new TextEncoder().encode(text);
+  return bytesToBase64(bytes)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+function fromBase64Url(payload) {
+  if (!/^[A-Za-z0-9_-]+$/.test(payload)) {
+    return null;
+  }
+
+  const padding = (4 - (payload.length % 4)) % 4;
+  const base64 = `${payload.replace(/-/g, '+').replace(/_/g, '/')}${'='.repeat(padding)}`;
+  const bytes = base64ToBytes(base64);
+  return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+}
+
+function compactState(state) {
+  const compact = {
+    c: typeof state?.cddl === 'string' ? state.cddl : '',
+  };
+
+  if (typeof state?.instance === 'string' && state.instance.length > 0) {
+    compact.i = state.instance;
+  }
+
+  if (state?.kind === 'json' || state?.kind === 'cbor') {
+    compact.k = state.kind;
+  }
+
+  return compact;
+}
+
+function expandState(compact) {
+  if (!compact || typeof compact !== 'object' || Array.isArray(compact)) {
+    return null;
+  }
+
+  if (typeof compact.c !== 'string') {
+    return null;
+  }
+
+  const state = { cddl: compact.c };
+
+  if (typeof compact.i === 'string' && compact.i.length > 0) {
+    state.instance = compact.i;
+  }
+
+  if (compact.k === 'json' || compact.k === 'cbor') {
+    state.kind = compact.k;
+  }
+
+  return state;
+}
+
+// ─── Share State ─────────────────────────────────────────────────────────────
+
+/** Encode state into a URL-hash-safe string (no leading '#'). */
+export function encodeState(state) {
+  return `${SHARE_PREFIX}${toBase64Url(JSON.stringify(compactState(state)))}`;
+}
+
+/** Decode a hash string (with or without leading '#'); returns null if absent/invalid. */
+export function decodeState(hash) {
+  try {
+    const fragment = typeof hash === 'string' && hash.startsWith('#') ? hash.slice(1) : hash;
+    if (typeof fragment !== 'string' || !fragment.startsWith(SHARE_PREFIX)) {
+      return null;
+    }
+
+    const payload = fragment.slice(SHARE_PREFIX.length);
+    if (!payload) {
+      return null;
+    }
+
+    const json = fromBase64Url(payload);
+    if (json === null) {
+      return null;
+    }
+
+    return expandState(JSON.parse(json));
+  } catch (err) {
+    return null;
+  }
+}
+
+/** Build a full absolute shareable URL for the given state. */
+export function buildShareUrl(state, baseUrl) {
+  let url = baseUrl;
+  try {
+    if (typeof url !== 'string') {
+      url = globalThis.location?.href || '';
+    }
+    url = url.split('#')[0];
+  } catch (err) {
+    url = '';
+  }
+
+  return `${url}#${encodeState(state)}`;
+}
+
+export function isTooLargeToShare(state) {
+  return encodeState(state).length > MAX_SHARE_BYTES;
+}
+
+/** Read state from the current window.location. Returns null if no share payload. */
+export function readStateFromLocation() {
+  try {
+    return decodeState(globalThis.location?.hash || '');
+  } catch (err) {
+    return null;
+  }
+}
+
+/** Remove the share payload from the address bar without reloading (history.replaceState). */
+export function clearLocationState() {
+  try {
+    const location = globalThis.location;
+    const history = globalThis.history;
+    if (!location || !history || typeof history.replaceState !== 'function') {
+      return;
+    }
+
+    history.replaceState(null, '', `${location.pathname || ''}${location.search || ''}`);
+  } catch (err) {
+    // Ignore browsers that disallow history updates.
+  }
+}
+
+/** Copy text to clipboard with a execCommand fallback. @returns {Promise<boolean>} success */
+export async function copyToClipboard(text) {
+  try {
+    if (globalThis.navigator?.clipboard?.writeText) {
+      await globalThis.navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch (err) {
+    // Fall back below.
+  }
+
+  let textarea;
+  try {
+    const document = globalThis.document;
+    if (!document?.body || typeof document.createElement !== 'function') {
+      return false;
+    }
+
+    textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.left = '-9999px';
+    textarea.style.top = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    return document.execCommand('copy') === true;
+  } catch (err) {
+    return false;
+  } finally {
+    try {
+      if (textarea?.parentNode) {
+        textarea.parentNode.removeChild(textarea);
+      }
+    } catch (err) {
+      // Ignore cleanup failures.
+    }
+  }
+}

--- a/www/src/shortcuts.js
+++ b/www/src/shortcuts.js
@@ -1,0 +1,246 @@
+const ALLOWED_GROUPS = ['Editor', 'Playground', 'Panels'];
+
+/** @typedef {{ keys: string[], desc: string, group: string }} Shortcut */
+
+/** The canonical shortcut list, grouped. */
+export const SHORTCUTS = Object.freeze([
+  { keys: ['Mod', 'S'], desc: 'Format document (when Format on save is enabled)', group: 'Editor' },
+  { keys: ['Mod', 'F'], desc: 'Find', group: 'Editor' },
+  { keys: ['Mod', 'H'], desc: 'Replace', group: 'Editor' },
+  { keys: ['Mod', '/'], desc: 'Toggle line comment', group: 'Editor' },
+  { keys: ['Mod', 'Enter'], desc: 'Validate instance against schema', group: 'Playground' },
+  { keys: ['Mod', 'K'], desc: 'Open the examples menu', group: 'Playground' },
+  { keys: ['Mod', 'O'], desc: 'Open a file', group: 'Playground' },
+  { keys: ['Mod', 'Shift', 'S'], desc: 'Download the schema', group: 'Playground' },
+  { keys: ['Mod', 'Shift', 'C'], desc: 'Copy a shareable link', group: 'Playground' },
+  { keys: ['?'], desc: 'Show this shortcuts help', group: 'Playground' },
+  { keys: ['Esc'], desc: 'Close the open dialog/menu', group: 'Playground' },
+  { keys: ['Mod', 'B'], desc: 'Toggle the outline sidebar', group: 'Panels' },
+  { keys: ['Mod', 'I'], desc: 'Toggle the instance pane', group: 'Panels' },
+  { keys: ['Mod', 'J'], desc: 'Toggle the problems panel', group: 'Panels' },
+]);
+
+let warnedMissingElements = false;
+
+/** True on macOS — used to render ⌘ vs Ctrl. */
+export function isMac() {
+  if (typeof navigator === 'undefined') return false;
+  const platform = navigator.userAgentData?.platform || navigator.platform || '';
+  return /mac/i.test(platform);
+}
+
+function keyLabel(key) {
+  if (key === 'Mod') return isMac() ? '⌘' : 'Ctrl';
+  return key;
+}
+
+function getDocument(el) {
+  if (el && el.ownerDocument) return el.ownerDocument;
+  if (typeof document !== 'undefined') return document;
+  return null;
+}
+
+function clearElement(el) {
+  if ('textContent' in el) {
+    el.textContent = '';
+  }
+  while (el.firstChild) {
+    el.removeChild(el.firstChild);
+  }
+}
+
+function appendShortcutRow(doc, parent, shortcut) {
+  const rowEl = doc.createElement('div');
+  rowEl.className = 'shortcut-row';
+
+  const keysEl = doc.createElement('div');
+  keysEl.className = 'shortcut-keys';
+  for (const key of shortcut.keys) {
+    const keyEl = doc.createElement('kbd');
+    keyEl.className = 'shortcut-key';
+    keyEl.textContent = keyLabel(key);
+    keysEl.appendChild(keyEl);
+  }
+  rowEl.appendChild(keysEl);
+
+  const descEl = doc.createElement('div');
+  descEl.className = 'shortcut-desc';
+  descEl.textContent = shortcut.desc;
+  rowEl.appendChild(descEl);
+
+  parent.appendChild(rowEl);
+}
+
+/** Render the shortcut list into the modal body. */
+export function renderShortcuts(bodyEl) {
+  if (!bodyEl) return;
+  const doc = getDocument(bodyEl);
+  if (!doc) return;
+
+  clearElement(bodyEl);
+  const frag = doc.createDocumentFragment();
+
+  for (const group of ALLOWED_GROUPS) {
+    const groupShortcuts = SHORTCUTS.filter((shortcut) => shortcut.group === group);
+    if (groupShortcuts.length === 0) continue;
+
+    const titleEl = doc.createElement('div');
+    titleEl.className = 'shortcuts-group-title';
+    titleEl.textContent = group;
+    frag.appendChild(titleEl);
+
+    for (const shortcut of groupShortcuts) {
+      appendShortcutRow(doc, frag, shortcut);
+    }
+  }
+
+  bodyEl.appendChild(frag);
+}
+
+function warnMissingElements() {
+  if (warnedMissingElements) return;
+  warnedMissingElements = true;
+  if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+    console.warn('Shortcuts modal was not initialized because one or more elements are missing.');
+  }
+}
+
+function noopController() {
+  return {
+    open: () => {},
+    close: () => {},
+    toggle: () => {},
+    dispose: () => {},
+  };
+}
+
+function isTypingTarget(target) {
+  if (!target) return false;
+  const tagName = target.tagName ? target.tagName.toLowerCase() : '';
+  if (tagName === 'input' || tagName === 'textarea' || tagName === 'select') return true;
+  if (target.isContentEditable) return true;
+  if (typeof target.closest === 'function') {
+    return Boolean(target.closest('[contenteditable], .monaco-editor'));
+  }
+  return false;
+}
+
+function focusableElements(modal) {
+  if (typeof modal.querySelectorAll !== 'function') return [];
+  return Array.from(modal.querySelectorAll([
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(','))).filter((el) => (
+    !el.hasAttribute ||
+    (!el.hasAttribute('disabled') && el.getAttribute('aria-hidden') !== 'true')
+  ));
+}
+
+/**
+ * Wire the shortcuts modal open/close behavior.
+ * @param {{ btn: HTMLElement, modal: HTMLElement, closeBtn: HTMLElement, bodyEl: HTMLElement }} els
+ * @returns {{ open: () => void, close: () => void, toggle: () => void, dispose: () => void }}
+ */
+export function initShortcutsModal(els) {
+  if (!els || !els.btn || !els.modal || !els.closeBtn || !els.bodyEl) {
+    warnMissingElements();
+    return noopController();
+  }
+
+  const { btn, modal, closeBtn, bodyEl } = els;
+  const doc = getDocument(modal);
+  if (!doc) {
+    warnMissingElements();
+    return noopController();
+  }
+
+  let open = false;
+  let previousFocus = null;
+
+  const controller = {
+    open: () => {
+      if (open) return;
+      previousFocus = doc.activeElement;
+      renderShortcuts(bodyEl);
+      modal.classList.add('visible');
+      modal.setAttribute('aria-hidden', 'false');
+      open = true;
+      if (typeof closeBtn.focus === 'function') closeBtn.focus();
+    },
+    close: () => {
+      if (!open) return;
+      modal.classList.remove('visible');
+      modal.setAttribute('aria-hidden', 'true');
+      open = false;
+      if (previousFocus && typeof previousFocus.focus === 'function') {
+        previousFocus.focus();
+      }
+      previousFocus = null;
+    },
+    toggle: () => {
+      if (open) {
+        controller.close();
+      } else {
+        controller.open();
+      }
+    },
+    dispose: () => {
+      btn.removeEventListener('click', onButtonClick);
+      closeBtn.removeEventListener('click', onCloseClick);
+      modal.removeEventListener('click', onBackdropClick);
+      doc.removeEventListener('keydown', onKeyDown);
+    },
+  };
+
+  const onButtonClick = () => controller.open();
+  const onCloseClick = () => controller.close();
+  const onBackdropClick = (e) => {
+    if (e.target === modal) controller.close();
+  };
+  const onKeyDown = (e) => {
+    if (e.key === '?' && !open && !isTypingTarget(doc.activeElement)) {
+      e.preventDefault();
+      controller.open();
+      return;
+    }
+
+    if (!open) return;
+
+    if (e.key === 'Escape' || e.key === 'Esc') {
+      e.preventDefault();
+      controller.close();
+      return;
+    }
+
+    if (e.key !== 'Tab') return;
+
+    const focusable = focusableElements(modal);
+    if (focusable.length === 0) {
+      e.preventDefault();
+      closeBtn.focus();
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (e.shiftKey && doc.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && doc.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  };
+
+  btn.addEventListener('click', onButtonClick);
+  closeBtn.addEventListener('click', onCloseClick);
+  modal.addEventListener('click', onBackdropClick);
+  doc.addEventListener('keydown', onKeyDown);
+  modal.setAttribute('aria-hidden', 'true');
+
+  return controller;
+}

--- a/www/src/shortcuts.js
+++ b/www/src/shortcuts.js
@@ -14,7 +14,7 @@ export const SHORTCUTS = Object.freeze([
   { keys: ['Mod', 'Shift', 'S'], desc: 'Download the schema', group: 'Playground' },
   { keys: ['Mod', 'Shift', 'C'], desc: 'Copy a shareable link', group: 'Playground' },
   { keys: ['?'], desc: 'Show this shortcuts help', group: 'Playground' },
-  { keys: ['Esc'], desc: 'Close the open dialog/menu', group: 'Playground' },
+  { keys: ['Esc'], desc: 'Close this shortcuts help', group: 'Playground' },
   { keys: ['Mod', 'B'], desc: 'Toggle the outline sidebar', group: 'Panels' },
   { keys: ['Mod', 'I'], desc: 'Toggle the instance pane', group: 'Panels' },
   { keys: ['Mod', 'J'], desc: 'Toggle the problems panel', group: 'Panels' },

--- a/www/src/toast.js
+++ b/www/src/toast.js
@@ -1,0 +1,176 @@
+const MAX_TOASTS = 4;
+const DEFAULT_DURATION_MS = 3200;
+const TRANSITION_FALLBACK_MS = 250;
+
+let containerEl = null;
+let warnedMissingContainer = false;
+let toasts = [];
+
+const ICONS = {
+  info: 'ℹ',
+  success: '✓',
+  error: '!',
+  warning: '⚠',
+};
+
+function warnMissingContainer() {
+  if (warnedMissingContainer) return;
+  warnedMissingContainer = true;
+  if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+    console.warn('Toasts have not been initialized. Call initToasts(containerEl) before toast().');
+  }
+}
+
+function normalizeType(type) {
+  return Object.prototype.hasOwnProperty.call(ICONS, type) ? type : 'info';
+}
+
+function removeToastRecord(record) {
+  toasts = toasts.filter((toastRecord) => toastRecord !== record);
+}
+
+function scheduleTimer(record, durationMs) {
+  if (record.timerId) clearTimeout(record.timerId);
+  record.timerId = null;
+  if (durationMs > 0) {
+    record.timerId = setTimeout(record.dismiss, durationMs);
+  }
+}
+
+function removeToastNode(record) {
+  if (record.removed) return;
+  record.removed = true;
+  if (record.fallbackTimerId) clearTimeout(record.fallbackTimerId);
+  if (record.el.parentNode) {
+    record.el.parentNode.removeChild(record.el);
+  }
+}
+
+function createToast(doc, message, type) {
+  const el = doc.createElement('div');
+  el.className = `toast toast-${type}`;
+  if (type === 'error') {
+    el.setAttribute('role', 'alert');
+  }
+
+  const iconEl = doc.createElement('span');
+  iconEl.className = 'toast-icon';
+  iconEl.setAttribute('aria-hidden', 'true');
+  iconEl.textContent = ICONS[type];
+  el.appendChild(iconEl);
+
+  const messageEl = doc.createElement('span');
+  messageEl.className = 'toast-message';
+  messageEl.textContent = message;
+  el.appendChild(messageEl);
+
+  const closeBtn = doc.createElement('button');
+  closeBtn.className = 'toast-close';
+  closeBtn.type = 'button';
+  closeBtn.setAttribute('aria-label', 'Dismiss');
+  closeBtn.textContent = '×';
+  el.appendChild(closeBtn);
+
+  return { el, closeBtn };
+}
+
+/** Set the container element the toasts render into. Must be called once at boot. */
+export function initToasts(container) {
+  containerEl = container || null;
+}
+
+/**
+ * Show a toast.
+ * @param {string} message
+ * @param {'info'|'success'|'error'|'warning'} [type='info']
+ * @param {number} [durationMs=3200] pass 0 to make it sticky until dismissed
+ * @returns {() => void} a dismiss function
+ */
+export function toast(message, type = 'info', durationMs = DEFAULT_DURATION_MS) {
+  if (!containerEl) {
+    warnMissingContainer();
+    return () => {};
+  }
+
+  const normalizedType = normalizeType(type);
+  const normalizedMessage = String(message);
+  const existing = toasts.find((record) => (
+    !record.removing &&
+    record.message === normalizedMessage &&
+    record.type === normalizedType
+  ));
+  if (existing) {
+    scheduleTimer(existing, durationMs);
+    return existing.dismiss;
+  }
+
+  const doc = containerEl.ownerDocument || (typeof document !== 'undefined' ? document : null);
+  if (!doc) {
+    warnMissingContainer();
+    return () => {};
+  }
+
+  const { el, closeBtn } = createToast(doc, normalizedMessage, normalizedType);
+  const record = {
+    el,
+    message: normalizedMessage,
+    type: normalizedType,
+    timerId: null,
+    fallbackTimerId: null,
+    removing: false,
+    removed: false,
+    dismiss: null,
+  };
+
+  record.dismiss = () => {
+    if (record.removing) return;
+    record.removing = true;
+    if (record.timerId) clearTimeout(record.timerId);
+    record.timerId = null;
+    removeToastRecord(record);
+
+    const onTransitionEnd = (e) => {
+      if (e && e.target !== el) return;
+      el.removeEventListener('transitionend', onTransitionEnd);
+      removeToastNode(record);
+    };
+
+    el.addEventListener('transitionend', onTransitionEnd);
+    el.classList.remove('visible');
+    record.fallbackTimerId = setTimeout(() => {
+      el.removeEventListener('transitionend', onTransitionEnd);
+      removeToastNode(record);
+    }, TRANSITION_FALLBACK_MS);
+  };
+
+  closeBtn.addEventListener('click', record.dismiss);
+  containerEl.appendChild(el);
+  toasts.push(record);
+  scheduleTimer(record, durationMs);
+
+  while (toasts.length > MAX_TOASTS) {
+    toasts[0].dismiss();
+  }
+
+  const show = () => {
+    if (!record.removing) el.classList.add('visible');
+  };
+  if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(show);
+  } else {
+    setTimeout(show, 0);
+  }
+
+  return record.dismiss;
+}
+
+/** Remove all visible toasts immediately. */
+export function clearToasts() {
+  for (const record of [...toasts]) {
+    if (record.timerId) clearTimeout(record.timerId);
+    if (record.fallbackTimerId) clearTimeout(record.fallbackTimerId);
+    record.removing = true;
+    removeToastNode(record);
+  }
+  toasts = [];
+}


### PR DESCRIPTION
## Summary

The CDDL Playground could parse a schema but never validate a document against it — `validate_json_from_str` and `validate_cbor_from_slice` were already exported from the wasm build and simply unused. This PR closes that gap and adds five more UX features around it.

All logic lands in new dependency-free ES modules under `www/src/`; `index.js` only wires them. **No new npm dependencies, no Rust changes, no version bumps.**

## Features

### 1. Instance validation (JSON + CBOR) — the headline gap
A second Monaco editor in a new right-hand pane validates a real document against the schema in the editor.
- **Before:** the site only told you whether your CDDL *parsed*.
- **After:** pick a root rule, paste JSON (or CBOR as hex/base64), hit **Validate**, and get per-constraint failures such as `/age: expected uint to be in range 0 <= value <= 120, got 500`.

Handles all three real wasm result shapes: success returns `undefined`, constraint failures throw a newline-delimited string, and malformed CDDL throws an array of `ParserError` objects.

### 2. Sample instance generator
**Generate sample** synthesizes a conforming JSON document from the schema, so the pane is never a blank page. Preserves literal discriminators, resolves group rules/generics/socket extensions, and is protected by depth caps, cycle detection and a node budget.

Verified against the bundled examples with the real wasm validator: **11 of 16 generated samples validate**; the other 5 are CBOR-only schemas (integer member keys, byte strings, tags) which are explicitly flagged `jsonRepresentable: false` and warn the user rather than silently producing something that cannot validate.

### 3. Rule outline + go-to-definition
A filterable sidebar listing every rule, with kind badges (type/group/socket/extension) and a preview. Click to jump; Monaco definition and hover providers use a CDDL-aware identifier expansion so `$sockets` and `hyphen-names` resolve (Monaco's default word pattern breaks on both).

### 4. File open / save / drag-and-drop
Open `.cddl`, `.json` and `.cbor` (binary, rendered as hex) via the picker or by dropping onto the window; download the schema as `schema.cddl`.

### 5. Shareable permalinks
**Share** copies a URL encoding schema + instance in a versioned `#s1=` fragment, UTF-8 safe so non-ASCII schemas survive. Opening the link restores the session and cleans the address bar.

### 6. Toasts + keyboard shortcuts
A toast system for feedback and a `?` shortcuts modal documenting all 14 shortcuts, including ones that already existed but were undiscoverable.

## Layout

`.workspace` becomes `outline | editor | instance` above the existing problems panel. Every pre-existing element ID and behavior is preserved.

## Verification

- `npm run build` (incl. `wasm-pack` via `prebuild`) compiles — only the pre-existing asset-size warning.
- Driven in headless Chromium against the production bundle: generated sample validates PASS; `{"name": 42, "age": 500}` correctly FAILS with both constraint errors; valid CBOR hex passes; garbage CBOR reports `Invalid CBOR input`; outline filter/empty-state/jump; share round-trip restores the schema and clears the hash; download yields `schema.cddl`; shortcuts modal opens and closes on Esc. **Zero console errors.**
- Light and dark themes checked at 1440 / 1280 / 1100 / 860 / 600px — no horizontal overflow, topbar never wraps, labels collapse to icon-only below 1280px with no mid-word truncation.
- `cargo fmt --all -- --check`, `cargo clippy --all`, and `cargo check --lib --target wasm32-unknown-unknown` all clean (one clippy warning pre-exists on `main`).

## Try it locally

```bash
cd www && npm install && npm start
```
Then: **Instance** → **Generate sample** → **Validate**, and edit a value to see it fail.
