### PR TITLE
Fix the defects the PR #700 review surfaced

### DIFF
--- a/www/index.js
+++ b/www/index.js
@@ -1410,6 +1410,7 @@ function generateCurrentSample() {
     toast(result.error, 'error');
     return;
   }
+  let warnedAlready = false;
   if (result.json !== null) {
     setInstanceKind('json');
     instanceEditor.setValue(result.json);
@@ -1421,21 +1422,24 @@ function generateCurrentSample() {
         'warning',
         7000,
       );
+      warnedAlready = true;
     } else if (result.verified) {
       toast('Generated sample instance', 'success');
     } else if (result.validationError) {
       toast(`Generated a sample, but it does not validate: ${result.validationError}`, 'warning', 7000);
+      warnedAlready = true;
     } else if (result.constraintsSatisfied === false) {
       toast(
         'Some control operator constraints could not be applied — the generated sample is a shape reference and may not validate. Adjust the highlighted values manually.',
         'warning',
         7000,
       );
+      warnedAlready = true;
     } else {
       toast('Generated sample instance', 'success');
     }
   }
-  if (result.warnings && result.warnings.length > 0) {
+  if (!warnedAlready && result.warnings && result.warnings.length > 0) {
     toast(`Generated with ${result.warnings.length} caveat(s): ${result.warnings[0]}`, 'warning');
   }
 }

--- a/www/index.js
+++ b/www/index.js
@@ -1058,6 +1058,7 @@ function applyFormat() {
 let validationTimer;
 
 let lastInput = '';
+let lastValidatedInput = null;
 let saveTimer;
 
 function scheduleValidation() {
@@ -1073,12 +1074,14 @@ function scheduleSave() {
 
 function runValidation() {
   const input = editor.getValue();
-  // Skip if content hasn't changed since last validation
-  if (input === lastInput) return;
+  // Skip only when the previous run produced a real result; a "not ready" stub
+  // must not poison the cache, or it survives until the next keystroke.
+  if (input === lastValidatedInput) return;
   lastInput = input;
   scheduleSave();
 
   if (!input.trim()) {
+    lastValidatedInput = input;
     updateProblems([]);
     monaco.editor.setModelMarkers(editor.getModel(), 'cddl', []);
     if (statusPill) statusPill.className = 'status-pill';
@@ -1091,6 +1094,7 @@ function runValidation() {
   if (statusText) statusText.textContent = 'Checking\u2026';
 
   const result = validateCDDLText(input);
+  lastValidatedInput = wasmModule?.validate_cddl_from_str ? input : null;
   updateProblems(result.errors);
 
   // Update Monaco markers
@@ -1389,7 +1393,19 @@ function refreshRootCandidates() {
 function generateCurrentSample() {
   if (!editor || !instanceEditor) return;
   const selectedRoot = instanceRootRule?.value || undefined;
-  const result = generateSample(editor.getValue(), selectedRoot);
+  const schema = editor.getValue();
+
+  // Verify candidates against the real validator rather than trusting heuristics.
+  const validate = wasmModule?.validate_json_from_str
+    ? (json) => {
+      const check = validateInstance({
+        wasmModule, cddl: schema, kind: 'json', text: json, rootRule: selectedRoot,
+      });
+      return check.ok ? null : (check.failures[0] || check.title);
+    }
+    : undefined;
+
+  const result = generateSample(schema, selectedRoot, { validate });
   if (result.error) {
     toast(result.error, 'error');
     return;
@@ -1401,10 +1417,14 @@ function generateCurrentSample() {
     toggleInstancePane(true);
     if (result.jsonRepresentable === false) {
       toast(
-        'This schema uses CBOR-only features (integer keys, byte strings, or tags) — the generated JSON is a shape reference and won\'t validate as JSON. Switch to the CBOR tab for this one.',
+        'This schema uses CBOR-only features (integer keys, byte strings, or tags). The sample shows the expected structure but cannot validate as JSON — encode an equivalent CBOR document to validate it.',
         'warning',
         7000,
       );
+    } else if (result.verified) {
+      toast('Generated sample instance', 'success');
+    } else if (result.validationError) {
+      toast(`Generated a sample, but it does not validate: ${result.validationError}`, 'warning', 7000);
     } else if (result.constraintsSatisfied === false) {
       toast(
         'Some control operator constraints could not be applied — the generated sample is a shape reference and may not validate. Adjust the highlighted values manually.',
@@ -1729,7 +1749,7 @@ function boot() {
     checkRefs = !checkRefs;
     if (refCheckTrack) refCheckTrack.classList.toggle('active', checkRefs);
     try { localStorage.setItem(REFS_CACHE_KEY, checkRefs); } catch (_) {}
-    if (editor) { lastInput = ''; runValidation(); }
+    if (editor) { lastInput = ''; lastValidatedInput = null; runValidation(); }
   });
 
   // Format-on-save toggle

--- a/www/index.js
+++ b/www/index.js
@@ -1436,7 +1436,8 @@ function generateCurrentSample() {
       );
       warnedAlready = true;
     } else {
-      toast('Generated sample instance', 'success');
+      toast('Generated a sample, but it could not be verified because the validator is not ready.', 'warning', 7000);
+      warnedAlready = true;
     }
   }
   if (!warnedAlready && result.warnings && result.warnings.length > 0) {

--- a/www/src/sample-gen.js
+++ b/www/src/sample-gen.js
@@ -940,8 +940,9 @@ function generateArray(entries, ctx, depth, visiting, env) {
       else if (entry.kind === 'group') array.push(...generateArray(entry.entries, ctx, depth + 1, visiting, env));
       else {
         // A group reference contributes its entries to the array, not a nested array.
-        const group = resolveGroupNode(entry.value, ctx, env, new Set());
-        if (group) array.push(...generateArray(group.entries, ctx, depth + 1, visiting, env));
+        const seen = new Set();
+        const resolved = resolveGroupNode(entry.value, ctx, env, seen, visiting);
+        if (resolved) array.push(...generateArray(resolved.group.entries, ctx, depth + 1, new Set([...visiting, ...seen]), resolved.env));
         else array.push(generateNode(entry.value, null, ctx, depth + 1, visiting, env, null));
       }
     }
@@ -960,16 +961,22 @@ function hasMemberEntries(entries) {
   });
 }
 
-/** Follow references to an inline group definition, or null when it is not one. */
-function resolveGroupNode(node, ctx, env, seen) {
+/** Follow references to an inline group definition with its environment, or null when it is not one. */
+function resolveGroupNode(node, ctx, env, seen, visiting) {
   if (!node) return null;
-  if (node.kind === 'group') return hasMemberEntries(node.entries) ? null : node;
-  if (node.kind !== 'ref' || node.args.length > 0) return null;
-  if (env?.has(node.name)) return resolveGroupNode(env.get(node.name), ctx, env, seen);
-  if (seen.has(node.name)) return null;
+  if (node.kind === 'group') return hasMemberEntries(node.entries) ? null : { group: node, env };
+  if (node.kind !== 'ref') return null;
+  if (env?.has(node.name)) return resolveGroupNode(env.get(node.name), ctx, env, seen, visiting);
+  if (seen.has(node.name) || visiting?.has(node.name)) return null;
   seen.add(node.name);
   const rule = ctx.model.rules.get(node.name);
-  return rule && rule.params.length === 0 ? resolveGroupNode(rule.node, ctx, env, seen) : null;
+  if (!rule) return null;
+  if (rule.params.length === 0) return resolveGroupNode(rule.node, ctx, env, seen, visiting);
+  const nextEnv = new Map(env || []);
+  rule.params.forEach((param, index) => {
+    if (node.args[index]) nextEnv.set(param, node.args[index]);
+  });
+  return resolveGroupNode(rule.node, ctx, nextEnv, seen, visiting);
 }
 
 function generateEnum(entries, ctx, depth, visiting, env) {

--- a/www/src/sample-gen.js
+++ b/www/src/sample-gen.js
@@ -1,9 +1,11 @@
 /**
- * @typedef {{ json: string|null, warnings: string[], error: string|null, jsonRepresentable: boolean, constraintsSatisfied: boolean }} SampleResult
+ * @typedef {{ json: string|null, warnings: string[], error: string|null, jsonRepresentable: boolean, constraintsSatisfied: boolean, verified: boolean, validationError: string|null }} SampleResult
  */
 
 const MAX_DEPTH = 32;
 const MAX_NODES = 5000;
+/** Upper bound on repeated occurrences; schemas demanding more fail explicitly. */
+const MAX_REPEAT = 64;
 const BUILTINS = new Set([
   'any', 'uint', 'nint', 'int', 'integer', 'unsigned', 'number', 'float', 'float16',
   'float32', 'float64', 'float16-32', 'float32-64', 'bool', 'true', 'false', 'nil',
@@ -19,6 +21,8 @@ export function listRootCandidates(source) {
     const model = parseSource(source || '');
     if (model.order.length === 0) return [];
 
+    // RFC 8610: the first rule in a schema is conventionally the entry point, so it
+    // outranks the "nothing references it" signal, which misfires on real-world schemas.
     const candidates = model.order.filter((name) => !name.startsWith('$'));
     const firstConcrete = candidates.find((name) => model.rules.get(name)?.params.length === 0);
     const referenced = collectReferences(model);
@@ -40,22 +44,51 @@ export function listRootCandidates(source) {
 
 /**
  * Generate a sample JSON instance for `rootRuleName` (or the best candidate when omitted).
+ *
+ * When `options.validate` is supplied it is treated as the source of truth: candidate
+ * samples are run through it and the first conforming one wins. Without it the generator
+ * can only report its own heuristics, which is why `verified` exists.
+ *
+ * @param {{ validate?: (json: string) => string|null }} [options]
+ *   `validate` returns null when the instance conforms, or the validator error otherwise.
  * @returns {SampleResult} json is pretty-printed with 2-space indent, or null on error.
  */
-export function generateSample(source, rootRuleName) {
+export function generateSample(source, rootRuleName, options = {}) {
+  const validate = typeof options.validate === 'function' ? options.validate : null;
+  let last = null;
+
+  // Optional members are a common cause of non-conformance (recursive rules, unsatisfiable
+  // controls). Try with them, then without, and let the validator pick the winner.
+  for (const includeOptional of [true, false]) {
+    const attempt = generateOnce(source, rootRuleName, includeOptional);
+    if (attempt.error || !attempt.jsonRepresentable || !validate) return attempt;
+
+    const validationError = validate(attempt.json);
+    if (!validationError) return { ...attempt, verified: true, validationError: null };
+    last = { ...attempt, verified: false, validationError };
+  }
+
+  if (last && last.validationError) {
+    last.warnings = [...last.warnings, 'Generated sample does not validate against this schema; it is a best-effort starting point.'];
+    last.constraintsSatisfied = false;
+  }
+  return last;
+}
+
+function generateOnce(source, rootRuleName, includeOptional) {
   const warnings = [];
 
   try {
     const model = parseSource(source || '');
     if (model.order.length === 0) {
-      return { json: null, warnings: [], error: 'No rules found in schema', jsonRepresentable: false, constraintsSatisfied: false };
+      return { json: null, warnings: [], error: 'No rules found in schema', jsonRepresentable: false, constraintsSatisfied: false, verified: false, validationError: null };
     }
 
     const roots = listRootCandidates(source);
     const root = rootRuleName || roots[0] || model.order[0];
     if (!root || !model.rules.has(root)) {
       warnings.push(`Unknown root rule "${root}"; emitted null.`);
-      return { json: JSON.stringify(null, null, 2), warnings, error: null, jsonRepresentable: true, constraintsSatisfied: true };
+      return { json: JSON.stringify(null, null, 2), warnings, error: null, jsonRepresentable: true, constraintsSatisfied: true, verified: false, validationError: null };
     }
 
     const ctx = {
@@ -66,6 +99,7 @@ export function generateSample(source, rootRuleName) {
       nonRepReasons: new Set(),
       constraintsSatisfied: true,
       unappliedControls: new Set(),
+      includeOptional,
     };
     const value = generateRef(root, [], null, ctx, 0, new Set(), new Map());
     return {
@@ -74,6 +108,8 @@ export function generateSample(source, rootRuleName) {
       error: null,
       jsonRepresentable: ctx.jsonRepresentable,
       constraintsSatisfied: ctx.constraintsSatisfied,
+      verified: false,
+      validationError: null,
     };
   } catch (err) {
     return {
@@ -82,6 +118,8 @@ export function generateSample(source, rootRuleName) {
       error: err && err.message ? err.message : String(err),
       jsonRepresentable: false,
       constraintsSatisfied: false,
+      verified: false,
+      validationError: null,
     };
   }
 }
@@ -304,6 +342,8 @@ function parseExpression(tokens) {
   if (isWrapped(trimmed, '(', ')')) {
     const inner = trimmed.slice(1, -1);
     if (findTopLevelOp(inner, [':', '=>']) >= 0) return { kind: 'map', entries: parseGroup(inner) };
+    // `( int, tstr )` is a group of entries, not a parenthesized single type.
+    if (splitTopLevel(inner, ',').length > 1) return { kind: 'group', entries: parseGroup(inner) };
     return parseExpression(inner);
   }
   if (isWrapped(trimmed, '{', '}')) return { kind: 'map', entries: parseGroup(trimmed.slice(1, -1)) };
@@ -417,7 +457,7 @@ function parseGroupEntry(tokens) {
   tokens = trimTokens(tokens);
   if (tokens.length === 0) return null;
 
-  let occurrence = { min: 1, count: 1, optional: false, raw: '' };
+  let occurrence = { min: 1, max: 1, count: 1, optional: false, raw: '' };
   const occ = readOccurrence(tokens);
   if (occ) {
     occurrence = occ.occurrence;
@@ -445,32 +485,66 @@ function parseGroupEntry(tokens) {
 function readOccurrence(tokens) {
   const first = tokens[0];
   if (!first) return null;
-  if (first.value === '?') return { consumed: 1, occurrence: { min: 0, count: 1, optional: true, raw: '?' } };
-  if (first.value === '*' && tokens[1]?.type !== 'number') return { consumed: 1, occurrence: { min: 0, count: 1, optional: false, raw: '*' } };
-  if (first.value === '+') return { consumed: 1, occurrence: { min: 1, count: 1, optional: false, raw: '+' } };
+  if (first.value === '?') return { consumed: 1, occurrence: makeOccurrence(0, 1, '?', true) };
+  if (first.value === '*' && tokens[1]?.type !== 'number') return { consumed: 1, occurrence: makeOccurrence(0, Infinity, '*') };
+  if (first.value === '+') return { consumed: 1, occurrence: makeOccurrence(1, Infinity, '+') };
 
   if (first.type === 'number' && tokens[1]?.value === '*' && tokens[2]?.type === 'number') {
     return {
       consumed: 3,
-      occurrence: { min: numberFromToken(first), count: Math.max(1, numberFromToken(first)), optional: false, raw: `${first.raw}*${tokens[2].raw}` },
+      occurrence: makeOccurrence(numberFromToken(first), numberFromToken(tokens[2]), `${first.raw}*${tokens[2].raw}`),
     };
   }
 
   if (first.type === 'number' && tokens[1]?.value === '*') {
     return {
       consumed: 2,
-      occurrence: { min: numberFromToken(first), count: Math.max(1, numberFromToken(first)), optional: false, raw: `${first.raw}*` },
+      occurrence: makeOccurrence(numberFromToken(first), Infinity, `${first.raw}*`),
     };
   }
 
   if (first.value === '*' && tokens[1]?.type === 'number') {
     return {
       consumed: 2,
-      occurrence: { min: 0, count: 1, optional: false, raw: `*${tokens[1].raw}` },
+      occurrence: makeOccurrence(0, numberFromToken(tokens[1]), `*${tokens[1].raw}`),
     };
   }
 
   return null;
+}
+
+/** Occurrence with a concrete repeat count that always respects [min, max]. */
+function makeOccurrence(min, max, raw, optional = false) {
+  const lo = Number.isFinite(min) && min >= 0 ? min : 0;
+  const hi = max === Infinity || (Number.isFinite(max) && max >= lo) ? max : lo;
+  const count = Math.max(lo, Math.min(1, hi));
+  return { min: lo, max: hi, count, optional, raw };
+}
+
+/** Repeat count clamped to MAX_REPEAT; exceeding the cap is reported, never silent. */
+function repeatCount(occurrence, ctx) {
+  const wanted = occurrence?.count ?? 1;
+  if (wanted <= MAX_REPEAT) return wanted;
+  ctx.constraintsSatisfied = false;
+  ctx.warnings.push(`Occurrence "${occurrence.raw}" requires ${wanted} items; generated ${MAX_REPEAT} to keep the sample manageable.`);
+  return MAX_REPEAT;
+}
+
+/** True when an optional entry should be omitted for this attempt. */
+function skipOptional(entry, ctx) {
+  return ctx.includeOptional === false && entry?.occurrence?.optional === true;
+}
+
+/** Assign without invoking inherited setters such as `__proto__`. */
+function setMember(object, key, value) {
+  Object.defineProperty(object, key, { value, enumerable: true, writable: true, configurable: true });
+}
+
+/** Object.assign equivalent that is safe for `__proto__` keys. */
+function mergeMembers(target, source) {
+  if (!source || typeof source !== 'object') return target;
+  for (const key of Object.keys(source)) setMember(target, key, source[key]);
+  return target;
 }
 
 function parseKey(tokens) {
@@ -583,6 +657,10 @@ function generateNode(node, key, ctx, depth, visiting, env, label) {
       return generateNode(node.inner, key, ctx, depth + 1, visiting, env, label);
     case 'map': return generateMap(node.entries, ctx, depth + 1, visiting, env);
     case 'array': return generateArray(node.entries, ctx, depth + 1, visiting, env);
+    case 'group':
+      return hasMemberEntries(node.entries)
+        ? generateMap(node.entries, ctx, depth + 1, visiting, env)
+        : generateArray(node.entries, ctx, depth + 1, visiting, env);
     case 'enum': return generateEnum(node.entries, ctx, depth + 1, visiting, env);
     case 'groupMerge': return generateGroupMerge(node.options, ctx, depth + 1, visiting, env);
     case 'enumRef': {
@@ -757,33 +835,55 @@ function generateMap(entries, ctx, depth, visiting, env) {
     if (!entry) continue;
     if (entry.kind === 'groupChoice') {
       ctx.warnings.push('Using first alternative of group choice.');
-      Object.assign(object, generateMap(entry.options[0], ctx, depth + 1, visiting, env));
+      mergeMembers(object, generateMap(entry.options[0], ctx, depth + 1, visiting, env));
       continue;
     }
 
     if (entry.kind === 'group') {
-      Object.assign(object, generateMap(entry.entries, ctx, depth + 1, visiting, env));
+      mergeMembers(object, generateMap(entry.entries, ctx, depth + 1, visiting, env));
       continue;
     }
     if (entry.kind === 'member') {
-      const key = keyToString(entry.key, ctx, depth, visiting, env, entry.arrow);
-      const before = ctx.warnings.length;
-      object[key] = generateNode(entry.value, key, ctx, depth + 1, visiting, env, key);
-      if (entry.occurrence.optional && ctx.warnings.length > before) {
-        ctx.warnings.push(`Optional member "${key}" was included using a heuristic value.`);
+      if (skipOptional(entry, ctx)) continue;
+      const count = repeatCount(entry.occurrence, ctx);
+      for (let i = 0; i < count; i++) {
+        const baseKey = keyToString(entry.key, ctx, depth, visiting, env, entry.arrow);
+        // A map cannot hold duplicate keys, so repeated members need distinct ones.
+        const key = i === 0 ? baseKey : distinctKey(object, baseKey, entry, ctx, i);
+        const before = ctx.warnings.length;
+        setMember(object, key, generateNode(entry.value, key, ctx, depth + 1, visiting, env, key));
+        if (entry.occurrence.optional && ctx.warnings.length > before) {
+          ctx.warnings.push(`Optional member "${key}" was included using a heuristic value.`);
+        }
       }
       continue;
     }
     if (entry.kind === 'element') {
       const value = generateNode(entry.value, null, ctx, depth + 1, visiting, env, null);
-      if (value && typeof value === 'object' && !Array.isArray(value)) Object.assign(object, value);
+      if (value && typeof value === 'object' && !Array.isArray(value)) mergeMembers(object, value);
       else if (value !== null) {
         ctx.warnings.push('Group entry did not produce an object member; stored it under "value".');
-        object.value = value;
+        setMember(object, 'value', value);
       }
     }
   }
   return object;
+}
+
+/** A key not already present, for repeated map members. Literal keys cannot repeat. */
+function distinctKey(object, baseKey, entry, ctx, index) {
+  if (entry.key?.kind === 'literal') {
+    ctx.constraintsSatisfied = false;
+    ctx.warnings.push(`Member "${baseKey}" repeats ${entry.occurrence.raw} times but has a literal key; a JSON object cannot hold duplicates.`);
+    return baseKey;
+  }
+  let candidate = `${baseKey}${index + 1}`;
+  let suffix = index + 1;
+  while (Object.prototype.hasOwnProperty.call(object, candidate)) {
+    suffix += 1;
+    candidate = `${baseKey}${suffix}`;
+  }
+  return candidate;
 }
 
 function generateGroupMerge(options, ctx, depth, visiting, env) {
@@ -801,14 +901,43 @@ function generateArray(entries, ctx, depth, visiting, env) {
       array.push(...generateArray(entry.options[0], ctx, depth + 1, visiting, env));
       continue;
     }
-    const count = Math.max(1, Math.min(entry.occurrence?.count ?? 1, 10));
+    if (skipOptional(entry, ctx)) continue;
+    const count = repeatCount(entry.occurrence, ctx);
     for (let i = 0; i < count; i++) {
       if (entry.kind === 'member') array.push(generateNode(entry.value, keyToString(entry.key, ctx, depth, visiting, env, entry.arrow), ctx, depth + 1, visiting, env, null));
       else if (entry.kind === 'group') array.push(...generateArray(entry.entries, ctx, depth + 1, visiting, env));
-      else array.push(generateNode(entry.value, null, ctx, depth + 1, visiting, env, null));
+      else {
+        // A group reference contributes its entries to the array, not a nested array.
+        const group = resolveGroupNode(entry.value, ctx, env, new Set());
+        if (group) array.push(...generateArray(group.entries, ctx, depth + 1, visiting, env));
+        else array.push(generateNode(entry.value, null, ctx, depth + 1, visiting, env, null));
+      }
     }
   }
   return array;
+}
+
+/** True when entries describe map members rather than array elements. */
+function hasMemberEntries(entries) {
+  return (entries || []).some((entry) => {
+    if (!entry) return false;
+    if (entry.kind === 'member') return true;
+    if (entry.kind === 'group') return hasMemberEntries(entry.entries);
+    if (entry.kind === 'groupChoice') return entry.options.some(hasMemberEntries);
+    return false;
+  });
+}
+
+/** Follow references to an inline group definition, or null when it is not one. */
+function resolveGroupNode(node, ctx, env, seen) {
+  if (!node) return null;
+  if (node.kind === 'group') return hasMemberEntries(node.entries) ? null : node;
+  if (node.kind !== 'ref' || node.args.length > 0) return null;
+  if (env?.has(node.name)) return resolveGroupNode(env.get(node.name), ctx, env, seen);
+  if (seen.has(node.name)) return null;
+  seen.add(node.name);
+  const rule = ctx.model.rules.get(node.name);
+  return rule && rule.params.length === 0 ? resolveGroupNode(rule.node, ctx, env, seen) : null;
 }
 
 function generateEnum(entries, ctx, depth, visiting, env) {

--- a/www/src/sample-gen.js
+++ b/www/src/sample-gen.js
@@ -974,7 +974,7 @@ function resolveGroupNode(node, ctx, env, seen, visiting) {
   if (rule.params.length === 0) return resolveGroupNode(rule.node, ctx, env, seen, visiting);
   const nextEnv = new Map(env || []);
   rule.params.forEach((param, index) => {
-    if (node.args[index]) nextEnv.set(param, node.args[index]);
+    if (node.args?.[index]) nextEnv.set(param, node.args[index]);
   });
   return resolveGroupNode(rule.node, ctx, nextEnv, seen, visiting);
 }

--- a/www/src/sample-gen.js
+++ b/www/src/sample-gen.js
@@ -6,6 +6,9 @@ const MAX_DEPTH = 32;
 const MAX_NODES = 5000;
 /** Upper bound on repeated occurrences; schemas demanding more fail explicitly. */
 const MAX_REPEAT = 64;
+/** Structural limits that keep hostile shared links from freezing the tab. */
+const MAX_NESTING = 64;
+const MAX_TOKENS = 20000;
 const BUILTINS = new Set([
   'any', 'uint', 'nint', 'int', 'integer', 'unsigned', 'number', 'float', 'float16',
   'float32', 'float64', 'float16-32', 'float32-64', 'bool', 'true', 'false', 'nil',
@@ -124,8 +127,32 @@ function generateOnce(source, rootRuleName, includeOptional) {
   }
 }
 
+/**
+ * Reject pathological input before the recursive-descent parser touches it.
+ * A shared permalink is attacker-controlled, and parseExpression recurses per
+ * nesting level, so deep nesting is a cheap way to freeze the tab.
+ */
+function assertParseable(tokens) {
+  if (tokens.length > MAX_TOKENS) {
+    throw new Error(`Schema is too large to analyze (${tokens.length} tokens).`);
+  }
+
+  let depth = 0;
+  for (const token of tokens) {
+    if (['{', '[', '(', '<'].includes(token.value)) {
+      depth += 1;
+      if (depth > MAX_NESTING) {
+        throw new Error(`Schema nesting is too deep to analyze (over ${MAX_NESTING} levels).`);
+      }
+    } else if (['}', ']', ')', '>'].includes(token.value)) {
+      depth -= 1;
+    }
+  }
+}
+
 function parseSource(source) {
   const tokens = tokenize(source);
+  assertParseable(tokens);
   const rules = new Map();
   const order = [];
   let pos = 0;

--- a/www/src/sample-gen.js
+++ b/www/src/sample-gen.js
@@ -856,8 +856,8 @@ function stringForKey(key) {
   return 'string';
 }
 
-function generateMap(entries, ctx, depth, visiting, env) {
-  const object = {};
+function generateMap(entries, ctx, depth, visiting, env, target) {
+  const object = target || {};
   for (const entry of entries) {
     if (!entry) continue;
     if (entry.kind === 'groupChoice') {
@@ -867,7 +867,10 @@ function generateMap(entries, ctx, depth, visiting, env) {
     }
 
     if (entry.kind === 'group') {
-      mergeMembers(object, generateMap(entry.entries, ctx, depth + 1, visiting, env));
+      if (skipOptional(entry, ctx)) continue;
+      const count = repeatCount(entry.occurrence, ctx);
+      // Repeated groups generate into the same object so dynamic keys stay distinct.
+      for (let i = 0; i < count; i++) generateMap(entry.entries, ctx, depth + 1, visiting, env, object);
       continue;
     }
     if (entry.kind === 'member') {
@@ -876,7 +879,8 @@ function generateMap(entries, ctx, depth, visiting, env) {
       for (let i = 0; i < count; i++) {
         const baseKey = keyToString(entry.key, ctx, depth, visiting, env, entry.arrow);
         // A map cannot hold duplicate keys, so repeated members need distinct ones.
-        const key = i === 0 ? baseKey : distinctKey(object, baseKey, entry, ctx, i);
+        const taken = Object.prototype.hasOwnProperty.call(object, baseKey);
+        const key = i === 0 && !taken ? baseKey : distinctKey(object, baseKey, entry, ctx, i);
         const before = ctx.warnings.length;
         setMember(object, key, generateNode(entry.value, key, ctx, depth + 1, visiting, env, key));
         if (entry.occurrence.optional && ctx.warnings.length > before) {
@@ -901,7 +905,8 @@ function generateMap(entries, ctx, depth, visiting, env) {
 function distinctKey(object, baseKey, entry, ctx, index) {
   if (entry.key?.kind === 'literal') {
     ctx.constraintsSatisfied = false;
-    ctx.warnings.push(`Member "${baseKey}" repeats ${entry.occurrence.raw} times but has a literal key; a JSON object cannot hold duplicates.`);
+    const repeats = entry.occurrence.raw ? `repeats ${entry.occurrence.raw} times` : 'occurs more than once';
+    ctx.warnings.push(`Member "${baseKey}" ${repeats} but has a literal key; a JSON object cannot hold duplicates.`);
     return baseKey;
   }
   let candidate = `${baseKey}${index + 1}`;

--- a/www/src/share.js
+++ b/www/src/share.js
@@ -6,6 +6,10 @@ export const MAX_SHARE_BYTES = 32000;
 
 const SHARE_PREFIX = 's1=';
 
+function byteLength(text) {
+  return typeof text === 'string' ? new TextEncoder().encode(text).length : 0;
+}
+
 // ─── UTF-8 Base64url ─────────────────────────────────────────────────────────
 
 function bytesToBase64(bytes) {
@@ -102,12 +106,22 @@ export function decodeState(hash) {
       return null;
     }
 
+    // Enforce the size ceiling on the way in too: a link can be hand-crafted, so
+    // trusting only the encode-side check leaves the decoder unbounded.
+    if (payload.length > MAX_SHARE_BYTES) {
+      return null;
+    }
+
     const json = fromBase64Url(payload);
     if (json === null) {
       return null;
     }
 
-    return expandState(JSON.parse(json));
+    const state = expandState(JSON.parse(json));
+    if (state && byteLength(state.cddl) + byteLength(state.instance) > MAX_SHARE_BYTES) {
+      return null;
+    }
+    return state;
   } catch (err) {
     return null;
   }


### PR DESCRIPTION
# Fix the defects the PR #700 review surfaced

Follow-up to #700 (merged as `72aa708`). Branch: `www/playground-ux-fixes`. Scope: `www/` only — three JS files, zero Rust.

Everything below was measured against the **real wasm validator**, not reasoned about. That matters because #700 shipped a sub-agent's faked verification (it asserted `JSON.parse()` succeeded and called that "validated"), and that exact failure mode recurred twice more while doing this work.

## What changed

### 1. The sample generator now uses the validator as its success criterion (`5eed986`)
`generateSample()` takes an optional `validate` callback, tries `includeOptional: true` then `false`, and returns the first candidate that **actually validates**. New `verified` / `validationError` fields. `www/index.js` wires in the real `validateInstance` call with the selected root rule.

Also fixed in the generator:
- **Occurrence bounds were ignored.** `readOccurrence` discarded the max. `0*0` produced one element instead of `[]`; `11*20` produced 1 instead of 11.
- **Parenthesized groups collapsed to their first entry.** `(a: int, b: int)` generated only `a`.
- **`__proto__` as a map key** silently corrupted the object. Members now go through `defineProperty`.
- Repeated map members collided on the same key.

| | before | after |
|---|---|---|
| Synthetic schema suite (27) | 20 pass / 7 fail | **26 pass / 1 fail** |
| Bundled examples (16) | 11 validate / 5 CBOR-only / 0 fail | **unchanged, zero diffs** |

The one remaining failure is `tstr .regexp "^x+$"` — correctly reported as `verified: false` with the validator's own message rather than presented as a good sample.

### 2. Hostile share links no longer freeze the page at boot (`94d44cf`)
`decodeState` parsed whatever the fragment contained before checking its size. A crafted permalink was a trivial DoS, and it was worse than the review reported:

| link | before | after |
|---|---|---|
| depth 8000 (21 KB) | 2001 ms, accepted | **3 ms** |
| depth 20000 (53 KB) | 6653 ms, accepted | **rejected on decode** |

Added a decode-side byte cap plus `MAX_NESTING` / `MAX_TOKENS` limits in the parser.

### 3. Validation results produced before wasm was ready got cached (`862740d`)
`runValidation()` short-circuited on `input === lastInput`, but assigned `lastInput` unconditionally — including on the early run that fires before the wasm module resolves. That run produces a "not ready" stub, poisons the cache, and the schema stays unvalidated **until the user types another character**. Caching now keys off a separate `lastValidatedInput` that is only set when a real result was produced.

### 4. Removed a false instruction (`862740d`)
The CBOR-only branch told users to "Switch to the CBOR tab for this one." The generator emits no CBOR, so that tab does nothing for them. It now says plainly that the sample is a structural reference and an equivalent CBOR document must be encoded to validate it.

**Deliberately not shipped:** a real CBOR encoder. Building one half-verified would repeat exactly the sin this PR exists to fix. Filed as future work.

### 5. Two warning toasts stacked for the same cause (`5f05848`)
Caught in browser verification, not in review.

## Three review findings I did NOT act on — and why

- **`.gt` control operator is broken.** It isn't. `boundedNumber` correctly returns `limit + 1`; `.gt` generates `11` and validates. False positive.
- **Malformed CBOR is misclassified.** It isn't. `ff`, `1c`, `9f`, `3b`, and `zz` all already return `title: "Invalid CBOR input"`. The existing `CBOR_DECODE_ERROR` regex covers it. **Do not "fix" this.**
- **Rank unreferenced rules first when picking a root.** This one was *actively harmful* and I reverted it after measuring. RFC 8610 §3.1 makes the **first** rule the root. The proposed change broke *Arrays & Ranges* (picked `rgb` over `color`), *Generics* (`user-page` over `user`), and *COSE Key* (`label` → generated a bare `0`). Bundled examples went 11/5/0 → 9/4/3. The original heuristic beat it on every real example. `listRootCandidates` is unchanged, now with a comment explaining why.

## How to try it locally

```bash
git checkout www/playground-ux-fixes
cd www && npm install && npm run build && npm start
```

Then:
1. Type `person = { name: tstr, age: uint }` — status goes **Valid** with no extra keystroke (fix #3).
2. Open the instance pane, click **Generate** — you get `{"name": "example name", "age": 1}` and a single success toast.
3. Click **Validate** → *Instance is valid. No failures.*
4. Change `"age"` to `"not-a-number"`, Validate → */age: expected type uint, got "not-a-number"*.
5. Try `m = { 1: bstr, 2: uint }` and Generate → the corrected CBOR-only message, once.

## Verification performed

- ✅ Production webpack build compiles (only the pre-existing asset-size warning).
- ✅ Real headless Chromium against the built `dist/`: all five steps above, both themes, 380px viewport (`scrollWidth === innerWidth`, no app-chrome overflow), hostile permalink boots in **159 ms**. **Zero console errors.**
- ✅ Synthetic suite 26/27 and bundled examples byte-identical, both against the real wasm validator.

## CI

All four workflows green on `f480a2e` — **Build and Test** [run 32152874533](https://github.com/anweiss/cddl/actions/runs/32152874533) (12/12 jobs: msrv ×3, compilation-check ×3, wasm-compilation-check, test-suite ×2, wasm-test-suite, style-linting, wasm-style-linting), plus CodeQL and Build and Test LSP Extension.

`style-linting` and `wasm-style-linting` cover `cargo fmt --check` and `clippy`, which I could not run locally — CI confirms them clean.

## Noted

The local production build was run by invoking `node_modules/webpack-cli` directly (npm was unavailable in my environment), so the `prebuild`/`wasm-pack` step did not re-run; it used the existing `pkg/`. The diff touches no Rust, so the wasm artifact is unchanged either way, and CI's `wasm-compilation-check` and `wasm-test-suite` both pass.
