### PR TITLE
fix(validator): track CBOR table candidate locations

### DIFF
--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -178,8 +178,8 @@ pub struct CBORValidator<'a> {
   probing_single_entry_assignment: bool,
   // Candidate batch produced while visiting one repeating map member's key.
   // `visit_value_member_key_entry` immediately takes this relay field so the
-  // physical indices and values cannot affect a later group entry.
-  map_entry_candidates: Option<Vec<(usize, Value)>>,
+  // physical indices, keys, and values cannot affect a later group entry.
+  map_entry_candidates: Option<Vec<(usize, Value, Value)>>,
   // Whether or not the validator is validating a map entry value
   validating_value: bool,
   range_upper: Option<usize>,
@@ -532,14 +532,14 @@ impl<'a> CBORValidator<'a> {
     entries: &[(Value, Value)],
     claimed_entries: &[usize],
     predicate: impl Fn(&Value) -> bool,
-  ) -> Vec<(usize, Value)> {
+  ) -> Vec<(usize, Value, Value)> {
     entries
       .iter()
       .enumerate()
-      .filter_map(|(entry_index, (key, value))| {
-        (predicate(key) && Self::is_unconsumed_map_entry(entry_index, claimed_entries))
-          .then(|| (entry_index, value.clone()))
+      .filter(|(entry_index, (key, _))| {
+        predicate(key) && Self::is_unconsumed_map_entry(*entry_index, claimed_entries)
       })
+      .map(|(entry_index, (key, value))| (entry_index, key.clone(), value.clone()))
       .collect()
   }
 
@@ -4141,7 +4141,7 @@ where
       let max_matches = Self::repeating_member_upper_bound(entry).unwrap_or(usize::MAX);
       let mut match_count = 0;
 
-      for (entry_index, value) in candidates {
+      for (entry_index, key, value) in candidates {
         if match_count == max_matches {
           break;
         }
@@ -4149,7 +4149,13 @@ where
         let mut cv = self.new_with_recursion_state(value);
         cv.state.is_multi_type_choice = self.state.is_multi_type_choice;
         cv.state.is_multi_group_choice = self.state.is_multi_group_choice;
-        cv.state.data_location.push_str(&self.state.data_location);
+        // The child inherits the recursion guard, so advance to this pair's
+        // value before resolving recursive table types (as JSON does).
+        let _ = write!(
+          cv.state.data_location,
+          "{}/{:?}",
+          self.state.data_location, key
+        );
         cv.state.type_group_name_entry = self.state.type_group_name_entry;
         cv.validating_value = true;
         cv.visit_type(&entry.entry_type)?;

--- a/src/validator/cbor.rs
+++ b/src/validator/cbor.rs
@@ -178,8 +178,8 @@ pub struct CBORValidator<'a> {
   probing_single_entry_assignment: bool,
   // Candidate batch produced while visiting one repeating map member's key.
   // `visit_value_member_key_entry` immediately takes this relay field so the
-  // physical indices, keys, and values cannot affect a later group entry.
-  map_entry_candidates: Option<Vec<(usize, Value, Value)>>,
+  // physical indices cannot affect a later group entry.
+  map_entry_candidates: Option<Vec<usize>>,
   // Whether or not the validator is validating a map entry value
   validating_value: bool,
   range_upper: Option<usize>,
@@ -532,14 +532,14 @@ impl<'a> CBORValidator<'a> {
     entries: &[(Value, Value)],
     claimed_entries: &[usize],
     predicate: impl Fn(&Value) -> bool,
-  ) -> Vec<(usize, Value, Value)> {
+  ) -> Vec<usize> {
     entries
       .iter()
       .enumerate()
-      .filter(|(entry_index, (key, _))| {
-        predicate(key) && Self::is_unconsumed_map_entry(*entry_index, claimed_entries)
+      .filter_map(|(entry_index, (key, _))| {
+        (predicate(key) && Self::is_unconsumed_map_entry(entry_index, claimed_entries))
+          .then_some(entry_index)
       })
-      .map(|(entry_index, (key, value))| (entry_index, key.clone(), value.clone()))
       .collect()
   }
 
@@ -4141,21 +4141,33 @@ where
       let max_matches = Self::repeating_member_upper_bound(entry).unwrap_or(usize::MAX);
       let mut match_count = 0;
 
-      for (entry_index, key, value) in candidates {
+      for entry_index in candidates {
         if match_count == max_matches {
           break;
         }
 
+        // Look the pair up lazily so candidate collection does not clone the
+        // key and value of every matching entry.
+        let candidate = match &self.cbor {
+          Value::Map(entries) => entries.get(entry_index).map(|(key, value)| {
+            let mut data_location = self.state.data_location.clone();
+            // The child inherits the recursion guard, so advance to this
+            // pair's value before resolving recursive table types (as JSON
+            // does).
+            let _ = write!(data_location, "/{:?}", key);
+            (data_location, value.clone())
+          }),
+          _ => None,
+        };
+
+        let Some((data_location, value)) = candidate else {
+          continue;
+        };
+
         let mut cv = self.new_with_recursion_state(value);
         cv.state.is_multi_type_choice = self.state.is_multi_type_choice;
         cv.state.is_multi_group_choice = self.state.is_multi_group_choice;
-        // The child inherits the recursion guard, so advance to this pair's
-        // value before resolving recursive table types (as JSON does).
-        let _ = write!(
-          cv.state.data_location,
-          "{}/{:?}",
-          self.state.data_location, key
-        );
+        cv.state.data_location = data_location;
         cv.state.type_group_name_entry = self.state.type_group_name_entry;
         cv.validating_value = true;
         cv.visit_type(&entry.entry_type)?;

--- a/tests/cbor_table_map_candidate_location.rs
+++ b/tests/cbor_table_map_candidate_location.rs
@@ -1,0 +1,120 @@
+//! Recursive CBOR table-map value regressions.
+//!
+//! RFC 8610 Sections 2.1.2 and 3.5.2 require both sides of every table-map
+//! pair to match: in `{* x => y}`, each key has type `x` and each value has
+//! type `y`. A recursion guard must therefore not waive validation of a
+//! nested pair value.
+
+#![cfg(feature = "std")]
+#![cfg(all(feature = "cbor", feature = "json"))]
+#![cfg(not(target_arch = "wasm32"))]
+
+use cddl::{validate_cbor_from_slice, validate_json_from_str};
+
+fn json_validates(schema: &str, instance: &str) -> bool {
+  validate_json_from_str(schema, instance, None).is_ok()
+}
+
+fn cbor_validates(schema: &str, hex: &str) -> bool {
+  let bytes = hex::decode(hex).unwrap();
+  validate_cbor_from_slice(schema, &bytes, None).is_ok()
+}
+
+fn both_accept(schema: &str, json: &str, cbor_hex: &str) {
+  let json_result = json_validates(schema, json);
+  let cbor_result = cbor_validates(schema, cbor_hex);
+  assert!(
+    json_result && cbor_result,
+    "expected both formats to accept; JSON {}: {}, CBOR {}: {}\nschema:\n{}",
+    json,
+    json_result,
+    cbor_hex,
+    cbor_result,
+    schema,
+  );
+}
+
+fn both_reject(schema: &str, json: &str, cbor_hex: &str) {
+  let json_result = json_validates(schema, json);
+  let cbor_result = cbor_validates(schema, cbor_hex);
+  assert!(
+    !json_result && !cbor_result,
+    "expected both formats to reject; JSON {}: {}, CBOR {}: {}\nschema:\n{}",
+    json,
+    json_result,
+    cbor_hex,
+    cbor_result,
+    schema,
+  );
+}
+
+#[test]
+fn recursive_table_values_are_validated_at_every_depth() {
+  let schema = "t = uint\nt /= {* tstr => t}\n";
+
+  both_accept(schema, r#"{"k":0}"#, "a1616b00");
+  both_accept(schema, r#"{"k":{"k":0}}"#, "a1616ba1616b00");
+  both_accept(schema, r#"{"k":{"k":{"k":0}}}"#, "a1616ba1616ba1616b00");
+
+  // Ruby cddl 0.12.14 rejects both ill-typed vectors in JSON and CBOR.
+  both_reject(schema, r#"{"k":{"k":true}}"#, "a1616ba1616bf5");
+  both_reject(schema, r#"{"k":{"k":{"k":true}}}"#, "a1616ba1616ba1616bf5");
+}
+
+#[test]
+fn recursive_table_values_remain_checked_behind_an_alias() {
+  let schema = "root = t\nt = uint\nt /= {* tstr => t}\n";
+
+  both_accept(schema, r#"{"k":0}"#, "a1616b00");
+  both_accept(schema, r#"{"k":{"k":0}}"#, "a1616ba1616b00");
+
+  // Ruby cddl 0.12.14 rejects these at the first ill-typed value.
+  both_reject(schema, r#"{"k":true}"#, "a1616bf5");
+  both_reject(schema, r#"{"k":"x"}"#, "a1616b6178");
+  both_reject(schema, r#"{"k":{"k":true}}"#, "a1616ba1616bf5");
+}
+
+#[test]
+fn inline_recursive_table_choice_checks_nested_values() {
+  let schema = "t = uint / {* tstr => t}\n";
+
+  both_accept(schema, r#"{"k":{"k":0}}"#, "a1616ba1616b00");
+  // This predates incremental-choice support; Ruby cddl 0.12.14 rejects it.
+  both_reject(schema, r#"{"k":{"k":true}}"#, "a1616ba1616bf5");
+}
+
+#[test]
+fn alternate_only_recursive_table_checks_nested_values() {
+  let schema = "t /= uint\nt /= {* tstr => t}\n";
+
+  // Ruby cddl 0.12.14 accepts these well-typed controls in both encodings.
+  both_accept(schema, r#"{"k":0}"#, "a1616b00");
+  both_accept(schema, r#"{"k":{"k":0}}"#, "a1616ba1616b00");
+
+  // This is the sharp S02/M04 coupling vector: pre-S02 Rust and Ruby reject,
+  // while S02 alone accepts the nested true in CBOR.
+  both_reject(schema, r#"{"k":true}"#, "a1616bf5");
+  both_reject(schema, r#"{"k":"x"}"#, "a1616b6178");
+  both_reject(schema, r#"{"k":{"k":true}}"#, "a1616ba1616bf5");
+}
+
+#[test]
+fn multiple_table_arms_do_not_hide_a_bad_recursive_value() {
+  let schema = "t /= {* tstr => t}\nt /= {\"z\" => uint}\n";
+
+  both_reject(schema, r#"{"k":{"k":true}}"#, "a1616ba1616bf5");
+}
+
+#[test]
+fn non_recursive_and_specific_key_map_controls_keep_their_verdicts() {
+  let table = "m = {* tstr => int}\n";
+  both_accept(table, r#"{"k":1}"#, "a1616b01");
+  both_reject(table, r#"{"k":"x"}"#, "a1616b6178");
+
+  // Specific-key descent already carries the pair key in both validators.
+  let specific = "t = uint\nt /= {\"k\" => t}\n";
+  both_accept(specific, r#"{"k":0}"#, "a1616b00");
+  both_accept(specific, r#"{"k":{"k":0}}"#, "a1616ba1616b00");
+  both_accept(specific, r#"{"k":{"k":{"k":0}}}"#, "a1616ba1616ba1616b00");
+  both_reject(specific, r#"{"k":{"k":true}}"#, "a1616ba1616bf5");
+}


### PR DESCRIPTION
The recursion guard previously keyed on `<rule name, path to the data>`, but in some cases (ex: nested table) that's not sufficient so we now append the pair's key to the child's path (JSON already did this)

## Relevant RFC 8610 rules

<details>
<summary>section list</summary>

- Section 2.1 (lines 367-370): every map pair must be covered by the group.
- Section 2.1.2 (lines 539-542): `keytype => valuetype` matches a pair only
  when both the key and value match their respective types.
- Section 3.5.2 (lines 1210-1224): in `{* x => y}`, every key has datatype
  `x` and every value has datatype `y`.
- Section 3.5.3 (lines 1245-1265): map matching selects candidate pairs from
  the complete unordered map and fails if pairs remain unpicked.
- Section 2.2.2 (lines 626-637) and Appendix C (lines 2639-2641,
  2669-2677): `/=` contributions form the named type choice in source order;
  Appendix C lines 2618-2620 explicitly permit self-reference.
- Section 3.5.4 distinguishes a cut from ordinary `=>` table matching. This
  change introduces no cut or commitment behavior.

</details>

## Rust and Ruby evidence

Rust and Ruby (0.12.14) match match on all combinations of the table below (cddl type row, cbor  value column)

| Schema shape | `{"k":0}` | `{"k":{"k":0}}` | `{"k":true}` | `{"k":{"k":true}}` |
| --- | --- | --- | --- | --- |
| `t = uint; t /= {* tstr => t}` | accept | accept | reject | reject |
| `root = t; t = uint; t /= ...` | accept | accept | reject | reject |
| `t = uint / {* tstr => t}` | accept | accept | reject | reject |
| `t /= uint; t /= {* tstr => t}` | accept | accept | reject | reject |
