### PR TITLE
fix(parser): reject plain rule redefinition after /= and //=

### DIFF
--- a/src/pest_bridge.rs
+++ b/src/pest_bridge.rs
@@ -451,6 +451,21 @@ fn pest_span_to_position(span: &PestSpan, input: &str) -> Position {
   }
 }
 
+/// Convert an AST span back to a full position, recomputing the column
+#[cfg(feature = "ast-span")]
+fn position_from_ast_span(span: ast::Span, input: &str) -> Position {
+  let (start, end, line) = span;
+  let line_start = input[..start].rfind('\n').map(|i| i + 1).unwrap_or(0);
+  let column = input[line_start..start].chars().count() + 1;
+
+  Position {
+    line,
+    column,
+    range: (start, end),
+    index: start,
+  }
+}
+
 /// Standard prelude names from RFC 8610 §D
 const STANDARD_PRELUDE: &[&str] = &[
   "any",
@@ -1827,19 +1842,32 @@ fn convert_cddl<'a>(mut pairs: Pairs<'a, Rule>, input: &'a str) -> Result<ast::C
     });
   }
 
-  // Check for duplicate rule names (non-alternate rules)
+  // Check for duplicate rule names (non-alternate rules). RFC 8610 Appendix C
+  // does let `/=` and `//=` create the named choice on their own ("It is not
+  // an error to extend a rule name that has not yet been defined"), but it
+  // never says whether that leaves the name "already defined" for the
+  // plain-`=` error clause. Treating a late `=` as a duplicate — rather than
+  // as a base to reorder ahead of the existing arms — is this crate's policy,
+  // chosen to match the name-based duplicate check applied to every other
+  // rule. Rules of both kinds share one namespace, so the check is keyed by
+  // name alone: a plain group rule after `t /= int` collides just like a
+  // plain type rule after `g //= (k: int)`. Pinned by
+  // tests/incremental_group_choices.rs.
   let mut seen_names: HashMap<String, usize> = HashMap::new();
+  let mut incremental_names: HashMap<String, usize> = HashMap::new();
   for (idx, rule) in rules.iter().enumerate() {
     let name = rule.name();
     let is_alternate = match rule {
       ast::Rule::Type { rule, .. } => rule.is_type_choice_alternate,
       ast::Rule::Group { rule, .. } => rule.is_group_choice_alternate,
     };
-    if !is_alternate {
-      if let Some(_prev_idx) = seen_names.get(&name) {
+    if is_alternate {
+      incremental_names.entry(name).or_insert(idx);
+    } else {
+      if seen_names.contains_key(&name) || incremental_names.contains_key(&name) {
         return Err(Error::PARSER {
           #[cfg(feature = "ast-span")]
-          position: Position::default(),
+          position: position_from_ast_span(rule.span(), input),
           msg: ErrorMsg {
             short: format!("rule \"{}\" is already defined", name),
             extended: None,

--- a/tests/incremental_group_choices.rs
+++ b/tests/incremental_group_choices.rs
@@ -1,0 +1,200 @@
+//! Incremental (`/=` / `//=`) redefinition regressions.
+//!
+//! RFC 8610 Appendix C states one redefinition rule for `/=` and `//=`
+//! together: the incremental operators populate a named choice in source
+//! order, and a plain `=` is an error when the name is "already defined
+//! with a different expression". Appendix C does not settle how a late
+//! plain `=` orders against arms an earlier `/=` or `//=` already
+//! contributed, and it would permit an identical redefinition; rejecting
+//! every later plain `=` once the name exists is this crate's policy —
+//! the policy the legacy pre-Pest parser enforced for all rules, and the
+//! one Ruby cddl 0.12.14 applies when the expressions differ; Ruby accepts
+//! an identical redefinition with a warning. The duplicate check in
+//! `pest_bridge::convert_cddl` originally ignored incremental
+//! definitions entirely, so a plain `=` after `/=` or `//=` parsed
+//! successfully — in any kind combination — and the validators then
+//! silently dropped one family's choice arms, giving the schema a
+//! meaning Appendix C never defines.
+//!
+//! Ruby cddl 0.12.14 corroborates the rejection: it reports "Duplicate
+//! rule definition t" for the cross-kind ordering and aborts in rule
+//! merging (`strip_nodes` NoMethodError) on the group ordering, so
+//! neither schema gets a verdict there either.
+
+#![cfg(feature = "std")]
+#![cfg(all(feature = "cbor", feature = "json"))]
+#![cfg(not(target_arch = "wasm32"))]
+
+use cddl::{cddl_from_str, validate_cbor_from_slice, validate_json_from_str};
+
+#[test]
+fn base_group_definition_cannot_follow_an_incremental_group_definition() {
+  for schema in [
+    // Plain group rule after a group-choice alternate (probe P9a).
+    "r = {g}\ng //= (k: int)\ng = (j: int)\n",
+    // Same ordering behind no alias.
+    "g //= (k: int)\ng = (j: int)\n",
+    // Socket names share the rule namespace with every other name.
+    "$$foo //= (k: int)\n$$foo = (j: int)\nroot = {$$foo}\n",
+  ] {
+    let error = cddl_from_str(schema, false).unwrap_err();
+    assert!(
+      error.contains("already defined"),
+      "unexpected parser error for {:?}: {}",
+      schema,
+      error
+    );
+  }
+}
+
+#[test]
+fn base_type_definition_cannot_follow_an_incremental_type_definition() {
+  for schema in [
+    "extended /= text\nextended = bool\n",
+    "root = extended\nextended /= text\nextended = bool\n",
+    // Ruby cddl 0.12.14 also rejects this ordering for socket names
+    // ("Duplicate rule definition $foo").
+    "$foo /= int\n$foo = text\nroot = text\n",
+    // Stricter than Appendix C's literal wording ("already defined with
+    // a *different* expression") and than Ruby, which accepts an
+    // identical redefinition with only a warning; the crate has always
+    // rejected duplicate plain definitions without comparing
+    // expressions, and the incremental check inherits that policy.
+    "a /= text\na = text\n",
+    // A generic head after `/=` of the same base name is likewise
+    // rejected, for one reason: RFC 8610 makes the bare `id` the rule's
+    // identity (`typename = id`, and §3.10 adds formal parameters "after
+    // the name being defined" — the parameters follow the name and are
+    // not part of it). So this is the same `=`-after-`/=` case as above,
+    // not a generics rule: the `<t>` never enters the argument. Ruby
+    // keeps both names live by dispatching on citation arity, an
+    // extension with no RFC basis it does not even carry to the
+    // definition side.
+    "a /= text\na<t> = int\n",
+  ] {
+    let error = cddl_from_str(schema, false).unwrap_err();
+    assert!(
+      error.contains("already defined"),
+      "unexpected parser error for {:?}: {}",
+      schema,
+      error
+    );
+  }
+}
+
+#[test]
+fn base_definition_cannot_change_kind_after_an_incremental_definition() {
+  for schema in [
+    // Type-choice alternate, then a plain rule whose parenthesized
+    // right-hand side parses as a group rule (probe P9b). Ruby 0.12.14
+    // rejects this ordering with "Duplicate rule definition t".
+    "r = t\nt /= int\nt = (j: int)\n",
+    // Group-choice alternate, then a plain type rule.
+    "r = {g}\ng //= (k: int)\ng = tstr\n",
+  ] {
+    let error = cddl_from_str(schema, false).unwrap_err();
+    assert!(
+      error.contains("already defined"),
+      "unexpected parser error for {:?}: {}",
+      schema,
+      error
+    );
+  }
+}
+
+#[cfg(feature = "ast-span")]
+#[test]
+fn duplicate_rule_errors_carry_the_offending_rule_position() {
+  // Every duplicate-rule arm must report the later, offending rule's real
+  // span, not `Position::default()`'s line 1, column 1. One schema per
+  // arm: plain-after-plain, plain-after-`/=`, plain-after-`//=`, and the
+  // cross-kind orderings.
+  for schema in [
+    "a = int\nb = tstr\na = tstr\n",
+    "t /= int\nx = tstr\nt = tstr\n",
+    "g //= (k: int)\nx = tstr\ng = (j: int)\n",
+    "t /= int\nx = tstr\nt = (j: int)\n",
+    "g //= (k: int)\nx = tstr\ng = tstr\n",
+  ] {
+    let error = cddl_from_str(schema, false).unwrap_err();
+    assert!(
+      error.contains("already defined"),
+      "unexpected parser error for {:?}: {}",
+      schema,
+      error
+    );
+    // The offending duplicate sits on line 3 in every schema above; the
+    // parser error Display includes the debug-formatted position.
+    assert!(
+      error.contains("line: 3"),
+      "duplicate-rule error for {:?} lost the rule position: {}",
+      schema,
+      error
+    );
+  }
+
+  // Exercise the column calculation and byte offsets, rather than only the
+  // line stored in the AST span. The multibyte comment makes the byte range
+  // differ from a character-counted offset, and the duplicate is indented so
+  // a default column cannot satisfy the assertion.
+  let schema = "a = int\n; é\n  a = tstr\n";
+  let error = cddl::pest_bridge::cddl_from_pest_str(schema).unwrap_err();
+  if let cddl::parser::Error::PARSER { position, msg } = error {
+    assert!(
+      msg.short.contains("already defined"),
+      "unexpected parser error for {:?}: {}",
+      schema,
+      msg
+    );
+    assert_eq!(position.line, 3);
+    assert_eq!(position.column, 3);
+    assert_eq!(position.range, (15, 24));
+    assert_eq!(position.index, 15);
+  } else {
+    panic!("unexpected parser error for {:?}: {}", schema, error);
+  }
+}
+
+#[test]
+fn incremental_definitions_after_a_plain_base_stay_valid() {
+  // Accepting control: extending an existing plain type rule with `/=`
+  // is the RFC's own example shape and must keep parsing, including an
+  // identical arm (only a plain `=` redefinition is rejected).
+  cddl_from_str("a = text\na /= text\n", false).unwrap();
+  cddl_from_str("a = bool\na /= text\na /= uint\n", false).unwrap();
+
+  // The check is name-based and generic-blind, so a rule carrying
+  // generic parameters may still be extended under the same name (RFC
+  // 8610 grammar: `rule = typename [genericparm] S assignt S type` with
+  // `assignt = "=" / "/="`). Parse acceptance only; the arms' binding
+  // semantics are validator scope.
+  cddl_from_str("root = a<int>\na<t> = [t]\na<t> /= {k: t}\n", false).unwrap();
+}
+
+#[test]
+fn incremental_group_chain_stays_valid_at_root_and_through_alias() {
+  // Accepting controls: a pure `//=` chain is the well-formed way to build
+  // a named group choice, whether or not a plain base rule ever existed.
+  // Ruby 0.12.14 agrees on all of these vectors, in both encodings.
+  const ALIAS: &str = "r = {g}\ng //= (k: int)\ng //= (j: int)\n";
+  const REORDERED: &str = "g //= (k: int)\ng //= (j: int)\nr = {g}\n";
+
+  for schema in [ALIAS, REORDERED] {
+    validate_json_from_str(schema, r#"{"k":1}"#, None).unwrap();
+    validate_json_from_str(schema, r#"{"j":1}"#, None).unwrap();
+    validate_json_from_str(schema, r#"{"x":1}"#, None).unwrap_err();
+
+    // {"k":1} / {"j":1} / {"x":1}
+    validate_cbor_from_slice(schema, &[0xa1, 0x61, b'k', 0x01], None).unwrap();
+    validate_cbor_from_slice(schema, &[0xa1, 0x61, b'j', 0x01], None).unwrap();
+    validate_cbor_from_slice(schema, &[0xa1, 0x61, b'x', 0x01], None).unwrap_err();
+  }
+}
+
+// NOTE deliberately absent here: the base-first ordering `g = (k: int)`
+// then `g //= (j: int)` is valid per Appendix C (base arm first, extension
+// arms after), and Ruby 0.12.14 accepts both keys — but this crate's
+// validators currently drop the plain base arm and honor only the `//=`
+// arms. That is a pre-existing validator-side resolution defect, separate
+// from the parse-time duplicate check pinned by this file, and is tracked
+// as its own issue.


### PR DESCRIPTION
This PR simply disallows you from using `=` to define a name that has previously been extended using `/=` and `//=`

The code is very simple, but shared by many downstream issues like #680, so it's done as its own easy-to-review PR (very few lines of code). As such, there are many pre-existing issues that this PR explicitly doesn't consider in scope (all meant to be fixed as follow-up PRs) and the goal of this PR is just to fix this simple case without introducing any regressions

This PR fixes:
- The check now records the first incremental definition of each name, for both rule kinds, keyed by the bare name.
- A later plain `=` of a recorded name is rejected, regardless of rule kind on either side.
- Every duplicate-rule error now carries the offending rule's real line, column, and byte range, rebuilt from the rule's `ast-span`.
- Every well-formed shape still parses: a plain base followed by incremental arms, alternate-only chains, a name first created by `/=`/`//=`, and generic rules extended under the same name.

## Relevant RFC rules

<details>
<summary>section list</summary>

- Appendix C (normative), lines 2669-2677 — one sentence covers both
  operators: "A plain equals sign defines the rule name as the
  equivalent of the expression to the right; it is an error if the name
  was already defined with a different expression. A `/=` or `//=`
  extends a named type or a group by additional choices … in the order
  of the rules given. (It is not an error to extend a rule name that
  has not yet been defined; this makes the right-hand side the first
  entry in the choice being created.)"
- Appendix C, lines 2639-2641: a rule that contributes via `/=` or
  `//=` populates the choice "in the order the rules are given".
- Section 2.2.2, lines 625-637: introduces `/=` and `//=` in the same
  sentence, and adds "It is not an error if a name is first used with a
  '/=' or '//=' (there is no need to 'create it' with '=')."
- Appendix A's CDDL-to-PEG mapping table, line 2436, treats them as one
  construct: `| "=" | "<-" | /= and //= are abbreviations |`.
- Section 3.10, lines 1839-1840, with the grammar at lines 2643-2646
  (`rule = typename [genericparm] S assignt S type`, `typename = id`):
  formal parameters come "after the name being defined". The bare `id`
  is the rule's identity; parameters are not part of it. This is why
  `a<t> = int` after `a /= text` is the same redefinition case, not a
  generics case.
- Policy note: the RFC's error condition is "already defined with a
  **different** expression". It does not spell out the `=`-after-`//=`
  ordering, and it would permit an identical redefinition. Rejecting
  every later plain `=` once the name exists is implementation policy —
  the policy the legacy parser enforced for all rules (from `a2488e2`
  on), corroborated by Ruby 0.12.14 on the differing-expression cells
  only (Ruby accepts an identical redefinition with a warning and keeps
  a generic head live), and the policy S02 adopted for type rules. The RFC
  is the conformance basis for the choice-arm semantics; the blanket
  rejection is corroborated, not mandated.

</details>

## Rust and Ruby evidence

| Schema and instance | main | Ruby 0.12.14 | This PR | Basis |
| --- | ---: | ---: | ---: | --- |
| `g //= (k: int); g = (j: int)`, root `{g}` | parses; honors only the `//=` arm (accepts `{"k":1}`, rejects `{"j":1}`) | panic (NoMethodError … in `strip_node`) | parser rejects | Appendix C; no gem verdict |
| `t /= int; t = (j: int)`, root `t` (cross-kind) | parses; honors only the `/=` arm (accepts `1`, rejects `{"j":1}`) | rejection: `Duplicate rule definition t` (`cddl.rb:231`) | parser rejects | Appendix C; interop |
| `t /= int; t = tstr` (all-Type) | parses | rejection: `Duplicate rule definition t` | parser rejects | Appendix C; interop |
| Cross-kind reverse `g //= (k: int); g = tstr` | parses | panic (NoMethodError … in `strip_node`) | parser rejects | Appendix C; no gem verdict |
| Sockets: `$foo /= int; $foo = text` and `$$foo //= (k: int); $$foo = (j: int)` | parses | `$foo`: rejection (`Duplicate rule definition $foo`); `$$foo`: panic (NoMethodError … in `strip_node`) | parser rejects (sockets share the rule namespace) | Appendix C; interop for `$foo`, no gem verdict for `$$foo` |
| Accepting control `g //= (k: int); g //= (j: int)`, root `{g}` (and rule-order-reversed) | accepts `{"k":1}` and `{"j":1}`, rejects `{"x":1}`, both encodings |  accepts both keys; rejection (not schema) for `{"x":1}`, JSON and CBOR | unchanged (to be fixed in PR stacked with #680) | Appendix C |
| Accepting controls `a = text; a /= text` and `a = bool; a /= text; a /= uint` | parses | accepts | parses (unchanged; fixed in #680) | Section 2.2.2 |
| Accepting control `a<t> = [t]; a<t> /= {k: t}` | parses | rejection: `Augment "/=" not implemented for generics` | parses — the check is generic-blind by design; arm semantics are S02's scope | grammar-legal (`assignt = "=" / "/="`) |
| Span: indented duplicate after a multibyte comment (`a = int\n; é\n  a = tstr\n`) | error at `line: 1, column: 1, range: (0, 0), index: 0` | n/a (rust-specific diagnostic comparison) | exact offending-rule position: `line: 3, column: 3, range: (15, 24), index: 15` | diagnostics |

Entries that are affected and differ from Ruby (but probably good to differ)
| Schema and instance | main | Ruby 0.12.14 | This PR | Basis |
| --- | ---: | ---: | ---: | --- |
| `a /= text; a<t> = int` (generic head) | parsed | accepts, and both names stay live: Ruby stores generic rules in `@generics`, separate from `@rules | parser rejects: generics share the rule namespace | §3.10 and Appendix C |
| `a /= text; a = text` (identical expression) | parsed | `Warning: Identical redefinition` | parser rejects  (Appendix C says only when a redefinition MUST be an error, never when one must be accepted) | policy; pinned by test |
