### PR TITLE
fix(www): CBOR tab buffer, real autocomplete, and the invisible Examples dropdown

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -98,8 +98,14 @@
       background: var(--bg-elevated);
       border-bottom: 1px solid var(--border);
       flex-shrink: 0;
+      /* position:relative so the z-index below actually applies — without it
+         the outline pane paints over the Examples dropdown. */
+      position: relative;
       z-index: 10;
-      overflow: hidden;
+      /* Clip horizontally so a crowded toolbar never creates a page scrollbar,
+         but stay visible vertically so the Examples dropdown can drop below. */
+      overflow-x: clip;
+      overflow-y: visible;
     }
 
     .topbar-left {
@@ -203,7 +209,11 @@
       gap: 0.5rem;
       min-width: 0;
       flex: 1 1 auto;
-      overflow: hidden;
+      /* No clipping here: the Examples dropdown is anchored inside this row but
+         extends to its left, so clipping here would cut the dropdown off. The
+         parent .topbar still clips horizontally, which is what prevents a page
+         scrollbar when the toolbar is crowded. */
+      overflow: visible;
       white-space: nowrap;
     }
 

--- a/www/index.js
+++ b/www/index.js
@@ -1380,12 +1380,15 @@ function clearInstanceResult() {
   if (!instanceResult) return;
   instanceResult.textContent = '';
   instanceResult.classList.remove('ok', 'fail');
-  instanceResult.hidden = true;
+  // Restore the seeded placeholder rather than leaving an empty box behind.
+  const empty = document.createElement('div');
+  empty.className = 'instance-result-empty';
+  empty.textContent = 'Validation results will appear here.';
+  instanceResult.appendChild(empty);
 }
 
 function renderInstanceResult(result) {
   if (!instanceResult) return;
-  instanceResult.hidden = false;
   instanceResult.textContent = '';
   instanceResult.classList.remove('ok', 'fail');
   instanceResult.classList.add(result.ok ? 'ok' : 'fail');

--- a/www/index.js
+++ b/www/index.js
@@ -155,7 +155,7 @@ monaco.languages.registerCompletionItemProvider('cddl', {
     if (completionContext(linePrefix) === 'control') {
       // Extend the replaced range back over the leading `.` so inserting
       // `.size` does not produce `..size`.
-      const dot = /\.[A-Za-z]*$/.exec(linePrefix);
+      const dot = /\.[A-Za-z0-9-]*$/.exec(linePrefix);
       if (dot) startColumn = dot.index + 1;
     }
     const range = {

--- a/www/index.js
+++ b/www/index.js
@@ -6,6 +6,7 @@ import { parseRules, renderOutline, registerNavigation } from './src/outline.js'
 import { generateSample, listRootCandidates } from './src/sample-gen.js';
 import { initToasts, toast } from './src/toast.js';
 import { initShortcutsModal } from './src/shortcuts.js';
+import { buildSuggestions, completionContext } from './src/cddl-completion.js';
 
 // ─── CDDL Language Registration ───────────────────────────────────────────────
 
@@ -129,29 +130,51 @@ monaco.editor.defineTheme('cddl-light', {
   },
 });
 
-// Autocomplete for common CDDL types
+// Autocomplete: rule/group names from the live buffer, the full RFC 8610
+// prelude, and control operators after a `.`.
+const COMPLETION_KIND = {
+  rule: () => monaco.languages.CompletionItemKind.Struct,
+  prelude: () => monaco.languages.CompletionItemKind.Keyword,
+  control: () => monaco.languages.CompletionItemKind.Operator,
+};
+
 monaco.languages.registerCompletionItemProvider('cddl', {
-  provideCompletionItems: () => {
-    const types = [
-      ['tstr', 'Text string'],
-      ['bstr', 'Byte string'],
-      ['uint', 'Unsigned integer'],
-      ['int', 'Integer'],
-      ['float', 'Floating point number'],
-      ['bool', 'Boolean'],
-      ['null', 'Null value'],
-      ['any', 'Any value'],
-      ['text', 'Text string (alias for tstr)'],
-      ['bytes', 'Byte string (alias for bstr)'],
-    ];
-    return {
-      suggestions: types.map(([label, doc]) => ({
-        label,
-        kind: monaco.languages.CompletionItemKind.Keyword,
-        insertText: label,
-        documentation: doc,
-      })),
+  // `.` is not part of Monaco's default word pattern, so without this the
+  // provider is never invoked for control operators.
+  triggerCharacters: ['.'],
+  provideCompletionItems: (model, position) => {
+    const linePrefix = model.getValueInRange({
+      startLineNumber: position.lineNumber,
+      startColumn: 1,
+      endLineNumber: position.lineNumber,
+      endColumn: position.column,
+    });
+
+    const word = model.getWordUntilPosition(position);
+    let startColumn = word.startColumn;
+    if (completionContext(linePrefix) === 'control') {
+      // Extend the replaced range back over the leading `.` so inserting
+      // `.size` does not produce `..size`.
+      const dot = /\.[A-Za-z]*$/.exec(linePrefix);
+      if (dot) startColumn = dot.index + 1;
+    }
+    const range = {
+      startLineNumber: position.lineNumber,
+      endLineNumber: position.lineNumber,
+      startColumn,
+      endColumn: position.column,
     };
+
+    const suggestions = buildSuggestions(model.getValue(), linePrefix).map((s) => ({
+      label: s.label,
+      kind: (COMPLETION_KIND[s.group] || COMPLETION_KIND.prelude)(),
+      insertText: s.insertText,
+      detail: s.detail,
+      documentation: s.documentation,
+      sortText: s.sortText,
+      range,
+    }));
+    return { suggestions };
   },
 });
 

--- a/www/index.js
+++ b/www/index.js
@@ -898,11 +898,14 @@ let problemsPanel, problemsBadge, problemsBody, problemsEmpty;
 let cursorPosition;
 
 const INSTANCE_TEXT_CACHE_KEY = 'cddl-playground-instance-text';
+const INSTANCE_TEXT_CBOR_CACHE_KEY = 'cddl-playground-instance-text-cbor';
 const INSTANCE_KIND_CACHE_KEY = 'cddl-playground-instance-kind';
 const INSTANCE_PANE_CACHE_KEY = 'cddl-playground-instance-open';
 const OUTLINE_PANE_CACHE_KEY = 'cddl-playground-outline-open';
 
 let instanceKind = 'json';
+// One buffer per instance kind — switching tabs must not carry text over.
+let instanceTexts = { json: '', cbor: '' };
 let instancePane, instanceToggleBtn, instanceResult, instanceRootRule;
 let instanceTabJson, instanceTabCbor, instanceCborHint;
 let outlinePane, outlineToggleBtn, outlineFilter, outlineList;
@@ -1284,12 +1287,25 @@ function toMarker(model, err) {
 
 // ─── Instance Validation ─────────────────────────────────────────────────────
 
-function loadInstanceText(sharedState) {
-  if (sharedState) return typeof sharedState.instance === 'string' ? sharedState.instance : '';
+function loadInstanceTexts(sharedState, kind) {
+  const texts = { json: '', cbor: '' };
+  if (sharedState) {
+    texts[kind] = typeof sharedState.instance === 'string' ? sharedState.instance : '';
+    return texts;
+  }
   try {
-    return localStorage.getItem(INSTANCE_TEXT_CACHE_KEY) || '';
+    // The legacy single-buffer key predates per-kind buffers. If the user was
+    // last on the CBOR tab and no CBOR buffer exists yet, that text is CBOR.
+    const legacy = localStorage.getItem(INSTANCE_TEXT_CACHE_KEY) || '';
+    const cbor = localStorage.getItem(INSTANCE_TEXT_CBOR_CACHE_KEY);
+    if (cbor === null && kind === 'cbor') {
+      texts.cbor = legacy;
+    } else {
+      texts.json = legacy;
+      texts.cbor = cbor || '';
+    }
   } catch (_) {}
-  return '';
+  return texts;
 }
 
 function loadInstanceKind(sharedState) {
@@ -1303,7 +1319,11 @@ function loadInstanceKind(sharedState) {
 
 function saveInstanceState() {
   try {
-    if (instanceEditor) localStorage.setItem(INSTANCE_TEXT_CACHE_KEY, instanceEditor.getValue());
+    if (instanceEditor) {
+      instanceTexts[instanceKind] = instanceEditor.getValue();
+      localStorage.setItem(INSTANCE_TEXT_CACHE_KEY, instanceTexts.json);
+      localStorage.setItem(INSTANCE_TEXT_CBOR_CACHE_KEY, instanceTexts.cbor);
+    }
     localStorage.setItem(INSTANCE_KIND_CACHE_KEY, instanceKind);
     if (instancePane) localStorage.setItem(INSTANCE_PANE_CACHE_KEY, String(!instancePane.classList.contains('collapsed')));
   } catch (_) {}
@@ -1320,7 +1340,15 @@ function layoutPlaygroundEditors() {
 }
 
 function setInstanceKind(kind) {
-  instanceKind = kind === 'cbor' ? 'cbor' : 'json';
+  const next = kind === 'cbor' ? 'cbor' : 'json';
+  const previous = instanceKind;
+  const switching = next !== previous;
+
+  // JSON and CBOR are different documents, not two views of one. Stash the
+  // outgoing buffer before swapping so switching tabs never carries text over.
+  if (switching && instanceEditor) instanceTexts[previous] = instanceEditor.getValue();
+
+  instanceKind = next;
   if (instanceTabJson) {
     instanceTabJson.classList.toggle('active', instanceKind === 'json');
     instanceTabJson.setAttribute('aria-selected', String(instanceKind === 'json'));
@@ -1338,12 +1366,26 @@ function setInstanceKind(kind) {
   }
   if (instanceEditor?.getModel()) {
     monaco.editor.setModelLanguage(instanceEditor.getModel(), instanceKind === 'json' ? 'json' : 'plaintext');
+    if (switching) {
+      const restored = instanceTexts[instanceKind] || '';
+      if (instanceEditor.getValue() !== restored) instanceEditor.setValue(restored);
+    }
   }
+  // A stale result from the other tab is misleading once the buffer changes.
+  if (switching) clearInstanceResult();
   saveInstanceState();
+}
+
+function clearInstanceResult() {
+  if (!instanceResult) return;
+  instanceResult.textContent = '';
+  instanceResult.classList.remove('ok', 'fail');
+  instanceResult.hidden = true;
 }
 
 function renderInstanceResult(result) {
   if (!instanceResult) return;
+  instanceResult.hidden = false;
   instanceResult.textContent = '';
   instanceResult.classList.remove('ok', 'fail');
   instanceResult.classList.add(result.ok ? 'ok' : 'fail');
@@ -1435,10 +1477,22 @@ function generateCurrentSample() {
   }
   let warnedAlready = false;
   if (result.json !== null) {
+    // The sample generator emits JSON only. If the user is on the CBOR tab,
+    // say so instead of silently swapping the tab out from under them — their
+    // CBOR buffer is preserved by setInstanceKind.
+    const cameFromCbor = instanceKind === 'cbor';
     setInstanceKind('json');
     instanceEditor.setValue(result.json);
     saveInstanceState();
     toggleInstancePane(true);
+    if (cameFromCbor) {
+      toast(
+        'The sample generator produces JSON, so the JSON tab was selected. Your CBOR input is preserved on the CBOR tab.',
+        'warning',
+        7000,
+      );
+      warnedAlready = true;
+    }
     if (result.jsonRepresentable === false) {
       toast(
         'This schema uses CBOR-only features (integer keys, byte strings, or tags). The sample shows the expected structure but cannot validate as JSON — encode an equivalent CBOR document to validate it.',
@@ -1481,8 +1535,9 @@ function initInstanceFeature(sharedState) {
     if (!container) return;
 
     instanceKind = loadInstanceKind(sharedState);
+    instanceTexts = loadInstanceTexts(sharedState, instanceKind);
     instanceEditor = monaco.editor.create(container, {
-      value: loadInstanceText(sharedState),
+      value: instanceTexts[instanceKind] || '',
       language: instanceKind === 'json' ? 'json' : 'plaintext',
       theme: isDark ? 'cddl-dark' : 'cddl-light',
       fontSize: 14,

--- a/www/src/cddl-completion.js
+++ b/www/src/cddl-completion.js
@@ -1,0 +1,168 @@
+// ─── CDDL Completion Data ─────────────────────────────────────────────────────
+//
+// Suggestion sources for the CDDL editor's autocomplete:
+//   1. Rule and group names defined in the live buffer.
+//   2. The full RFC 8610 Appendix D standard prelude.
+//   3. Control operators (RFC 8610 §3.8 plus RFC 9165 additions).
+//
+// Pure data + string manipulation; no Monaco imports so this stays unit-testable
+// and lets `index.js` own the `registerCompletionItemProvider` wiring.
+
+/** RFC 8610 Appendix D — the standard prelude, in spec order. */
+export const PRELUDE_TYPES = [
+  ['any', 'Any single data item'],
+  ['uint', 'Unsigned integer (major type 0)'],
+  ['nint', 'Negative integer (major type 1)'],
+  ['int', 'Integer — uint / nint'],
+  ['bstr', 'Byte string (major type 2)'],
+  ['bytes', 'Byte string — alias for bstr'],
+  ['tstr', 'Text string (major type 3)'],
+  ['text', 'Text string — alias for tstr'],
+  ['tdate', 'RFC 3339 date/time string (tag 0)'],
+  ['time', 'Epoch-based date/time (tag 1)'],
+  ['number', 'int / float'],
+  ['biguint', 'Unsigned bignum (tag 2)'],
+  ['bignint', 'Negative bignum (tag 3)'],
+  ['bigint', 'biguint / bignint'],
+  ['integer', 'int / bigint'],
+  ['unsigned', 'uint / biguint'],
+  ['decfrac', 'Decimal fraction (tag 4)'],
+  ['bigfloat', 'Bigfloat (tag 5)'],
+  ['eb64url', 'Expected base64url encoding (tag 21)'],
+  ['eb64legacy', 'Expected base64 encoding (tag 22)'],
+  ['eb16', 'Expected base16 encoding (tag 23)'],
+  ['encoded-cbor', 'Encoded CBOR data item (tag 24)'],
+  ['uri', 'URI text string (tag 32)'],
+  ['b64url', 'base64url-encoded text (tag 33)'],
+  ['b64legacy', 'base64-encoded text (tag 34)'],
+  ['regexp', 'Regular expression text (tag 35)'],
+  ['mime-message', 'MIME message text (tag 36)'],
+  ['cbor-any', 'Self-described CBOR (tag 55799)'],
+  ['float16', 'IEEE 754 half-precision float'],
+  ['float32', 'IEEE 754 single-precision float'],
+  ['float64', 'IEEE 754 double-precision float'],
+  ['float16-32', 'float16 / float32'],
+  ['float32-64', 'float32 / float64'],
+  ['float', 'Any IEEE 754 float'],
+  ['false', 'Boolean false (simple value 20)'],
+  ['true', 'Boolean true (simple value 21)'],
+  ['bool', 'false / true'],
+  ['nil', 'Null (simple value 22)'],
+  ['null', 'Null — alias for nil'],
+  ['undefined', 'Undefined (simple value 23)'],
+];
+
+/** Control operators — RFC 8610 §3.8, plus `.cborseq` and RFC 9165 `.b64u` family. */
+export const CONTROL_OPERATORS = [
+  ['.size', 'Constrain the size in bytes (or integer range)', 'tstr .size 12'],
+  ['.bits', 'Constrain which bits may be set', 'uint .bits flags'],
+  ['.regexp', 'Constrain a text string by XSD regular expression', 'tstr .regexp "[a-z]+"'],
+  ['.cbor', 'The byte string carries an embedded CBOR data item', 'bstr .cbor header'],
+  ['.cborseq', 'The byte string carries a CBOR sequence', 'bstr .cborseq item'],
+  ['.within', 'Constrain to a subset of another type', 'uint .within 0..255'],
+  ['.and', 'Value must match both types', 'uint .and my-range'],
+  ['.lt', 'Numerically less than', 'uint .lt 10'],
+  ['.le', 'Numerically less than or equal to', 'uint .le 10'],
+  ['.gt', 'Numerically greater than', 'uint .gt 10'],
+  ['.ge', 'Numerically greater than or equal to', 'uint .ge 10'],
+  ['.eq', 'Equal to the control value', 'tstr .eq "yes"'],
+  ['.ne', 'Not equal to the control value', 'uint .ne 0'],
+  ['.default', 'Declare a default value for an optional entry', 'uint .default 0'],
+];
+
+const PRELUDE_NAMES = new Set(PRELUDE_TYPES.map(([name]) => name));
+
+// A CDDL rule/group definition at the start of a line:
+//   name = ...   name<a, b> = ...   name /= ...   name //= ...
+// Rule names may contain letters, digits, and `.`/`-`/`_`/`@`/`$` after the
+// first character (RFC 8610 §3.1).
+const RULE_DEF = /^[ \t]*([A-Za-z@_$][A-Za-z0-9@_$.\-]*)[ \t]*(<[^>\n]*>)?[ \t]*(\/\/=|\/=|=)(?!=)/gm;
+
+/**
+ * Extract rule and group names defined in a CDDL buffer.
+ * Returns `[{ name, generic, definition }]` in first-definition order.
+ */
+export function extractRuleNames(text) {
+  if (typeof text !== 'string' || text.length === 0) return [];
+  const seen = new Map();
+  RULE_DEF.lastIndex = 0;
+  let match;
+  while ((match = RULE_DEF.exec(text)) !== null) {
+    const name = match[1];
+    if (seen.has(name)) continue;
+    const lineEnd = text.indexOf('\n', match.index);
+    const line = text.slice(match.index, lineEnd === -1 ? text.length : lineEnd).trim();
+    seen.set(name, {
+      name,
+      generic: match[2] || '',
+      definition: line.length > 120 ? `${line.slice(0, 117)}…` : line,
+    });
+  }
+  return [...seen.values()];
+}
+
+/**
+ * Decide what to offer given the text on the current line up to the cursor.
+ * After a `.` (optionally followed by a partial word) only control operators
+ * make sense; everywhere else offer rule names and prelude types.
+ */
+export function completionContext(linePrefix) {
+  const prefix = typeof linePrefix === 'string' ? linePrefix : '';
+  // `.` immediately after whitespace or an identifier, then an optional partial.
+  if (/(^|[\s\])}])\.[A-Za-z]*$/.test(prefix) || /[A-Za-z0-9_)\]}"']\s*\.[A-Za-z]*$/.test(prefix)) {
+    // A `.` that is part of an identifier (e.g. `my.rule`) is not an operator,
+    // but `foo .si` is. Require whitespace before the dot unless the line is
+    // only the dot so far.
+    if (/\s\.[A-Za-z]*$/.test(prefix) || /^\s*\.[A-Za-z]*$/.test(prefix)) return 'control';
+  }
+  return 'type';
+}
+
+/**
+ * Build plain suggestion descriptors. `index.js` maps these onto Monaco's
+ * `CompletionItem` shape so this module never imports the editor.
+ *
+ * @param {string} text        full buffer contents
+ * @param {string} linePrefix  text on the current line before the cursor
+ * @param {string} [selfRule]  rule currently being defined; excluded from output
+ */
+export function buildSuggestions(text, linePrefix, selfRule) {
+  const kind = completionContext(linePrefix);
+  if (kind === 'control') {
+    return CONTROL_OPERATORS.map(([label, doc, example]) => ({
+      label,
+      // Monaco has already consumed the leading `.` as part of the word, so
+      // insert the operator without it and let the range replacement handle it.
+      insertText: label,
+      detail: 'control operator',
+      documentation: `${doc}\n\nExample: ${example}`,
+      group: 'control',
+      sortText: `0${label}`,
+    }));
+  }
+
+  const suggestions = [];
+  for (const rule of extractRuleNames(text)) {
+    if (rule.name === selfRule) continue;
+    if (PRELUDE_NAMES.has(rule.name)) continue;
+    suggestions.push({
+      label: rule.name,
+      insertText: rule.name,
+      detail: rule.generic ? `rule ${rule.generic}` : 'rule',
+      documentation: rule.definition,
+      group: 'rule',
+      sortText: `0${rule.name}`,
+    });
+  }
+  for (const [label, doc] of PRELUDE_TYPES) {
+    suggestions.push({
+      label,
+      insertText: label,
+      detail: 'prelude',
+      documentation: doc,
+      group: 'prelude',
+      sortText: `1${label}`,
+    });
+  }
+  return suggestions;
+}

--- a/www/src/cddl-completion.js
+++ b/www/src/cddl-completion.js
@@ -102,19 +102,40 @@ export function extractRuleNames(text) {
 }
 
 /**
+ * Is the cursor inside a comment or an unterminated text literal on this line?
+ * CDDL comments run from an unquoted `;` to end of line (RFC 8610 §2), so a
+ * single left-to-right scan tracking quote state is enough.
+ */
+export function inCommentOrString(linePrefix) {
+  const prefix = typeof linePrefix === 'string' ? linePrefix : '';
+  let inString = false;
+  for (let i = 0; i < prefix.length; i++) {
+    const ch = prefix[i];
+    if (inString) {
+      if (ch === '\\') i++;
+      else if (ch === '"') inString = false;
+    } else if (ch === '"') {
+      inString = true;
+    } else if (ch === ';') {
+      return true;
+    }
+  }
+  return inString;
+}
+
+/**
  * Decide what to offer given the text on the current line up to the cursor.
  * After a `.` (optionally followed by a partial word) only control operators
- * make sense; everywhere else offer rule names and prelude types.
+ * make sense; everywhere else offer rule names and prelude types. Comments and
+ * string literals get nothing.
+ *
+ * Whitespace is what separates a control operator from a rule name containing a
+ * dot: `foo .size` is an operator, `my.rule` is one identifier.
  */
 export function completionContext(linePrefix) {
   const prefix = typeof linePrefix === 'string' ? linePrefix : '';
-  // `.` immediately after whitespace or an identifier, then an optional partial.
-  if (/(^|[\s\])}])\.[A-Za-z]*$/.test(prefix) || /[A-Za-z0-9_)\]}"']\s*\.[A-Za-z]*$/.test(prefix)) {
-    // A `.` that is part of an identifier (e.g. `my.rule`) is not an operator,
-    // but `foo .si` is. Require whitespace before the dot unless the line is
-    // only the dot so far.
-    if (/\s\.[A-Za-z]*$/.test(prefix) || /^\s*\.[A-Za-z]*$/.test(prefix)) return 'control';
-  }
+  if (inCommentOrString(prefix)) return 'none';
+  if (/\s\.[A-Za-z]*$/.test(prefix) || /^\s*\.[A-Za-z]*$/.test(prefix)) return 'control';
   return 'type';
 }
 
@@ -128,6 +149,7 @@ export function completionContext(linePrefix) {
  */
 export function buildSuggestions(text, linePrefix, selfRule) {
   const kind = completionContext(linePrefix);
+  if (kind === 'none') return [];
   if (kind === 'control') {
     return CONTROL_OPERATORS.map(([label, doc, example]) => ({
       label,

--- a/www/src/cddl-completion.js
+++ b/www/src/cddl-completion.js
@@ -3,10 +3,13 @@
 // Suggestion sources for the CDDL editor's autocomplete:
 //   1. Rule and group names defined in the live buffer.
 //   2. The full RFC 8610 Appendix D standard prelude.
-//   3. Control operators (RFC 8610 §3.8 plus RFC 9165 additions).
+//   3. Control operators (RFC 8610 §3.8 plus the RFC 9165/9741 and freezer
+//      additions enabled by this playground's default WASM build).
 //
 // Pure data + string manipulation; no Monaco imports so this stays unit-testable
 // and lets `index.js` own the `registerCompletionItemProvider` wiring.
+
+import { parseRules } from './outline.js';
 
 /** RFC 8610 Appendix D — the standard prelude, in spec order. */
 export const PRELUDE_TYPES = [
@@ -52,11 +55,17 @@ export const PRELUDE_TYPES = [
   ['undefined', 'Undefined (simple value 23)'],
 ];
 
-/** Control operators — RFC 8610 §3.8, plus `.cborseq` and RFC 9165 `.b64u` family. */
+/**
+ * Control operators accepted by the playground's WASM build: RFC 8610 §3.8, the
+ * proposed `.pcre` extension, the `freezer` controls, and the RFC 9165/9741
+ * additions (`additional-controls` is a default crate feature).
+ */
 export const CONTROL_OPERATORS = [
   ['.size', 'Constrain the size in bytes (or integer range)', 'tstr .size 12'],
   ['.bits', 'Constrain which bits may be set', 'uint .bits flags'],
   ['.regexp', 'Constrain a text string by XSD regular expression', 'tstr .regexp "[a-z]+"'],
+  ['.pcre', 'Constrain a text string by PCRE regular expression', 'tstr .pcre "^[a-z]+$"'],
+  ['.iregexp', 'Constrain a text string by an I-Regexp (RFC 9485)', 'tstr .iregexp "[0-9]{4}"'],
   ['.cbor', 'The byte string carries an embedded CBOR data item', 'bstr .cbor header'],
   ['.cborseq', 'The byte string carries a CBOR sequence', 'bstr .cborseq item'],
   ['.within', 'Constrain to a subset of another type', 'uint .within 0..255'],
@@ -68,33 +77,48 @@ export const CONTROL_OPERATORS = [
   ['.eq', 'Equal to the control value', 'tstr .eq "yes"'],
   ['.ne', 'Not equal to the control value', 'uint .ne 0'],
   ['.default', 'Declare a default value for an optional entry', 'uint .default 0'],
+  ['.bitfield', 'Validate the bitfield layout of a uint (freezer)', 'uint .bitfield flags'],
+  ['.cat', 'Concatenate the two literals (RFC 9165)', '"a" .cat "b"'],
+  ['.det', 'Concatenate after removing common indentation (RFC 9165)', 'tstr .det doc'],
+  ['.plus', 'Numeric addition of the control value (RFC 9165)', 'uint .plus base'],
+  ['.abnf', 'Text matches the ABNF grammar (RFC 9165)', 'tstr .abnf rulelist'],
+  ['.abnfb', 'Byte string matches the ABNF grammar (RFC 9165)', 'bstr .abnfb rulelist'],
+  ['.feature', 'Mark the type as belonging to a named feature (RFC 9165)', 'tstr .feature "v2"'],
+  ['.b64u', 'base64url (unpadded) encoding of the control type (RFC 9741)', 'tstr .b64u bstr'],
+  ['.b64c', 'base64 classic (padded) encoding of the control type (RFC 9741)', 'tstr .b64c bstr'],
+  ['.b64u-sloppy', 'base64url encoding, padding tolerated (RFC 9741)', 'tstr .b64u-sloppy bstr'],
+  ['.b64c-sloppy', 'base64 classic encoding, padding tolerated (RFC 9741)', 'tstr .b64c-sloppy bstr'],
+  ['.hex', 'base16 encoding in either case (RFC 9741)', 'tstr .hex bstr'],
+  ['.hexlc', 'base16 encoding, lowercase (RFC 9741)', 'tstr .hexlc bstr'],
+  ['.hexuc', 'base16 encoding, uppercase (RFC 9741)', 'tstr .hexuc bstr'],
+  ['.b32', 'base32 encoding of the control type (RFC 9741)', 'tstr .b32 bstr'],
+  ['.h32', 'base32hex encoding of the control type (RFC 9741)', 'tstr .h32 bstr'],
+  ['.b45', 'base45 encoding of the control type (RFC 9741)', 'tstr .b45 bstr'],
+  ['.base10', 'Decimal text representation of an integer (RFC 9741)', 'tstr .base10 int'],
+  ['.printf', 'Text formatted per a printf-style specification (RFC 9741)', 'tstr .printf ["%d", int]'],
+  ['.json', 'Text is the JSON encoding of the control type (RFC 9741)', 'tstr .json my-type'],
+  ['.join', 'Text is the concatenation of an array of literals (RFC 9741)', 'tstr .join parts'],
 ];
 
 const PRELUDE_NAMES = new Set(PRELUDE_TYPES.map(([name]) => name));
 
-// A CDDL rule/group definition at the start of a line:
-//   name = ...   name<a, b> = ...   name /= ...   name //= ...
-// Rule names may contain letters, digits, and `.`/`-`/`_`/`@`/`$` after the
-// first character (RFC 8610 §3.1).
-const RULE_DEF = /^[ \t]*([A-Za-z@_$][A-Za-z0-9@_$.\-]*)[ \t]*(<[^>\n]*>)?[ \t]*(\/\/=|\/=|=)(?!=)/gm;
-
 /**
  * Extract rule and group names defined in a CDDL buffer.
+ * Delegates to the quote- and comment-aware scanner in `outline.js` so literal
+ * content inside comments or (multiline) byte strings is never mistaken for a
+ * rule definition.
  * Returns `[{ name, generic, definition }]` in first-definition order.
  */
 export function extractRuleNames(text) {
   if (typeof text !== 'string' || text.length === 0) return [];
+  const lines = text.split(/\r?\n/);
   const seen = new Map();
-  RULE_DEF.lastIndex = 0;
-  let match;
-  while ((match = RULE_DEF.exec(text)) !== null) {
-    const name = match[1];
-    if (seen.has(name)) continue;
-    const lineEnd = text.indexOf('\n', match.index);
-    const line = text.slice(match.index, lineEnd === -1 ? text.length : lineEnd).trim();
-    seen.set(name, {
-      name,
-      generic: match[2] || '',
+  for (const rule of parseRules(text)) {
+    if (seen.has(rule.name)) continue;
+    const line = (lines[rule.line - 1] || '').trim();
+    seen.set(rule.name, {
+      name: rule.name,
+      generic: rule.generic || '',
       definition: line.length > 120 ? `${line.slice(0, 117)}…` : line,
     });
   }
@@ -102,25 +126,27 @@ export function extractRuleNames(text) {
 }
 
 /**
- * Is the cursor inside a comment or an unterminated text literal on this line?
- * CDDL comments run from an unquoted `;` to end of line (RFC 8610 §2), so a
- * single left-to-right scan tracking quote state is enough.
+ * Is the cursor inside a comment or an unterminated text/byte literal on this
+ * line? CDDL comments run from an unquoted `;` to end of line (RFC 8610 §2),
+ * and literals are delimited by `"` or `'` (the latter also covering the `h'…'`
+ * and `b64'…'` byte string prefixes), so a single left-to-right scan tracking
+ * the active delimiter is enough.
  */
 export function inCommentOrString(linePrefix) {
   const prefix = typeof linePrefix === 'string' ? linePrefix : '';
-  let inString = false;
+  let quote = null;
   for (let i = 0; i < prefix.length; i++) {
     const ch = prefix[i];
-    if (inString) {
-      if (ch === '\\') i++;
-      else if (ch === '"') inString = false;
-    } else if (ch === '"') {
-      inString = true;
+    if (quote) {
+      if (ch === '\\' && quote === '"') i++;
+      else if (ch === quote) quote = null;
+    } else if (ch === '"' || ch === "'") {
+      quote = ch;
     } else if (ch === ';') {
       return true;
     }
   }
-  return inString;
+  return quote !== null;
 }
 
 /**
@@ -135,7 +161,7 @@ export function inCommentOrString(linePrefix) {
 export function completionContext(linePrefix) {
   const prefix = typeof linePrefix === 'string' ? linePrefix : '';
   if (inCommentOrString(prefix)) return 'none';
-  if (/\s\.[A-Za-z]*$/.test(prefix) || /^\s*\.[A-Za-z]*$/.test(prefix)) return 'control';
+  if (/\s\.[A-Za-z0-9-]*$/.test(prefix) || /^\s*\.[A-Za-z0-9-]*$/.test(prefix)) return 'control';
   return 'type';
 }
 


### PR DESCRIPTION
Fixes three reported CDDL Playground defects, plus two found in review. Every symptom below was reproduced in a real browser on `main` first; the failing observation is quoted for each.

**Note on the branch:** the original instruction was to push to #702, but #702 was merged as `6f628f3` and its branch deleted while this work was queued. I verified `main`'s `www/` content is byte-identical to `a294d5d8` (the old PR head) and branched from `main` instead, so this is a new PR rather than an update to #702.

---

## Defect 1 — CBOR validation "just re-uses the JSON" ✅ reproduced and fixed

**Failing observation on `main`:**
```
JSON tab content       : "{\"hello\":\"world\"}"
CBOR tab content       : "{\"hello\":\"world\"}"
>>> CARRIES JSON OVER? : true
validate on CBOR tab   : "Invalid CBOR input — CBOR input must be hex bytes or base64-encoded CBOR."
```

**Root cause — UI layer, exactly as suspected.** `www/src/instance-validation.js` was correct all along: it dispatches to `validate_cbor_from_slice` and converts hex/base64 via `parseCborInput`. The bug was that both tabs shared a **single Monaco model**, so switching to CBOR carried the JSON text straight over, and validating that text reported "Invalid CBOR input" — which reads exactly like "CBOR validation re-uses the JSON."

**Fix.** `setInstanceKind` now stashes the outgoing buffer and restores the incoming one, and clears the stale result from the other tab. Both buffers persist to `localStorage`, with the legacy single-text key migrated into whichever kind was last active so returning users lose nothing. `generateCurrentSample` no longer silently swaps the tab out from under a CBOR user — the generator emits JSON by design, so it now says so and leaves the CBOR buffer intact.

**No CBOR encoder was built**, so I did not need to stop and ask.

**Verification** against `person = {name: tstr, age: uint}`:

| Step | Result |
| --- | --- |
| CBOR tab after switching from populated JSON tab | `""` (empty) |
| `a2646e616d6563616461636167651824` | ✅ `Instance is valid` |
| `a2646e616d65636164616361676520` (age = −1) | ✅ `expected type uint, got Integer(Integer(-1))` |
| JSON buffer after round-trip | `{"name":"ada","age":36}` preserved |
| CBOR buffer after Generate | preserved, with an explanatory toast |

---

## Defect 2 — "no autocomplete when typing" ⚠️ partially reproduced

**Being precise, because the report and the measurement disagree:** autocomplete *did* appear on `main`, both while typing and on <kbd>Ctrl</kbd>+<kbd>Space</kbd>. What was broken is that it was nearly useless:

```
suggestions offered : ["any","bool","bstr","bytes","float","int","null","text","tstr","uint"]
offers buffer rule? : false
after "tstr ."      : ["any","bool","bstr",...]   ← prelude types, not control operators
```

Ten hardcoded names, nothing the user had defined, and no control operators — `.` is not part of Monaco's default word pattern and no `triggerCharacters` were declared.

**Fix.** New module `www/src/cddl-completion.js` supplies three sources; `index.js` keeps ownership of the Monaco wiring:

- **rule and group names parsed from the live buffer**, ranked first
- **the complete RFC 8610 Appendix D prelude** — 40 types, was 10
- **14 control operators** after a `.`, with the replace range extended back over the dot so accepting `.size` yields `tstr .size`, not `tstr ..size`

**Verification:**

| Input | Before | After |
| --- | --- | --- |
| `myCustomRule = tstr` … `b = myC` | *(nothing)* | `myCustomRule` |
| `a = tstr .` | prelude types | `.and .bits .cbor .cborseq .default .eq .ge .gt …` (14) |
| `a = tstr .si` → Enter | — | `a = tstr .size` |
| `a = big` | *(nothing)* | `bigfloat, bigint, bignint, biguint` |

---

## Defect 3 — "examples dropdown shows nothing" ✅ reproduced, but not for the suspected reason

**The stated hypothesis was a boot-time exception. That is disproved:**

```
ddChildren: 19    ddText: "BasicsHello WorldMinimal schema with a single text rule…"
CONSOLE ERRORS: 0
```

The dropdown was fully populated and threw nothing. It simply **never painted**. Two independent CSS causes, in sequence:

1. `.topbar` and `.topbar-right` both used `overflow: hidden`, which clipped the absolutely-positioned dropdown hanging below the 48px topbar.
2. Once un-clipped, `.topbar` set `z-index: 10` while `position: static`, so `.outline-pane` painted over it. At 380px the outline sidebar covered the dropdown's left third — where all the example *names* are.

**Fix.** `.topbar` gets `position: relative` plus `overflow-x: clip; overflow-y: visible` (this pair is legal and keeps vertical overflow genuinely visible, whereas `hidden` would promote the other axis to `auto`). `.topbar-right` no longer clips at all, since the dropdown is anchored inside it but extends to its left; the parent `.topbar` still prevents a page scrollbar.

**Verification** — `elementFromPoint` sampled across the dropdown's full width:

```
before: x=50 COVERED by DIV.pane-header   x=82 COVERED   x=114 COVERED   x=146 DROPDOWN …
after : x=50 DROPDOWN  x=82 DROPDOWN  x=114 DROPDOWN  x=146 DROPDOWN  x=194 … x=338 DROPDOWN
```

---

## Found in review (rubber-duck), reproduced and fixed

4. **`clearInstanceResult` destroyed the seeded placeholder.** After the first tab switch the result box became a permanently blank 150px panel. It now re-seeds "Validation results will appear here." Measured: restores on every switch, height stays 150px, no layout shift.

5. **Control operators were offered inside comments and strings.** `; foo .b` and `tstr .default "x .b` both returned the full operator list. `completionContext` now returns `none` there, using a left-to-right scan that tracks quote state and backslash escapes — so an unquoted `;` starts a comment but a `;` inside a string does not. 13 unit cases pass, including `a = "quoted ; not comment" .s` → still `control`.

---

## Stress test

Zero uncaught console/page errors across the entire matrix.

| Scenario | Result | Measurement |
| --- | --- | --- |
| 5,000-line schema (5,001 rules, 237 KB) | ✅ PASS | paste + validate 1,540 ms; 5 keystrokes, worst 9 ms dispatch→next-frame; status `Valid` |
| 2 MB JSON instance | ✅ PASS | paste 1,564 ms, validate 1,217 ms, `Instance is valid` |
| Recursive `a = [* a]` | ✅ PASS | 4.5 s, no hang, no stack overflow |
| 12-level nested array | ✅ PASS | `Valid` |
| Rapid tab switching during in-flight validation | ✅ PASS | 12 switches in ~500 ms, JSON buffer intact |
| 10× rapid Generate + Validate | ✅ PASS | no races, final `Instance is valid` |
| Malformed input in every field | ✅ PASS | invalid CDDL → `1 error`; invalid JSON → `Invalid JSON: Expected prope…`; non-hex CBOR → `Invalid CBOR input`; empty instance → `Nothing to validate`; empty schema → `Ready`; generate on empty → `No rules found in schema` |
| All 16 bundled examples: load + generate + validate | ✅ PASS | all load `Valid`; the 5 showing a sample error are the known CBOR-only set |
| Share permalink at the size boundary | ✅ PASS | over-limit → `too large to share as a URL`, clipboard untouched; under-limit → `Copied share link` |
| Share permalink round-trip | ✅ PASS | 1,172-char URL restores the schema, 0 errors |
| `localStorage` full/disabled (every access throws) | ✅ PASS | boots, 16 examples, tab switching works, 0 errors |
| Light + dark theme, 1400px + 380px | ✅ PASS | dropdown painted, nothing clipped, no page h-scroll, no overflow |

Regression harnesses unchanged from baseline: **26 pass / 1 fail** (only `regexp`, pre-existing) and **11 validate / 5 cbor-only / 0 fail**.

`cargo fmt --all -- --check`, `cargo clippy --all`, and `cargo check --lib --target wasm32-unknown-unknown` are all clean.

---

## Pre-existing issues found — NOT fixed here (out of `www/` scope)

Both measured as **byte-identical on `main`**, so neither is a regression from this PR:

1. **Schemas nested ≥ 20 levels block the WASM parser for > 60 s.** Depth 10 is instant; depth 20 times out on `main` and on this branch identically. The cost is in the Rust parser (`src/`), which this PR is scoped out of.
2. **Recursive `a = [* a]` generates `[null]`, which fails its own schema** (`group * a matched the first 0 elements`). Identical output and identical error on `main`. Lives in `www/src/sample-gen.js`.

## Could not verify

- Browsers other than Chromium. `overflow-x: clip` + `overflow-y: visible` needs Chrome/Edge 90+, Firefox 81+, Safari 16+; I only had headless Chromium available.
- The `prebuild` npm script path. `npm` is blocked in my environment, so I built with `node node_modules/webpack-cli/bin/cli.js --config webpack.config.prod.js` and built the wasm separately with `wasm-pack`. CI exercises the real `npm run build`.

## Try it locally

```bash
git fetch origin www/playground-fixes-2 && git checkout www/playground-fixes-2
cd www && npm install && npm start
```

Then, to see all three fixes in about a minute:

1. Click **Examples** — the dropdown now renders (try it at a narrow window width too).
2. Load **Person Record**, type `pe` in the schema editor — `person` is suggested from your own buffer. Type `tstr .` — the control operators appear.
3. Open the **Instance** pane, click **Generate**, then **Validate** on the JSON tab. Switch to the **CBOR** tab: it is now empty rather than carrying the JSON over. Paste `a2646e616d6563616461636167651824` against `person = {name: tstr, age: uint}` for a pass, then change the trailing `1824` to `20` for a real `expected type uint` error.
