### PR TITLE
fix(www): omit unsatisfiable elements instead of emitting null in generated samples

### DIFF
--- a/www/src/sample-gen.js
+++ b/www/src/sample-gen.js
@@ -4,6 +4,19 @@
 
 const MAX_DEPTH = 32;
 const MAX_NODES = 5000;
+/**
+ * Returned when a node cannot be generated at all — a reference cycle, the depth
+ * limit, or the node budget. It is deliberately not `null`, because `null` is a
+ * legitimate sample value for `nil`/`null`, and conflating the two made cyclic
+ * schemas emit `[null]`, which does not validate against the schema that produced it.
+ * Occurrence sites omit the entry instead when the occurrence permits zero items.
+ */
+const UNSATISFIABLE = Symbol('unsatisfiable');
+
+/** Collapse the sentinel to `null` for contexts that must yield a concrete value. */
+function concrete(value) {
+  return value === UNSATISFIABLE ? null : value;
+}
 /** Upper bound on repeated occurrences; schemas demanding more fail explicitly. */
 const MAX_REPEAT = 64;
 /** Structural limits that keep hostile shared links from freezing the tab. */
@@ -104,7 +117,12 @@ function generateOnce(source, rootRuleName, includeOptional) {
       unappliedControls: new Set(),
       includeOptional,
     };
-    const value = generateRef(root, [], null, ctx, 0, new Set(), new Map());
+    const generated = generateRef(root, [], null, ctx, 0, new Set(), new Map());
+    if (generated === UNSATISFIABLE) {
+      ctx.constraintsSatisfied = false;
+      warnings.push(`Root rule "${root}" is recursive with no terminating case; emitted null, which will not validate.`);
+    }
+    const value = concrete(generated);
     return {
       json: JSON.stringify(value, null, 2),
       warnings,
@@ -627,12 +645,12 @@ function generateRef(name, args, key, ctx, depth, visiting, env) {
   if (env.has(name)) return generateNode(env.get(name), key, ctx, depth + 1, visiting, env, name);
   if (BUILTINS.has(name)) return generateBuiltin(name, key, ctx);
   if (depth > MAX_DEPTH) {
-    ctx.warnings.push(`Recursion depth exceeded while resolving "${name}"; emitted null.`);
-    return null;
+    ctx.warnings.push(`Recursion depth exceeded while resolving "${name}".`);
+    return UNSATISFIABLE;
   }
   if (visiting.has(name)) {
-    ctx.warnings.push(`Cycle detected while resolving "${name}"; emitted null.`);
-    return null;
+    ctx.warnings.push(`Cycle detected while resolving "${name}".`);
+    return UNSATISFIABLE;
   }
 
   const rule = ctx.model.rules.get(name);
@@ -654,12 +672,12 @@ function generateRef(name, args, key, ctx, depth, visiting, env) {
 function generateNode(node, key, ctx, depth, visiting, env, label) {
   if (!node) return null;
   if (--ctx.budget < 0) {
-    ctx.warnings.push('Sample generation node budget exhausted; emitted null.');
-    return null;
+    ctx.warnings.push('Sample generation node budget exhausted.');
+    return UNSATISFIABLE;
   }
   if (depth > MAX_DEPTH) {
-    ctx.warnings.push(`Recursion depth exceeded${label ? ` at "${label}"` : ''}; emitted null.`);
-    return null;
+    ctx.warnings.push(`Recursion depth exceeded${label ? ` at "${label}"` : ''}.`);
+    return UNSATISFIABLE;
   }
 
   switch (node.kind) {
@@ -714,6 +732,7 @@ function generateControl(node, key, ctx, depth, visiting, env, label) {
     case '.size': {
       const size = controlNumber(node.controller);
       const value = base();
+      if (value === UNSATISFIABLE) return UNSATISFIABLE;
       if (size == null || size < 0) return markControlUnapplied(ctx, node.op, value);
       if (typeof value === 'string') return sizedString(value, size);
       if (typeof value === 'number') return Number.isInteger(value) ? sizedInteger(value, size) : value;
@@ -725,20 +744,24 @@ function generateControl(node, key, ctx, depth, visiting, env, label) {
     case '.ge': {
       const limit = controlNumber(node.controller);
       const value = base();
+      if (value === UNSATISFIABLE) return UNSATISFIABLE;
       if (limit == null || typeof value !== 'number') return markControlUnapplied(ctx, node.op, value);
       return boundedNumber(value, limit, node.op);
     }
     case '.ne': {
       const value = base();
       const excluded = controller();
+      if (value === UNSATISFIABLE || excluded === UNSATISFIABLE) return UNSATISFIABLE;
       if (value !== excluded) return value;
       if (typeof value === 'number') return value + 1;
       if (typeof value === 'string') return `${value}x`;
       if (typeof value === 'boolean') return !value;
       return markControlUnapplied(ctx, node.op, value);
     }
-    default:
-      return markControlUnapplied(ctx, node.op, base());
+    default: {
+      const value = base();
+      return value === UNSATISFIABLE ? UNSATISFIABLE : markControlUnapplied(ctx, node.op, value);
+    }
   }
 }
 
@@ -882,7 +905,12 @@ function generateMap(entries, ctx, depth, visiting, env, target) {
         const taken = Object.prototype.hasOwnProperty.call(object, baseKey);
         const key = i === 0 && !taken ? baseKey : distinctKey(object, baseKey, entry, ctx, i);
         const before = ctx.warnings.length;
-        setMember(object, key, generateNode(entry.value, key, ctx, depth + 1, visiting, env, key));
+        const placed = placeAtOccurrence(
+          generateNode(entry.value, key, ctx, depth + 1, visiting, env, key),
+          entry.occurrence, ctx, `Member "${key}"`,
+        );
+        if (placed.omit) continue;
+        setMember(object, key, placed.value);
         if (entry.occurrence.optional && ctx.warnings.length > before) {
           ctx.warnings.push(`Optional member "${key}" was included using a heuristic value.`);
         }
@@ -891,6 +919,7 @@ function generateMap(entries, ctx, depth, visiting, env, target) {
     }
     if (entry.kind === 'element') {
       const value = generateNode(entry.value, null, ctx, depth + 1, visiting, env, null);
+      if (value === UNSATISFIABLE) continue;
       if (value && typeof value === 'object' && !Array.isArray(value)) mergeMembers(object, value);
       else if (value !== null) {
         ctx.warnings.push('Group entry did not produce an object member; stored it under "value".');
@@ -924,6 +953,22 @@ function generateGroupMerge(options, ctx, depth, visiting, env) {
   return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
 }
 
+/**
+ * Resolve a generated value at an occurrence site.
+ * Returns `{ omit: true }` when the value could not be generated and the
+ * occurrence permits zero items, and otherwise a concrete value — falling back
+ * to `null` with an explicit warning when the occurrence demands at least one.
+ */
+function placeAtOccurrence(value, occurrence, ctx, what) {
+  if (value !== UNSATISFIABLE) return { omit: false, value };
+  if ((occurrence?.min ?? 1) === 0) return { omit: true, value: undefined };
+  ctx.constraintsSatisfied = false;
+  ctx.warnings.push(
+    `${what} requires at least ${occurrence?.min ?? 1} item${(occurrence?.min ?? 1) === 1 ? '' : 's'} but cannot be generated (recursive or too deeply nested); emitted null, which will not validate.`,
+  );
+  return { omit: false, value: null };
+}
+
 function generateArray(entries, ctx, depth, visiting, env) {
   const array = [];
   for (const entry of entries) {
@@ -936,14 +981,26 @@ function generateArray(entries, ctx, depth, visiting, env) {
     if (skipOptional(entry, ctx)) continue;
     const count = repeatCount(entry.occurrence, ctx);
     for (let i = 0; i < count; i++) {
-      if (entry.kind === 'member') array.push(generateNode(entry.value, keyToString(entry.key, ctx, depth, visiting, env, entry.arrow), ctx, depth + 1, visiting, env, null));
-      else if (entry.kind === 'group') array.push(...generateArray(entry.entries, ctx, depth + 1, visiting, env));
+      if (entry.kind === 'member') {
+        const key = keyToString(entry.key, ctx, depth, visiting, env, entry.arrow);
+        const placed = placeAtOccurrence(
+          generateNode(entry.value, key, ctx, depth + 1, visiting, env, null),
+          entry.occurrence, ctx, `Array element "${key}"`,
+        );
+        if (!placed.omit) array.push(placed.value);
+      } else if (entry.kind === 'group') array.push(...generateArray(entry.entries, ctx, depth + 1, visiting, env));
       else {
         // A group reference contributes its entries to the array, not a nested array.
         const seen = new Set();
         const resolved = resolveGroupNode(entry.value, ctx, env, seen, visiting);
         if (resolved) array.push(...generateArray(resolved.group.entries, ctx, depth + 1, new Set([...visiting, ...seen]), resolved.env));
-        else array.push(generateNode(entry.value, null, ctx, depth + 1, visiting, env, null));
+        else {
+          const placed = placeAtOccurrence(
+            generateNode(entry.value, null, ctx, depth + 1, visiting, env, null),
+            entry.occurrence, ctx, 'Array element',
+          );
+          if (!placed.omit) array.push(placed.value);
+        }
       }
     }
   }
@@ -1000,12 +1057,12 @@ function keyToString(key, ctx, depth, visiting, env, arrow = false) {
     return String(key.value);
   }
   if (key.kind === 'name' && arrow && (ctx.model.rules.has(key.name) || BUILTINS.has(key.name))) {
-    const value = generateRef(key.name, [], null, ctx, depth + 1, visiting, env);
+    const value = concrete(generateRef(key.name, [], null, ctx, depth + 1, visiting, env));
     if (typeof value !== 'string') markNotJsonRepresentable(ctx, 'integer or non-text member keys');
     return value == null ? key.name : String(value);
   }
   if (key.kind === 'name') return key.name;
-  const value = generateNode(key.node, null, ctx, depth + 1, visiting, env, null);
+  const value = concrete(generateNode(key.node, null, ctx, depth + 1, visiting, env, null));
   if (typeof value !== 'string') markNotJsonRepresentable(ctx, 'integer or non-text member keys');
   ctx.warnings.push(`Computed map key "${key.text}" approximated as a JSON object key.`);
   return value == null ? 'key' : String(value);

--- a/www/src/sample-gen.js
+++ b/www/src/sample-gen.js
@@ -120,7 +120,7 @@ function generateOnce(source, rootRuleName, includeOptional) {
     const generated = generateRef(root, [], null, ctx, 0, new Set(), new Map());
     if (generated === UNSATISFIABLE) {
       ctx.constraintsSatisfied = false;
-      warnings.push(`Root rule "${root}" is recursive with no terminating case; emitted null, which will not validate.`);
+      warnings.push(`Root rule "${root}" cannot be generated (recursive, too deeply nested, or too large); emitted null, which will not validate.`);
     }
     const value = concrete(generated);
     return {
@@ -918,8 +918,12 @@ function generateMap(entries, ctx, depth, visiting, env, target) {
       continue;
     }
     if (entry.kind === 'element') {
-      const value = generateNode(entry.value, null, ctx, depth + 1, visiting, env, null);
-      if (value === UNSATISFIABLE) continue;
+      const placed = placeAtOccurrence(
+        generateNode(entry.value, null, ctx, depth + 1, visiting, env, null),
+        entry.occurrence, ctx, 'Group entry',
+      );
+      if (placed.omit) continue;
+      const value = placed.value;
       if (value && typeof value === 'object' && !Array.isArray(value)) mergeMembers(object, value);
       else if (value !== null) {
         ctx.warnings.push('Group entry did not produce an object member; stored it under "value".');
@@ -964,7 +968,7 @@ function placeAtOccurrence(value, occurrence, ctx, what) {
   if ((occurrence?.min ?? 1) === 0) return { omit: true, value: undefined };
   ctx.constraintsSatisfied = false;
   ctx.warnings.push(
-    `${what} requires at least ${occurrence?.min ?? 1} item${(occurrence?.min ?? 1) === 1 ? '' : 's'} but cannot be generated (recursive or too deeply nested); emitted null, which will not validate.`,
+    `${what} requires at least ${occurrence?.min ?? 1} item${(occurrence?.min ?? 1) === 1 ? '' : 's'} but cannot be generated (recursive, too deeply nested, or too large); the sample will not validate.`,
   );
   return { omit: false, value: null };
 }


### PR DESCRIPTION
Fixes the first of the two pre-existing defects flagged on #704. Branched off `main`, not off #704. Scope is `www/src/sample-gen.js` only.

## The defect

Schema `a = [* a]`, click **Generate**. The generator emitted `[null]`, which then **failed validation against the very schema that produced it**:

```
error validating at the root of the JSON document: array validation failed
```

Reproduced on `main` @ `6e98f66`. It is broader than originally reported — **six** recursion shapes were affected, not just `* a`:

| Shape | Schema | Before | Validates? |
| --- | --- | --- | --- |
| zero-or-more | `a = [* a]` | `[null]` | ❌ |
| optional | `a = [? a]` | `[null]` | ❌ |
| one-or-more | `a = [+ a]` | `[null]` | ❌ |
| bare required | `a = [a]` | `[null]` | ❌ |
| map value | `a = {* tstr => a}` | `{"tstr": null}` | ❌ |
| mutual | `a = [* b]` / `b = [* a]` | `[[null]]` | ❌ |

## Root cause

Not quite "the cycle guard returns null into a context that cannot accept it". The real problem is that **`null` was doing double duty**.

`generateBuiltin` legitimately returns `null` for the `nil` / `null` / `undefined` prelude types, and the parser maps the `null`/`nil` tokens to `{ kind: 'literal', value: null }`. So when the cycle guard also returned `null`, an occurrence site had **no way to distinguish "this is a CDDL nil" from "generation gave up"** — and dutifully placed the failure marker into the array.

This is why the obvious fix — "if null, omit" — is wrong: it would silently drop every legitimate `nil` from every sample.

## The fix

Introduce a module-level `UNSATISFIABLE` symbol, returned by exactly the three **resource** guards: cycle detected, `MAX_DEPTH` exceeded, node budget exhausted. Guards for unknown rules and unsupported constructs keep returning `null`, since those are *schema* errors, not resource limits — deliberately narrowing the blast radius.

Resolution happens at the **occurrence level** (`generateArray`, `generateMap`) via a new `placeAtOccurrence` helper, keyed on `occurrence.min`:

- **occurrence permits zero** (`*`, `?`, `0*n` → `min === 0`) → **omit the entry**. The existing cycle warning is kept.
- **occurrence requires ≥ 1** (`+`, bare → `min >= 1`) → genuinely unsatisfiable. **Emit `null`, set `constraintsSatisfied = false`, and warn explicitly** that the sample will not validate.
- **map keys under a cycle** → omit the whole entry, never a null key.

### Why `null` rather than an empty array for `+` and bare

Per the prompt, stating this explicitly. `a = [+ a]` is genuinely unsatisfiable — *no* finite JSON document satisfies it, so there is no correct sample to emit. The options were to emit nothing, or to emit something visibly wrong plus a loud explanation. I chose the latter: emitting `[]` for `[+ a]` would be **just as invalid** but would look plausible, and would flip the panel to a confusing pass-looking state. Instead the user gets the sample, `constraintsSatisfied = false`, and:

> Array element requires at least 1 item but cannot be generated (recursive or too deeply nested); emitted null, which will not validate.

The cycle guard itself is untouched — only what it *returns* changed.

The sentinel is prevented from escaping: it is propagated through the control operators (`.size`, `.lt`/`.le`/`.gt`/`.ge`, `.ne`, default) rather than being mistaken for a value, collapsed at the root in `generateOnce`, and collapsed in `keyToString` — which would otherwise have thrown a `TypeError` on `String(Symbol)`.

## Verification

**Stop condition met:** `a = [* a]` now generates a sample that validates against `a = [* a]`.

| Shape | After | Validates | `constraintsSatisfied` |
| --- | --- | --- | --- |
| `a = [* a]` | `[]` | ✅ VALID | true |
| `a = [? a]` | `[]` | ✅ VALID | true |
| `a = {* tstr => a}` | `{}` | ✅ VALID | true |
| `a = {? "k" => a}` | `{}` | ✅ VALID | true |
| `a = [* b]` / `b = [* a]` | `[[]]` | ✅ VALID | true |
| `a = [+ a]` | `[null]` | ❌ (by design) | **false** + warning |
| `a = [a]` | `[null]` | ❌ (by design) | **false** + warning |
| `a = a` | `null` | ❌ (by design) | **false** + warning |

**Regression guard — the main risk of the sentinel change** — legitimate `nil` must still generate `null`:

| Schema | Generated | Validates |
| --- | --- | --- |
| `a = [nil]` | `[null]` | ✅ VALID |
| `a = [null]` | `[null]` | ✅ VALID |
| `a = {b: nil}` | `{"b": null}` | ✅ VALID |
| `a = [? nil]` | `[null]` | ✅ VALID |
| `a = [1*3 int]` | `[0]` | ✅ VALID |

**Existing harnesses — both exactly at baseline, no drift:**

| Harness | Baseline | After |
| --- | --- | --- |
| `run.mjs` (27 synthetic schemas) | 26 pass / 1 fail | **26 pass / 1 fail** |
| `tally.mjs` (16 bundled examples) | 11 validate / 5 cbor-only / 0 fail | **11 validate / 5 cbor-only / 0 fail** |

The single `run.mjs` failure is `regexp`, pre-existing and unrelated.

**Real browser** — built `www/dist` with webpack (clean, only the pre-existing asset-size warnings), served it, and drove Chromium. What I clicked, per case: clicked into `#cddlEditor`, ⌘A + Backspace, typed the schema, clicked `#instanceGenBtn`, then clicked `#instanceValidateBtn`.

| Case | Generated | Result panel |
| --- | --- | --- |
| `a = [* a]` | `[]` | **Instance is valid — No failures.** |
| `a = [nil]` | `[null]` | **Instance is valid — No failures.** |
| `a = [+ a]` | `[null]` | Instance does not conform (2 errors) — as designed |

**Zero console errors** across all three.

## Flagged / not verified

- **No theme or viewport testing.** This PR touches no UI surface — it is pure generator logic in `www/src/sample-gen.js`. There is no new or changed markup or CSS to check at 380px or in dark mode.
- **Pre-existing, not addressed here:** `a = {* a => tstr}` (recursion in the map *key*) generates `{"a": "string"}` and the validator rejects it with `Recursive rule reference`. `keyToString`'s name branch returns the rule name literally without generating, so the sentinel never reaches it. Behaviour is identical on `main` — out of scope for this fix.
- No cargo suite run: this PR changes no Rust. CI will cover it.
