### PR TITLE
perf(parser): remove exponential nested-array parse time by factoring the group_entry prefix

### DIFF
--- a/cddl.pest
+++ b/cddl.pest
@@ -172,8 +172,15 @@ group_choice_op = { "//" }
 // - Named group reference: groupname
 // - Nested group: ( group )
 // - Cut entries: key ^ => type (prevents backtracking)
-group_entry = { occur? ~ S ~ member_key ~ S ~ cut? ~ S ~ "=>" ~ S ~ type_expr
-              | occur? ~ S ~ member_key ~ S ~ ":" ~ S ~ type_expr
+// Note on ordering/factoring: alternatives 1 and 2 previously each began with
+// `occur? ~ S ~ member_key`, so a failing entry parsed `member_key` twice before
+// falling through to the bare `type_expr` alternative. Because `member_key`'s
+// first alternative is `type1 ~ &("=>")`, every array element was fully parsed
+// three times per nesting level, giving O(3^depth) parse time on nested arrays.
+// Factoring the shared prefix into a single `member_key` attempt removes one of
+// those redundant full parses. `member_key` is deterministic for a given input,
+// so the combined form matches exactly the same language as the split form.
+group_entry = { occur? ~ S ~ member_key ~ S ~ (cut? ~ S ~ "=>" | ":") ~ S ~ type_expr
               | occur? ~ S ~ "(" ~ S ~ group ~ S ~ ")"
               | occur? ~ S ~ type_expr
               | occur? ~ S ~ groupname ~ generic_args? }

--- a/tests/nested_group_parse_perf.rs
+++ b/tests/nested_group_parse_perf.rs
@@ -1,0 +1,250 @@
+#![cfg(feature = "std")]
+#![cfg(not(feature = "lsp"))]
+#![cfg(not(target_arch = "wasm32"))]
+
+use cddl::{
+  ast::{GroupEntry, MemberKey, Rule, Type2},
+  parser::cddl_from_str,
+};
+use std::time::{Duration, Instant};
+
+/// Regression tests for exponential parse time on deeply nested arrays.
+///
+/// `group_entry` used to begin two separate alternatives with
+/// `occur? ~ S ~ member_key`, and `member_key`'s first alternative is
+/// `type1 ~ &("=>")`. A group entry that is not a member -- every plain array
+/// element -- therefore parsed its entire nested subtree once per `member_key`
+/// attempt and again for the bare `type_expr` alternative: three full parses
+/// per nesting level, i.e. O(3^depth).
+///
+/// Measured on the pre-fix grammar: depth 12 took 1.9s, depth 14 took 16.8s and
+/// depth 16 took 152s. After factoring the shared prefix, the same depths take
+/// 13ms, 50ms and 208ms.
+///
+/// The bounds below are deliberately loose -- many times the post-fix cost --
+/// so they stay reliable on slow or contended CI hardware while still failing
+/// by a wide margin on the old grammar. Depth 14 rather than 16 is used for the
+/// absolute bound so that a genuine regression fails in about 17s instead of
+/// about 96s.
+fn nested_array(depth: usize) -> String {
+  format!("a = {}int{}", "[".repeat(depth), "]".repeat(depth))
+}
+
+/// Best of several runs, so that one descheduled thread cannot skew a timing.
+fn best_parse_time(src: &str, runs: u32) -> Duration {
+  let mut best = Duration::MAX;
+  for _ in 0..runs {
+    let start = Instant::now();
+    let parsed = cddl_from_str(src, true);
+    let elapsed = start.elapsed();
+    assert!(parsed.is_ok(), "expected {} to parse", src);
+    best = best.min(elapsed);
+  }
+  best
+}
+
+#[test]
+fn deeply_nested_arrays_parse_in_reasonable_time() {
+  let src = nested_array(14);
+
+  let start = Instant::now();
+  let parsed = cddl_from_str(&src, true);
+  let elapsed = start.elapsed();
+
+  assert!(parsed.is_ok(), "depth-14 nested array should parse");
+  assert!(
+    elapsed < Duration::from_secs(5),
+    "depth-14 nested array took {:?}; the pre-fix grammar took about 16.8s and \
+     the post-fix grammar takes about 50ms, so this indicates the exponential \
+     group_entry backtracking has returned",
+    elapsed
+  );
+}
+
+/// The cost curve must stay sub-exponential. Going from depth 7 to depth 14 grew
+/// the old grammar by roughly 3^7 (~2000x) and the new one by roughly 2^7
+/// (~130x). Comparing two depths rather than asserting an absolute time keeps
+/// this meaningful across hardware.
+#[test]
+fn nested_array_parse_cost_is_not_exponential() {
+  let shallow = nested_array(7);
+  let deep = nested_array(14);
+
+  // warm up so one-time initialisation is not attributed to the shallow parse
+  let _ = cddl_from_str(&shallow, true);
+
+  let shallow_ns = best_parse_time(&shallow, 5).as_nanos().max(1);
+  let deep_ns = best_parse_time(&deep, 3).as_nanos().max(1);
+
+  let ratio = deep_ns as f64 / shallow_ns as f64;
+  assert!(
+    ratio < 600.0,
+    "depth 14 was {:.0}x the cost of depth 7 (shallow {}ns, deep {}ns); the \
+     pre-fix grammar was roughly 2000x and the post-fix grammar is roughly \
+     130x, so this looks exponential again",
+    ratio,
+    shallow_ns,
+    deep_ns
+  );
+}
+
+/// Nesting through the other bracketing forms must stay fast too. Parenthesised
+/// groups route through `type_expr` and map entries use a cheap bareword key, so
+/// neither hit the pathological path -- these guard against a "fix" that helps
+/// arrays by pushing the cost somewhere else.
+#[test]
+fn deeply_nested_groups_and_maps_parse_quickly() {
+  let parens = format!("a = {}int{}", "(".repeat(16), ")".repeat(16));
+  let mut inner = String::from("int");
+  for _ in 0..16 {
+    inner = format!("{{ k: {} }}", inner);
+  }
+  let maps = format!("a = {}", inner);
+
+  for src in [parens, maps] {
+    let start = Instant::now();
+    let parsed = cddl_from_str(&src, true);
+    let elapsed = start.elapsed();
+    assert!(parsed.is_ok(), "depth-16 nesting should parse: {}", src);
+    assert!(
+      elapsed < Duration::from_secs(5),
+      "depth-16 nesting took {:?} for {}",
+      elapsed,
+      src
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Semantic equivalence
+//
+// The perf fix factored two `group_entry` alternatives that shared the prefix
+// `occur? ~ S ~ member_key` into one alternative with an inner `("=>" | ":")`
+// choice. Because `member_key` is itself an ordered choice whose first branch
+// is `type1 ~ &("=>")`, the delicate part is that the arrow and colon forms
+// must still select the same `member_key` branch as before. These tests pin
+// down the member key variant produced by each syntactic form, so a future
+// grammar edit cannot silently change which one is produced.
+// ---------------------------------------------------------------------------
+
+fn first_member_key(src: &str) -> (MemberKey<'_>, bool) {
+  let cddl = Box::leak(Box::new(cddl_from_str(src, true).unwrap()));
+
+  let group = match &cddl.rules[0] {
+    Rule::Type { rule, .. } => match &rule.value.type_choices[0].type1.type2 {
+      Type2::Map { group, .. } => group,
+      Type2::Array { group, .. } => group,
+      other => panic!("expected a map or array, got {:?}", other),
+    },
+    other => panic!("expected a type rule, got {:?}", other),
+  };
+
+  match &group.group_choices[0].group_entries[0].0 {
+    GroupEntry::ValueMemberKey { ge, .. } => {
+      let mk = ge.member_key.clone().expect("expected a member key");
+      let is_cut = match &mk {
+        MemberKey::Type1 { is_cut, .. } => *is_cut,
+        _ => false,
+      };
+      (mk, is_cut)
+    }
+    other => panic!("expected a value member key entry, got {:?}", other),
+  }
+}
+
+#[test]
+fn colon_forms_produce_bareword_or_value_keys() {
+  assert!(
+    matches!(
+      first_member_key("a = { key: int }").0,
+      MemberKey::Bareword { .. }
+    ),
+    "bareword colon key should stay a Bareword"
+  );
+  assert!(
+    matches!(
+      first_member_key("a = { 1: tstr }").0,
+      MemberKey::Value { .. }
+    ),
+    "literal integer colon key should stay a Value"
+  );
+  assert!(
+    matches!(
+      first_member_key(r#"a = { "key": int }"#).0,
+      MemberKey::Value { .. }
+    ),
+    "literal text colon key should stay a Value"
+  );
+}
+
+#[test]
+fn arrow_forms_produce_type1_keys_and_preserve_cut() {
+  let (mk, is_cut) = first_member_key("a = { key => int }");
+  assert!(
+    matches!(mk, MemberKey::Type1 { .. }),
+    "arrow key should be a Type1 key"
+  );
+  assert!(!is_cut, "plain arrow key should not be cut");
+
+  let (mk, is_cut) = first_member_key("a = { key ^ => int }");
+  assert!(
+    matches!(mk, MemberKey::Type1 { .. }),
+    "cut arrow key should be a Type1 key"
+  );
+  assert!(is_cut, "`^ =>` must still be recorded as a cut");
+
+  assert!(
+    matches!(
+      first_member_key("a = { (int / tstr) => bool }").0,
+      MemberKey::Type1 { .. }
+    ),
+    "computed arrow key should be a Type1 key"
+  );
+}
+
+#[test]
+fn generic_args_pick_the_same_branch_for_both_delimiters() {
+  assert!(
+    cddl_from_str("foo<a> = [a]\nb = { foo<int> => tstr }", true).is_ok(),
+    "generic typename with an arrow key should parse"
+  );
+  assert!(
+    cddl_from_str("foo<a> = [a]\nb = [ foo<int> ]", true).is_ok(),
+    "generic typename as a plain entry should parse"
+  );
+  // A generic typename used as a *colon* key is rejected, and was rejected
+  // identically before the alternatives were factored (same message, same
+  // position). Pinned here so the factoring cannot silently start accepting it.
+  assert!(
+    cddl_from_str("foo<a> = [a]\nb = { foo<int>: tstr }", true).is_err(),
+    "generic typename with a colon key is rejected, as it was before"
+  );
+}
+
+#[test]
+fn cut_before_a_colon_is_still_rejected() {
+  // `^` is only meaningful before `=>`. Factoring the alternatives must not
+  // make `key ^ : int` suddenly parse.
+  assert!(
+    cddl_from_str("a = { key ^ : int }", true).is_err(),
+    "`^` before `:` must remain a parse error"
+  );
+}
+
+#[test]
+fn non_member_entries_still_parse() {
+  for src in [
+    "a = [ int ]",
+    "a = [ ? int ]",
+    "a = [ * int ]",
+    "a = [ 1*3 int ]",
+    "g = ( x: int )\na = { g }",
+    "a = [ (int, tstr) ]",
+  ] {
+    assert!(
+      cddl_from_str(src, true).is_ok(),
+      "non-member group entry should still parse: {}",
+      src
+    );
+  }
+}


### PR DESCRIPTION
Fixes the second pre-existing defect flagged on #704: exponential parse time on nested groups. Branched off `main`, separate from #705 (the sample-generator fix) because the risk profiles are completely different.

**This is a real fix, not a mitigation.** No recursion cap was added and nothing the grammar accepts was relaxed.

## Confirming the curve first

Re-measured before changing anything. Note my earlier harness on #704 **silently never called `initSync`** and reported a fake `0ms` at every depth — every measurement below comes from a loader that refuses to return a module unless `validate_cddl_from_str('a = int', true)` returns `[]` *and* `'a = = int'` returns a non-empty error array.

Schema: `a = [[[...int...]]]`, N nested arrays.

| depth | parse (`cddl_from_str`) | validate | delta |
| --- | --- | --- | --- |
| 8 | 24ms | 24ms | 0% |
| 10 | 210ms | 207ms | -1% |
| 12 | 1,854ms | 1,850ms | 0% |
| 14 | 16,765ms | 16,731ms | 0% |

~3.0× per level, and **the validator is not involved** — it is all parse.

## Profiling — which disproved the stated hypothesis

The prompt's hypothesis was PEG backtracking across `type2`'s `[ group ]` / `{ group }` / `( group )` alternatives. **That is wrong.** A native release bench splitting pest from the bridge, across all three bracketing forms:

| shape | depth 14, pest only | pest+bridge | bridge delta |
| --- | --- | --- | --- |
| `[[[int]]]` | **10,771ms** | 10,469ms | ~0ms |
| `(((int)))` | **0.0ms** | 0.0ms | ~0ms |
| `{k:{k:int}}` | **0.1ms** | 0.1ms | ~0ms |

Two things fall out immediately:

1. **The bridge is free.** `src/pest_bridge.rs` — the 4,785-line file that was the prime suspect — contributes ~0ms. It is not touched by this PR.
2. **Only `[` explodes.** Parens and maps are *flat*. So it is not generic `type2` ambiguity, which would have hit all three.

`(` routes to `type_expr`, not `group`, so it never enters the hot path. `{` and `[` both route to `group` — so the difference had to be in what happens to an entry *inside* the group.

## Root cause

```
group_entry = { occur? ~ S ~ member_key ~ S ~ cut? ~ S ~ "=>" ~ S ~ type_expr
              | occur? ~ S ~ member_key ~ S ~ ":"  ~ S ~ type_expr
              | occur? ~ S ~ "(" ~ S ~ group ~ S ~ ")"
              | occur? ~ S ~ type_expr
              | occur? ~ S ~ groupname ~ generic_args? }
```

Two alternatives share the prefix `occur? ~ S ~ member_key`. And `member_key`'s first alternative is:

```
member_key = { type1 ~ S ~ &(("^" ~ S)? ~ "=>") | bareword | typename ~ generic_args? | value }
```

`type1 ~ &("=>")` **parses an entire type expression and only then checks a lookahead**. For an entry that is not a member — which is *every plain array element* — that lookahead fails after the full nested subtree has already been parsed. Then the grammar does it again for the colon alternative, and a third time for the bare `type_expr` alternative.

**Three full parses of the subtree per nesting level → O(3^depth).** That is exactly the measured 3.0× base.

Maps escape it because `{ k: ... }` matches the cheap `bareword` branch of `member_key` and commits immediately. Parens escape it by never reaching `group_entry`. Only array elements pay.

## The fix

Option 1 from the prompt's preference order — remove the redundancy, one line:

```diff
-group_entry = { occur? ~ S ~ member_key ~ S ~ cut? ~ S ~ "=>" ~ S ~ type_expr
-              | occur? ~ S ~ member_key ~ S ~ ":" ~ S ~ type_expr
+group_entry = { occur? ~ S ~ member_key ~ S ~ (cut? ~ S ~ "=>" | ":") ~ S ~ type_expr
               | occur? ~ S ~ "(" ~ S ~ group ~ S ~ ")"
```

Five alternatives become four; `member_key` is attempted once instead of twice. No memoization, no atomic rules, no depth cap.

### Before / after

Native, same bench, same machine:

| depth | before | after | speedup |
| --- | --- | --- | --- |
| 12 | 1,212ms | **13ms** | 95× |
| 14 | 10,771ms | **50ms** | 214× |
| 16 | 152,159ms | **208ms** | **731×** |
| 18 | — | 804ms | |
| 20 | — | 3,293ms | |

Through wasm, i.e. what the playground actually calls:

| depth | `cddl_from_str` | `validate_cddl_from_str` |
| --- | --- | --- |
| 14 | 81ms | 81ms |
| 16 | **322ms** | 321ms |
| 18 | 1,288ms | 1,283ms |

**Stop condition met:** depth 16 parses in **208ms native / 322ms wasm**, against the required <1s.

Growth is now 2.05× per level, down from 3.0× — consistent with removing exactly one of three redundant parses. It is still exponential in the limit; a PEG with this shape of nesting inherently is. What is gone is the cliff at realistic depths.

## Semantic equivalence — the actual risk of this PR

Performance was the easy part. The thing worth scrutinising is whether the factored grammar accepts the same language.

**The argument:** in PEG semantics an ordered choice commits to its first successful alternative, and the engine never re-enters an already-succeeded sub-expression. So `member_key` yields the same single result at a given input position in both forms, making `M ~ ("=>" | ":")` equivalent to `(M ~ "=>") | (M ~ ":")`.

Rather than trust that, I measured it:

- **Full test suite is bit-for-bit unchanged.** `cargo test --all` gives **696 passed / 0 failed on `main` and 696 passed / 0 failed on this branch**, with an identical count of stderr `error: parser errors` lines (11 on both). With the 8 new tests the branch total is 704.
- **Diagnostics are unchanged.** Ten malformed inputs — including `a = { a ^ : int }`, `a = { foo<int> ^ : tstr }`, `a = { (int) : tstr }`, `a = { => int }`, `a = { key ^ int }` — produce **byte-identical** error text, message, line, column *and* range under both grammars. **10/10 identical.**
- **The bridge required no change.** `convert_group_entry` switches only on child `Rule` values and finds `cut` by scanning for `Rule::cut`; `convert_member_key_simple` maps a `Rule::type1` child to the arrow form and `bareword`/`typename`/`value` to colon keys. Nothing depends on which alternative matched or on how many there are.
- **`^` before `:` is still rejected**, verified by trace and by test.

## Regression test

`tests/nested_group_parse_perf.rs`, 8 tests:

**Two timing tests** — verified to actually fail on today's `main`. Reverting only the grammar rule and re-running: **FAILED, 2 of 3, 33.4s**, with `depth-14 nested array took 11.385922833s`. With the fix: **passes in 0.17s**.

I used depth 14 rather than 16 for the absolute bound, and a best-of-N ratio rather than a single sample — both on review feedback (see below). The bounds are deliberately loose (5s against a ~50ms actual) so they do not flake on contended CI, while still failing by 200×+ on the old grammar.

**Six semantic-equivalence tests** pinning the `MemberKey` variant produced by each syntactic form — bareword/value colon keys, plain and cut arrow keys, computed `(int / tstr) =>` keys, generic args, and non-member entries. These pass on **both** the old and new grammars, which is exactly what an equivalence test should do.

## Rubber-duck review

Ran the diff past the rubber-duck agent. It found **no blocking issues** and independently confirmed the equivalence argument against pest 2.8.8's source (`generator.rs:465-507`, `parser_state.rs:912-929`), including that a failed outer sequence restores position and truncates the token queue rather than re-entering a successful inner choice.

**Accepted (3):**
1. *Ratio test could be skewed by a single descheduled thread, and integer division discarded precision.* Valid. Now best-of-5 / best-of-3 with float division.
2. *A real regression pays the full parse cost before the assertion fires (~96s at depth 16).* Valid. Moved the absolute bound to depth 14 — still fails by 200×+, but in ~11s instead of ~96s.
3. *Add a semantic matrix rather than inferring equivalence.* Valid, and the highest-value suggestion. Added the six tests above.

**Rejected (1), with the measurement that disproved it:**

- *"Factoring can change pest's internal failed-attempt stacks and therefore the precise error message for malformed inputs"* — flagged as a caveat to check. I checked it directly instead of assuming: built both grammars and diffed diagnostics across ten malformed inputs, including the exact three the review named. **All 10 byte-identical**, including position ranges. No diagnostic drift.

I also **caught one of my own test assertions being wrong**: I initially asserted `b = { foo<int>: tstr }` (generic typename as a colon key) should parse. It does not — but it does not parse on `main` either, with an identical error at an identical position. That is a pre-existing limitation, not a regression, and it is now pinned as such rather than silently "fixed".

## Verification

| Check | Result |
| --- | --- |
| `cargo fmt --all -- --check` | PASS |
| `cargo clippy --all` | PASS |
| `cargo clippy --lib --target wasm32-unknown-unknown` | PASS |
| `cargo check --lib --target wasm32-unknown-unknown` | PASS |
| `cargo +stable check --all --bins --examples --tests` | PASS |
| `... --no-default-features` | PASS |
| `cargo test --all -- --nocapture` | **704 passed / 0 failed** (696 baseline + 8 new) |
| `run.mjs` | **26 pass / 1 fail** — baseline held |
| `tally.mjs` | **11 validate / 5 cbor-only / 0 fail** — baseline held |

Both JS harnesses were re-run against a wasm bundle rebuilt from this grammar. The single `run.mjs` failure is `regexp`, pre-existing and unrelated.

## Flagged / not verified

- **No browser testing.** This PR changes no `www/` code. The wasm timings above were taken through the same `pkg/` bundle the site loads, but I did not click through the UI — there is no UI change to exercise.
- **Growth is still exponential asymptotically**, just with a smaller base (2.05× vs 3.0×). Depth 24 still takes ~51s. Eliminating that entirely would need memoization or a grammar restructure well beyond this fix; I did not attempt it, since the stop condition was depth 16 under 1s.
- **The remaining 2.05× is not itself attributed.** I did not profile further once the stop condition was met, so I cannot say whether the residual doubling is the `member_key`/`type_expr` pair or something else.
- No `perf`/`samply`/`flamegraph` was used — neither is installed. Attribution came from a native release bench that isolates pest from the bridge and compares the three bracketing forms, which was sufficient to localise the cost and disprove the original hypothesis.
