### PR TITLE
feat(modules): implement CDDL module structure (draft-ietf-cbor-cddl-modules-06)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,13 @@ jobs:
           cargo +${{ matrix.rust_toolchain }} test --all -- --nocapture
 
       - name: cargo +${{ matrix.rust_toolchain }} test ${{ matrix.os }} (modules)
+        # Reusing the incremental cache left by the run above, which has a
+        # different feature set, has produced spurious link failures, so this
+        # run compiles from scratch.
+        env:
+          CARGO_INCREMENTAL: 0
         run: |
-          cargo +${{ matrix.rust_toolchain }} test --all --features modules -- --nocapture
+          cargo +${{ matrix.rust_toolchain }} test -p cddl --features modules -- --nocapture
 
   wasm-test-suite:
     name: wasm test suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,11 +91,11 @@ jobs:
           cargo +${{ matrix.rust_toolchain }} test --all -- --nocapture
 
       - name: cargo +${{ matrix.rust_toolchain }} test ${{ matrix.os }} (modules)
-        # Reusing the incremental cache left by the run above, which has a
-        # different feature set, has produced spurious link failures, so this
-        # run compiles from scratch.
-        env:
-          CARGO_INCREMENTAL: 0
+        # Scoped to -p cddl: under `--all`, cddl-derive's proc-macro
+        # dependency on cddl is built without `modules` while the workspace
+        # build enables it, and resolver v2 keeps those feature sets separate.
+        # The two builds then collide on the unhashed `libcddl.so` name of the
+        # cdylib target and the link fails.
         run: |
           cargo +${{ matrix.rust_toolchain }} test -p cddl --features modules -- --nocapture
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,10 @@ jobs:
         run: |
           cargo +${{ matrix.rust_toolchain }} test --all -- --nocapture
 
+      - name: cargo +${{ matrix.rust_toolchain }} test ${{ matrix.os }} (modules)
+        run: |
+          cargo +${{ matrix.rust_toolchain }} test --all --features modules -- --nocapture
+
   wasm-test-suite:
     name: wasm test suite
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,9 @@ ast-parent = []
 json = ["std"]
 cbor = ["std"]
 csv-validate = ["std", "json", "csv"]
+# CDDL module structure (draft-ietf-cbor-cddl-modules-06). Default-off: with the
+# feature disabled, parsing behavior is unchanged from RFC 8610.
+modules = []
 _build-parser = ["dep:pest_generator", "dep:proc-macro2"]
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -176,8 +176,9 @@ let basic_cddl = resolve_modules(
 let ast = cddl::parser::cddl_from_str(&basic_cddl, false)?;
 ```
 
-Modules are located by filename along the colon-separated `CDDL_INCLUDE_PATH`,
-which defaults to `.:`. Targets without a filesystem (such as
+Modules are located by filename along `CDDL_INCLUDE_PATH`, whose elements are
+separated by `:` on Unix and by `;` on Windows, where `:` occurs in drive-letter
+paths. It defaults to `.:` (`.;` on Windows). Targets without a filesystem (such as
 `wasm32-unknown-unknown`) can supply modules through the `ModuleSource` trait;
 `MemoryModuleSource` is provided for that purpose.
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,45 @@ An extension for editing CDDL documents with Visual Studio Code has been publish
 * [x] unprefixed byte strings
 * [x] prefixed byte strings
 
+## Module structure (experimental)
+
+Behind the default-off `modules` feature, this crate implements the CDDL module
+structure of
+[draft-ietf-cbor-cddl-modules-06](https://datatracker.ietf.org/doc/draft-ietf-cbor-cddl-modules/06/).
+Directives are carried in comments beginning with `;#`, so a module-structured
+document remains valid basic CDDL for tools that do not understand them.
+
+Resolution is a source-to-source transformation into basic RFC 8610 CDDL,
+matching the behavior of the `cddlc -2tcddl` tool described in Appendix B of the
+draft:
+
+```rust
+use cddl::modules::{resolve_modules, FsModuleSource, ResolveOptions};
+
+let input = "start = cose.COSE_Key\n;# import rfc9052 as cose\n";
+let basic_cddl = resolve_modules(
+  input,
+  &FsModuleSource::from_env(),
+  &ResolveOptions::default(),
+)?;
+let ast = cddl::parser::cddl_from_str(&basic_cddl, false)?;
+```
+
+Modules are located by filename along the colon-separated `CDDL_INCLUDE_PATH`,
+which defaults to `.:`. Targets without a filesystem (such as
+`wasm32-unknown-unknown`) can supply modules through the `ModuleSource` trait;
+`MemoryModuleSource` is provided for that purpose.
+
+The CLI exposes the same functionality, including the `-i` and `-s` shortcuts of
+§2.7:
+
+```sh
+cddl resolve-modules -icose=rfc9052 -scose.COSE_Key
+```
+
+Being an unratified draft, this is gated off by default and its output is not
+covered by semantic versioning guarantees.
+
 ## Usage
 
 Simply add the dependency to `Cargo.toml` :

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This crate supports the following CDDL-related RFCs:
 | [RFC 9741](https://datatracker.ietf.org/doc/html/rfc9741) | Additional Control Operators for Text in CDDL | ✔️ `.b64u` , `.b64c` , `.hex` , `.hexlc` , `.hexuc` , `.b32` , `.h32` , `.b45` , `.base10` , `.printf` , `.json` , `.join` and sloppy variants |
 | [draft-bormann-cbor-cddl-csv-08](https://datatracker.ietf.org/doc/draft-bormann-cbor-cddl-csv/08/) | Using CDDL for CSV | ✔️ CSV validation via generic data model mapping |
 | [draft-bormann-cbor-cddl-freezer-17](https://datatracker.ietf.org/doc/html/draft-bormann-cbor-cddl-freezer-17) | CDDL Feature Freezer | ✔️ `.pcre` (PCRE2), `.iregexp` (RFC 9485), `.bitfield` |
+| [draft-ietf-cbor-cddl-modules-06](https://datatracker.ietf.org/doc/draft-ietf-cbor-cddl-modules/06/) | CDDL Module Structure | ✔️ `;#` directives, `import` / `include`, `from` selection and `as` namespacing — behind the default-off `modules` feature |
 
 This crate uses [Pest](https://pest.rs/) (a PEG parser generator for Rust) to parse CDDL. The grammar is defined in [ `cddl.pest` ](cddl.pest) and closely follows the ABNF grammar in [Appendix B.](https://tools.ietf.org/html/rfc8610#appendix-B) of the spec. All CDDL must use UTF-8 for its encoding per the spec.
 
@@ -160,9 +161,60 @@ structure of
 Directives are carried in comments beginning with `;#`, so a module-structured
 document remains valid basic CDDL for tools that do not understand them.
 
+### Directives
+
+| Directive | Effect |
+| --- | --- |
+| `;# import <module>` | Bring in the rules of `<module>` this document actually references, transitively. |
+| `;# import <module> as <ns>` | As above, with each imported rule prefixed `<ns>.`. Prelude names are never prefixed. |
+| `;# include <module>` | Bring in every rule of `<module>`. |
+| `;# include <names> from <module>` | Bring in exactly the rules named, plus whatever they reference. |
+| `;# import <name> from <module> as <ns>` | Bring in `<name>` under the `<ns>.` prefix, and emit an alias so the unprefixed name resolves too. |
+| `;# include * from <module>` | `*` selects every rule of the module. |
+
+Names in a `from` clause may be written with or without the namespace prefix.
+Modules may themselves carry directives; they are resolved transitively, and
+circular references are reported rather than followed.
+
+### Example
+
+Given a module `rfc9052.cddl` on the search path:
+
+```cddl
+COSE_Key = {
+  1 => tstr / int,
+  ? 2 => bstr,
+  * label => values,
+}
+label = int / tstr
+values = any
+```
+
+this document:
+
+```cddl
+start = cose.COSE_Key
+;# import rfc9052 as cose
+```
+
+resolves to:
+
+```cddl
+start = cose.COSE_Key
+cose.COSE_Key = {
+  1 => tstr / int,
+  ? 2 => bstr,
+  * cose.label => cose.values,
+}
+cose.label = int / tstr
+cose.values = any
+```
+
+### Library
+
 Resolution is a source-to-source transformation into basic RFC 8610 CDDL,
 matching the behavior of the `cddlc -2tcddl` tool described in Appendix B of the
-draft:
+draft. Resolve first, then parse the result:
 
 ```rust
 use cddl::modules::{resolve_modules, FsModuleSource, ResolveOptions};
@@ -182,15 +234,34 @@ paths. It defaults to `.:` (`.;` on Windows). Targets without a filesystem (such
 `wasm32-unknown-unknown`) can supply modules through the `ModuleSource` trait;
 `MemoryModuleSource` is provided for that purpose.
 
-The CLI exposes the same functionality, including the `-i` and `-s` shortcuts of
-§2.7:
+Each loaded module is parsed after resolution, so a module that is not valid
+CDDL is reported as an error rather than silently producing a broken document.
+This check is skipped on `wasm32`, where the crate's parser entry point is the
+`wasm_bindgen` export.
+
+### CLI
+
+```sh
+cddl resolve-modules --cddl schema.cddl
+```
+
+The document may also be piped in on stdin. The `-i` and `-s` shortcuts of §2.7
+are supported, which import a module and emit a start rule without editing the
+document:
 
 ```sh
 cddl resolve-modules -icose=rfc9052 -scose.COSE_Key
 ```
 
+`--include-path` overrides the module search path for a single invocation.
+
+### Stability
+
 Being an unratified draft, this is gated off by default and its output is not
-covered by semantic versioning guarantees.
+covered by semantic versioning guarantees. Two deliberate deviations from the
+Appendix A ABNF are documented in the source: identifiers accept `.` and `-`
+(required, since the draft's own examples use `cose.label`), and `.` and `..`
+are rejected as module names.
 
 ## Usage
 

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -8,6 +8,8 @@
 extern crate log;
 
 use cddl::cddl_from_str;
+#[cfg(all(feature = "modules", not(target_arch = "wasm32")))]
+use cddl::modules::{resolve_modules, FsModuleSource, ResolveOptions};
 #[cfg(not(target_arch = "wasm32"))]
 use cddl::{
   parser::root_type_name_from_cddl_str, validate_cbor_from_slice, validate_csv_from_str,
@@ -48,6 +50,37 @@ enum Commands {
     file: String,
   },
   Validate(Validate),
+  #[cfg(feature = "modules")]
+  #[clap(
+    name = "resolve-modules",
+    about = "Resolve CDDL module directives (draft-ietf-cbor-cddl-modules) into basic RFC 8610 CDDL"
+  )]
+  ResolveModules {
+    #[clap(
+      short = 'c',
+      long = "cddl",
+      help = "Path to a module-structured CDDL document; omit or pass \"-\" to read stdin"
+    )]
+    file: Option<String>,
+    #[clap(
+      short = 'i',
+      long = "import",
+      help = "Synthesize an import directive: -icose=rfc9052 is shorthand for \";# import rfc9052 as cose\"",
+      action = ArgAction::Append
+    )]
+    imports: Vec<String>,
+    #[clap(
+      short = 's',
+      long = "start",
+      help = "Emit a start (root) rule, as $.start.$ = <rule>"
+    )]
+    start: Option<String>,
+    #[clap(
+      long = "include-path",
+      help = "Colon-separated module search path; defaults to CDDL_INCLUDE_PATH, then \".:\""
+    )]
+    include_path: Option<String>,
+  },
 }
 
 #[derive(Args)]
@@ -332,6 +365,62 @@ fn main() -> Result<(), Box<dyn Error>> {
           }
         }
       }
+    }
+    #[cfg(feature = "modules")]
+    Commands::ResolveModules {
+      file,
+      imports,
+      start,
+      include_path,
+    } => {
+      let input = match file.as_deref() {
+        None | Some("-") => {
+          let mut buffer = String::new();
+          io::stdin().read_to_string(&mut buffer)?;
+          buffer
+        }
+        Some(path) => {
+          let p = Path::new(path);
+          if !p.exists() {
+            error!(cli.ci, "CDDL document {:?} does not exist", p);
+            return Ok(());
+          }
+
+          fs::read_to_string(path)?
+        }
+      };
+
+      let mut command_line_imports = Vec::new();
+      for spec in imports {
+        match spec.split_once('=') {
+          Some((namespace, module)) if !namespace.is_empty() && !module.is_empty() => {
+            command_line_imports.push((namespace.to_string(), module.to_string()))
+          }
+          _ => {
+            error!(
+              cli.ci,
+              "invalid --import {:?}; expected <namespace>=<module>", spec
+            );
+            return Ok(());
+          }
+        }
+      }
+
+      let source = match include_path {
+        Some(path) => FsModuleSource::from_include_path(path),
+        None => FsModuleSource::from_env(),
+      };
+
+      let resolved = resolve_modules(
+        &input,
+        &source,
+        &ResolveOptions {
+          start_rule: start.clone(),
+          command_line_imports,
+        },
+      )?;
+
+      print!("{}", resolved);
     }
   }
 

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -26,6 +26,18 @@ use std::{
   path::Path,
 };
 
+/// Help text for `--include-path`, whose separator is platform-specific: `;` on
+/// Windows, where `:` occurs in drive-letter paths, and `:` elsewhere.
+#[cfg(all(feature = "modules", windows))]
+const INCLUDE_PATH_HELP: &str =
+  "Semicolon-separated module search path; defaults to CDDL_INCLUDE_PATH, then \".;\"";
+
+/// Help text for `--include-path`, whose separator is platform-specific: `;` on
+/// Windows, where `:` occurs in drive-letter paths, and `:` elsewhere.
+#[cfg(all(feature = "modules", not(windows)))]
+const INCLUDE_PATH_HELP: &str =
+  "Colon-separated module search path; defaults to CDDL_INCLUDE_PATH, then \".:\"";
+
 #[derive(Parser)]
 #[clap(author, version, about = "Tool for verifying conformance of CDDL definitions against RFC 8610 and for validating JSON documents and CBOR binary files", long_about = None)]
 struct Cli {
@@ -77,7 +89,7 @@ enum Commands {
     start: Option<String>,
     #[clap(
       long = "include-path",
-      help = "Colon-separated module search path; defaults to CDDL_INCLUDE_PATH, then \".:\""
+      help = INCLUDE_PATH_HELP
     )]
     include_path: Option<String>,
   },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,118 @@
 //! - [x] unprefixed byte strings
 //! - [x] prefixed byte strings
 //!
+//! ## Module structure (experimental)
+//!
+//! Behind the default-off `modules` feature, this crate implements the CDDL
+//! module structure of
+//! [draft-ietf-cbor-cddl-modules-06](https://datatracker.ietf.org/doc/draft-ietf-cbor-cddl-modules/06/).
+//! Directives are carried in comments beginning with `;#`, so a
+//! module-structured document remains valid basic CDDL for tools that do not
+//! understand them.
+//!
+//! ### Directives
+//!
+//! | Directive | Effect |
+//! | --- | --- |
+//! | `;# import <module>` | Bring in the rules of `<module>` this document actually references, transitively. |
+//! | `;# import <module> as <ns>` | As above, with each imported rule prefixed `<ns>.`. Prelude names are never prefixed. |
+//! | `;# include <module>` | Bring in every rule of `<module>`. |
+//! | `;# include <names> from <module>` | Bring in exactly the rules named, plus whatever they reference. |
+//! | `;# import <name> from <module> as <ns>` | Bring in `<name>` under the `<ns>.` prefix, and emit an alias so the unprefixed name resolves too. |
+//! | `;# include * from <module>` | `*` selects every rule of the module. |
+//!
+//! Names in a `from` clause may be written with or without the namespace
+//! prefix. Modules may themselves carry directives; they are resolved
+//! transitively, and circular references are reported rather than followed.
+//!
+//! ### Example
+//!
+//! Given a module `rfc9052.cddl` on the search path:
+//!
+//! ```text
+//! COSE_Key = {
+//!   1 => tstr / int,
+//!   ? 2 => bstr,
+//!   * label => values,
+//! }
+//! label = int / tstr
+//! values = any
+//! ```
+//!
+//! this document:
+//!
+//! ```text
+//! start = cose.COSE_Key
+//! ;# import rfc9052 as cose
+//! ```
+//!
+//! resolves to:
+//!
+//! ```text
+//! start = cose.COSE_Key
+//! cose.COSE_Key = {
+//!   1 => tstr / int,
+//!   ? 2 => bstr,
+//!   * cose.label => cose.values,
+//! }
+//! cose.label = int / tstr
+//! cose.values = any
+//! ```
+//!
+//! ### Library
+//!
+//! Resolution is a source-to-source transformation into basic RFC 8610 CDDL,
+//! matching the behavior of the `cddlc -2tcddl` tool described in Appendix B
+//! of the draft. Resolve first, then parse the result:
+//!
+//! ```ignore
+//! use cddl::modules::{resolve_modules, FsModuleSource, ResolveOptions};
+//!
+//! let input = "start = cose.COSE_Key\n;# import rfc9052 as cose\n";
+//! let basic_cddl = resolve_modules(
+//!   input,
+//!   &FsModuleSource::from_env(),
+//!   &ResolveOptions::default(),
+//! )?;
+//! let ast = cddl::parser::cddl_from_str(&basic_cddl, false)?;
+//! ```
+//!
+//! Modules are located by filename along `CDDL_INCLUDE_PATH`, whose elements
+//! are separated by `:` on Unix and by `;` on Windows, where `:` occurs in
+//! drive-letter paths. It defaults to `.:` (`.;` on Windows). Targets
+//! without a filesystem (such as `wasm32-unknown-unknown`) can supply
+//! modules through the `ModuleSource` trait; `MemoryModuleSource` is
+//! provided for that purpose.
+//!
+//! Each loaded module is parsed after resolution, so a module that is not
+//! valid CDDL is reported as an error rather than silently producing a
+//! broken document. This check is skipped on `wasm32`, where the crate's
+//! parser entry point is the `wasm_bindgen` export.
+//!
+//! ### CLI
+//!
+//! ```sh
+//! cddl resolve-modules --cddl schema.cddl
+//! ```
+//!
+//! The document may also be piped in on stdin. The `-i` and `-s` shortcuts of
+//! §2.7 are supported, which import a module and emit a start rule without
+//! editing the document:
+//!
+//! ```sh
+//! cddl resolve-modules -icose=rfc9052 -scose.COSE_Key
+//! ```
+//!
+//! `--include-path` overrides the module search path for a single invocation.
+//!
+//! ### Stability
+//!
+//! Being an unratified draft, this is gated off by default and its output is
+//! not covered by semantic versioning guarantees. Two deliberate deviations
+//! from the Appendix A ABNF are documented in the source: identifiers accept
+//! `.` and `-` (required, since the draft's own examples use `cose.label`),
+//! and `.` and `..` are rejected as module names.
+//!
 //! ## Usage
 //!
 //! Simply add the dependency to `Cargo.toml`:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -518,6 +518,9 @@ pub mod ast;
 pub mod error;
 /// Lexer types (position information)
 pub mod lexer;
+/// CDDL module structure (draft-ietf-cbor-cddl-modules)
+#[cfg(feature = "modules")]
+pub mod modules;
 /// Parser for CDDL
 pub mod parser;
 /// Bridge layer between Pest parser and existing AST

--- a/src/modules/directive.rs
+++ b/src/modules/directive.rs
@@ -103,7 +103,10 @@ fn parse_line(rest: &str, line: usize) -> Result<Directive, ModuleError> {
     Some(other) => {
       return Err(ModuleError::Directive {
         line,
-        message: format!("unknown directive \"{}\"; expected \"import\" or \"include\"", other),
+        message: format!(
+          "unknown directive \"{}\"; expected \"import\" or \"include\"",
+          other
+        ),
       })
     }
     None => return Err(err(line, "empty directive")),
@@ -202,9 +205,9 @@ fn is_id(name: &str) -> bool {
     _ => return false,
   }
 
-  chars.all(|c| {
-    c == '$' || c == '@' || c == '_' || c == '.' || c == '-' || c.is_ascii_alphanumeric()
-  }) && !name.ends_with(['.', '-'])
+  chars
+    .all(|c| c == '$' || c == '@' || c == '_' || c == '.' || c == '-' || c.is_ascii_alphanumeric())
+    && !name.ends_with(['.', '-'])
 }
 
 /// Whether `name` matches the `filename` production. Note that the production
@@ -296,14 +299,10 @@ mod tests {
       ";# include from rfc9052\n",
     ] {
       assert!(
-        matches!(
-          parse_directives(input),
-          Err(ModuleError::Directive { .. })
-        ),
+        matches!(parse_directives(input), Err(ModuleError::Directive { .. })),
         "expected {:?} to be rejected",
         input
       );
     }
   }
 }
-

--- a/src/modules/directive.rs
+++ b/src/modules/directive.rs
@@ -1,0 +1,309 @@
+//! Parsing of `;#` module directives per Appendix A of
+//! draft-ietf-cbor-cddl-modules-06.
+//!
+//! ```abnf
+//! directive = ";#" RS (%s"import" / %s"include") RS [from-clause]
+//!                     filename [as-clause] CRLF
+//! from-clause = 1*(id-or-all [","] RS) %s"from" RS
+//! as-clause = RS %s"as" RS id
+//! filename = 1*("-" / "." / %x30-39 / %x41-5a / "_" / %x61-7a)
+//! id = ("$" / %x40-5a / "_" / %x61-7a)
+//!      *("$" / %x30-39 / %x40-5a / "_" / %x61-7a)
+//! id-or-all = id / "*"
+//! RS = 1*WS
+//! WS = SP
+//! SP = %x20
+//! CRLF = %x0A / %x0D.0A
+//! ```
+
+#[cfg(not(feature = "std"))]
+use alloc::{
+  format,
+  string::{String, ToString},
+  vec::Vec,
+};
+
+use super::ModuleError;
+
+/// Which of the two directive groups a directive belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirectiveKind {
+  /// `include` — bring in the named rules (or all rules) verbatim.
+  Include,
+  /// `import` — bring in only the rules that are referenced, transitively.
+  Import,
+}
+
+/// A single entry in a `from` clause.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NameSelector {
+  /// The `*` wildcard, selecting every rule of the module.
+  All,
+  /// An explicitly named rule, as written in the directive (which may carry a
+  /// namespace prefix, e.g. `cose.label`).
+  Name(String),
+}
+
+/// A parsed `;#` directive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Directive {
+  /// `import` or `include`.
+  pub kind: DirectiveKind,
+  /// The `from` clause, if present. `None` means no explicit selection was
+  /// made, which for `include` means "all rules" and for `import` means "the
+  /// rules referenced by the importing module".
+  pub names: Option<Vec<NameSelector>>,
+  /// The module name (a filename, without any directory component).
+  pub filename: String,
+  /// The namespace prefix supplied by an `as` clause, if present.
+  pub alias: Option<String>,
+  /// 1-based line number the directive appeared on.
+  pub line: usize,
+}
+
+/// Extract and parse every `;#` directive in `input`, in source order.
+///
+/// A line whose first two characters are `;#` is a directive; if it does not
+/// match the grammar above, a [`ModuleError::Directive`] is returned rather
+/// than the line being silently treated as an ordinary comment.
+pub fn parse_directives(input: &str) -> Result<Vec<Directive>, ModuleError> {
+  let mut directives = Vec::new();
+
+  for (index, raw) in input.lines().enumerate() {
+    let line = index + 1;
+    let text = raw.trim_end_matches('\r');
+
+    if !text.starts_with(";#") {
+      continue;
+    }
+
+    directives.push(parse_line(&text[2..], line)?);
+  }
+
+  Ok(directives)
+}
+
+fn err(line: usize, message: &str) -> ModuleError {
+  ModuleError::Directive {
+    line,
+    message: message.to_string(),
+  }
+}
+
+fn parse_line(rest: &str, line: usize) -> Result<Directive, ModuleError> {
+  if !rest.starts_with([' ', '\t']) {
+    return Err(err(line, "expected whitespace after \";#\""));
+  }
+
+  let tokens: Vec<&str> = rest.split_whitespace().collect();
+
+  let kind = match tokens.first() {
+    Some(&"import") => DirectiveKind::Import,
+    Some(&"include") => DirectiveKind::Include,
+    Some(other) => {
+      return Err(ModuleError::Directive {
+        line,
+        message: format!("unknown directive \"{}\"; expected \"import\" or \"include\"", other),
+      })
+    }
+    None => return Err(err(line, "empty directive")),
+  };
+
+  let tail = &tokens[1..];
+
+  // The `from` keyword is only a keyword when at least one name precedes it,
+  // which keeps `from` usable as an ordinary rule name.
+  let from_at = tail
+    .iter()
+    .position(|t| *t == "from")
+    .filter(|position| *position >= 1);
+
+  let (names, remainder) = match from_at {
+    Some(position) => {
+      let mut selectors = Vec::new();
+
+      for token in &tail[..position] {
+        for name in token.split(',') {
+          if name.is_empty() {
+            continue;
+          }
+
+          if name == "*" {
+            selectors.push(NameSelector::All);
+          } else if is_id(name) {
+            selectors.push(NameSelector::Name(name.to_string()));
+          } else {
+            return Err(ModuleError::Directive {
+              line,
+              message: format!("\"{}\" is not a valid rule name", name),
+            });
+          }
+        }
+      }
+
+      if selectors.is_empty() {
+        return Err(err(line, "\"from\" clause names no rules"));
+      }
+
+      (Some(selectors), &tail[position + 1..])
+    }
+    None => (None, tail),
+  };
+
+  let filename = match remainder.first() {
+    Some(name) if is_filename(name) => (*name).to_string(),
+    Some(name) => {
+      return Err(ModuleError::Directive {
+        line,
+        message: format!("\"{}\" is not a valid module name", name),
+      })
+    }
+    None => return Err(err(line, "directive names no module")),
+  };
+
+  let alias = match &remainder[1..] {
+    [] => None,
+    ["as"] => return Err(err(line, "\"as\" clause names no namespace")),
+    ["as", alias] if is_id(alias) => Some((*alias).to_string()),
+    ["as", alias] => {
+      return Err(ModuleError::Directive {
+        line,
+        message: format!("\"{}\" is not a valid namespace", alias),
+      })
+    }
+    extra => {
+      return Err(ModuleError::Directive {
+        line,
+        message: format!("unexpected trailing text: \"{}\"", extra.join(" ")),
+      })
+    }
+  };
+
+  Ok(Directive {
+    kind,
+    names,
+    filename,
+    alias,
+    line,
+  })
+}
+
+/// Whether `name` is a valid `id`.
+///
+/// Appendix A does not admit `.` or `-` in an `id`, but §2.6 of the same
+/// document writes namespaced selectors such as `cose.label`, and RFC 8610
+/// names admit both characters internally. Both are accepted here so that the
+/// specification's own examples parse.
+fn is_id(name: &str) -> bool {
+  let mut chars = name.chars();
+
+  match chars.next() {
+    Some(c) if c == '$' || c == '@' || c == '_' || c.is_ascii_alphabetic() => {}
+    _ => return false,
+  }
+
+  chars.all(|c| {
+    c == '$' || c == '@' || c == '_' || c == '.' || c == '-' || c.is_ascii_alphanumeric()
+  }) && !name.ends_with(['.', '-'])
+}
+
+/// Whether `name` matches the `filename` production. Note that the production
+/// admits no path separator, so a module name can never escape a configured
+/// source directory; `.` and `..` are rejected explicitly all the same.
+fn is_filename(name: &str) -> bool {
+  !name.is_empty()
+    && name != "."
+    && name != ".."
+    && name
+      .chars()
+      .all(|c| c == '-' || c == '.' || c == '_' || c.is_ascii_alphanumeric())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn one(input: &str) -> Directive {
+    let mut directives = parse_directives(input).unwrap();
+    assert_eq!(directives.len(), 1);
+    directives.pop().unwrap()
+  }
+
+  #[test]
+  fn plain_import() {
+    let directive = one("start = COSE_Key\n;# import rfc9052\n");
+    assert_eq!(directive.kind, DirectiveKind::Import);
+    assert_eq!(directive.filename, "rfc9052");
+    assert_eq!(directive.names, None);
+    assert_eq!(directive.alias, None);
+    assert_eq!(directive.line, 2);
+  }
+
+  #[test]
+  fn import_with_alias() {
+    let directive = one(";# import rfc9052 as cose\n");
+    assert_eq!(directive.alias.as_deref(), Some("cose"));
+  }
+
+  #[test]
+  fn include_with_from_clause() {
+    let directive = one(";# include label, values from rfc9052\n");
+    assert_eq!(directive.kind, DirectiveKind::Include);
+    assert_eq!(
+      directive.names,
+      Some(vec![
+        NameSelector::Name("label".to_string()),
+        NameSelector::Name("values".to_string()),
+      ])
+    );
+  }
+
+  #[test]
+  fn namespaced_from_clause_with_alias() {
+    let directive = one(";# include cose.label, cose.values from rfc9052 as cose\n");
+    assert_eq!(
+      directive.names,
+      Some(vec![
+        NameSelector::Name("cose.label".to_string()),
+        NameSelector::Name("cose.values".to_string()),
+      ])
+    );
+    assert_eq!(directive.alias.as_deref(), Some("cose"));
+  }
+
+  #[test]
+  fn wildcard_selector() {
+    let directive = one(";# include * from rfc9052\n");
+    assert_eq!(directive.names, Some(vec![NameSelector::All]));
+  }
+
+  #[test]
+  fn ordinary_comments_are_not_directives() {
+    assert!(parse_directives("; import rfc9052\na = int\n")
+      .unwrap()
+      .is_empty());
+  }
+
+  #[test]
+  fn malformed_directives_are_errors_not_comments() {
+    for input in [
+      ";# imprt rfc9052\n",
+      ";#import rfc9052\n",
+      ";# import\n",
+      ";# import rfc9052 as\n",
+      ";# import rfc9052 as cose extra\n",
+      ";# import ../etc/passwd\n",
+      ";# include from rfc9052\n",
+    ] {
+      assert!(
+        matches!(
+          parse_directives(input),
+          Err(ModuleError::Directive { .. })
+        ),
+        "expected {:?} to be rejected",
+        input
+      );
+    }
+  }
+}
+

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -40,7 +40,7 @@ pub use resolver::{resolve_modules, ResolveOptions};
 pub use source::{MemoryModuleSource, ModuleSource};
 
 #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
-pub use source::{FsModuleSource, DEFAULT_INCLUDE_PATH, INCLUDE_PATH_VAR};
+pub use source::{FsModuleSource, DEFAULT_INCLUDE_PATH, INCLUDE_PATH_SEPARATOR, INCLUDE_PATH_VAR};
 
 /// Errors arising from parsing or resolving CDDL module directives.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -107,11 +107,7 @@ impl fmt::Display for ModuleError {
       ModuleError::ModuleParse { name, message } => {
         write!(f, "module \"{}\" is not valid CDDL: {}", name, message)
       }
-      ModuleError::RuleNotFound {
-        rule,
-        module,
-        line,
-      } => write!(
+      ModuleError::RuleNotFound { rule, module, line } => write!(
         f,
         "rule \"{}\" named on line {} is not defined in module \"{}\"",
         rule, line, module

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,0 +1,127 @@
+//! CDDL module structure as specified in
+//! [draft-ietf-cbor-cddl-modules-06](https://datatracker.ietf.org/doc/draft-ietf-cbor-cddl-modules/06/).
+//!
+//! The module structure is a *super-syntax* carried in comments: lines that
+//! begin with `;#` are parsed as directives by a module-aware processor while
+//! remaining ordinary comments to a basic (RFC 8610) CDDL parser. Processing
+//! the directives of a source file turns it into a *module*.
+//!
+//! Resolution is a source-to-source transformation: a module-structured CDDL
+//! document is resolved into an equivalent basic CDDL document, which can then
+//! be handed to [`crate::parser::cddl_from_str`] like any other input.
+//!
+//! ```no_run
+//! # #[cfg(all(feature = "modules", feature = "std", not(target_arch = "wasm32")))]
+//! # fn main() -> Result<(), cddl::modules::ModuleError> {
+//! use cddl::modules::{resolve_modules, ResolveOptions};
+//!
+//! let input = "start = COSE_Key\n;# import rfc9052 as cose\n";
+//! let source = cddl::modules::FsModuleSource::from_env();
+//! let basic_cddl = resolve_modules(input, &source, &ResolveOptions::default())?;
+//! let _ast = cddl::parser::cddl_from_str(&basic_cddl, false);
+//! # Ok(())
+//! # }
+//! # #[cfg(not(all(feature = "modules", feature = "std", not(target_arch = "wasm32"))))]
+//! # fn main() {}
+//! ```
+
+mod directive;
+mod resolver;
+mod scan;
+mod source;
+
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
+
+use core::fmt;
+
+pub use directive::{parse_directives, Directive, DirectiveKind, NameSelector};
+pub use resolver::{resolve_modules, ResolveOptions};
+pub use source::{MemoryModuleSource, ModuleSource};
+
+#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
+pub use source::{FsModuleSource, DEFAULT_INCLUDE_PATH, INCLUDE_PATH_VAR};
+
+/// Errors arising from parsing or resolving CDDL module directives.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ModuleError {
+  /// A `;#` directive could not be parsed against the grammar in Appendix A
+  /// of the specification. Carries the 1-based line number and a description.
+  Directive {
+    /// 1-based line number of the offending directive.
+    line: usize,
+    /// Human-readable description of the syntax error.
+    message: String,
+  },
+  /// A referenced module could not be located in any configured source.
+  ModuleNotFound {
+    /// The module name as written in the directive.
+    name: String,
+    /// 1-based line number of the directive that referenced it.
+    line: usize,
+  },
+  /// A module was located but could not be read.
+  ModuleUnreadable {
+    /// The module name as written in the directive.
+    name: String,
+    /// Underlying reason.
+    message: String,
+  },
+  /// A module could not be parsed as basic CDDL.
+  ModuleParse {
+    /// The module name as written in the directive.
+    name: String,
+    /// Parser diagnostics.
+    message: String,
+  },
+  /// A rule named in a `from` clause does not exist in the referenced module.
+  RuleNotFound {
+    /// The rule name as written in the directive.
+    rule: String,
+    /// The module the rule was expected in.
+    module: String,
+    /// 1-based line number of the directive.
+    line: usize,
+  },
+  /// A cycle was detected while following module references.
+  CircularReference {
+    /// The chain of module names, in the order they were entered.
+    chain: Vec<String>,
+  },
+}
+
+impl fmt::Display for ModuleError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      ModuleError::Directive { line, message } => {
+        write!(f, "invalid directive on line {}: {}", line, message)
+      }
+      ModuleError::ModuleNotFound { name, line } => write!(
+        f,
+        "module \"{}\" referenced on line {} was not found in any module source",
+        name, line
+      ),
+      ModuleError::ModuleUnreadable { name, message } => {
+        write!(f, "module \"{}\" could not be read: {}", name, message)
+      }
+      ModuleError::ModuleParse { name, message } => {
+        write!(f, "module \"{}\" is not valid CDDL: {}", name, message)
+      }
+      ModuleError::RuleNotFound {
+        rule,
+        module,
+        line,
+      } => write!(
+        f,
+        "rule \"{}\" named on line {} is not defined in module \"{}\"",
+        rule, line, module
+      ),
+      ModuleError::CircularReference { chain } => {
+        write!(f, "circular module reference: {}", chain.join(" -> "))
+      }
+    }
+  }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ModuleError {}

--- a/src/modules/resolver.rs
+++ b/src/modules/resolver.rs
@@ -309,7 +309,31 @@ fn load_module(
   let resolved = resolve(&text, source, &ResolveOptions::default(), chain);
   chain.pop();
 
-  resolved
+  let resolved = resolved?;
+  validate_module(name, &resolved)?;
+
+  Ok(resolved)
+}
+
+/// Check that a resolved module is basic CDDL, so that a malformed module is
+/// reported against the module that contains it rather than surfacing later as
+/// a parse failure of the resolved document.
+#[cfg(not(target_arch = "wasm32"))]
+fn validate_module(name: &str, resolved: &str) -> Result<(), ModuleError> {
+  crate::parser::cddl_from_str(resolved, false)
+    .map(|_| ())
+    .map_err(|message| ModuleError::ModuleParse {
+      name: name.to_string(),
+      message,
+    })
+}
+
+/// On `wasm32`, [`crate::parser::cddl_from_str`] is the `wasm_bindgen` export
+/// rather than the native parser entry point, so a loaded module is taken as
+/// given.
+#[cfg(target_arch = "wasm32")]
+fn validate_module(_name: &str, _resolved: &str) -> Result<(), ModuleError> {
+  Ok(())
 }
 
 /// Resolve a name written in a directive against the directive's namespace.

--- a/src/modules/resolver.rs
+++ b/src/modules/resolver.rs
@@ -252,6 +252,10 @@ fn resolve(
       }
 
       if let Some(rule) = index.get(name.as_str()) {
+        // A rule pulled in here may reference names that a later directive is
+        // responsible for supplying, so the reference set has to grow as rules
+        // are emitted rather than being fixed at the original body.
+        references.extend(referenced_names(&rule.text));
         pulled.push(rule.text.clone());
       }
     }
@@ -366,6 +370,11 @@ fn strip_directives(input: &str) -> String {
 
 /// Split a document into its rules, recording each rule's dependencies on
 /// other rules of the same document.
+///
+/// A name may be defined more than once — RFC 8610 allows a rule to be extended
+/// with `/=` and `//=`, and those extensions need not be adjacent to the
+/// original definition. All occurrences of a name are merged into a single
+/// entry so that selecting a rule always carries its extensions with it.
 fn rules_of(src: &str) -> Vec<ModuleRule> {
   let scanned = scan(src);
   let defined: BTreeSet<&str> = scanned
@@ -374,33 +383,45 @@ fn rules_of(src: &str) -> Vec<ModuleRule> {
     .map(|rule| rule.name.as_str())
     .collect();
 
-  scanned
-    .rules
-    .iter()
-    .map(|rule| {
-      let mut deps: Vec<String> = Vec::new();
+  let mut merged: Vec<ModuleRule> = Vec::new();
 
-      for ident in &scanned.idents {
-        if ident.role != IdentRole::Reference
-          || ident.start < rule.start
-          || ident.end > rule.end
-          || ident.text == rule.name
-          || PRELUDE.contains(&ident.text.as_str())
-          || !defined.contains(ident.text.as_str())
-        {
-          continue;
+  for rule in &scanned.rules {
+    let mut deps: Vec<String> = Vec::new();
+
+    for ident in &scanned.idents {
+      if ident.role != IdentRole::Reference
+        || ident.start < rule.start
+        || ident.end > rule.end
+        || ident.text == rule.name
+        || PRELUDE.contains(&ident.text.as_str())
+        || !defined.contains(ident.text.as_str())
+      {
+        continue;
+      }
+
+      push_unique(&mut deps, ident.text.clone());
+    }
+
+    let text = src[rule.start..rule.end].to_string();
+
+    match merged.iter_mut().find(|existing| existing.name == rule.name) {
+      Some(existing) => {
+        existing.text.push('\n');
+        existing.text.push_str(&text);
+
+        for dep in deps {
+          push_unique(&mut existing.deps, dep);
         }
-
-        push_unique(&mut deps, ident.text.clone());
       }
-
-      ModuleRule {
+      None => merged.push(ModuleRule {
         name: rule.name.clone(),
-        text: src[rule.start..rule.end].to_string(),
+        text,
         deps,
-      }
-    })
-    .collect()
+      }),
+    }
+  }
+
+  merged
 }
 
 /// Every name referenced — as opposed to defined — by a document.

--- a/src/modules/resolver.rs
+++ b/src/modules/resolver.rs
@@ -155,8 +155,10 @@ fn resolve(
     };
 
     let rules = rules_of(&text);
-    let index: BTreeMap<&str, &ModuleRule> =
-      rules.iter().map(|rule| (rule.name.as_str(), rule)).collect();
+    let index: BTreeMap<&str, &ModuleRule> = rules
+      .iter()
+      .map(|rule| (rule.name.as_str(), rule))
+      .collect();
 
     let mut aliases: Vec<String> = Vec::new();
 
@@ -404,7 +406,10 @@ fn rules_of(src: &str) -> Vec<ModuleRule> {
 
     let text = src[rule.start..rule.end].to_string();
 
-    match merged.iter_mut().find(|existing| existing.name == rule.name) {
+    match merged
+      .iter_mut()
+      .find(|existing| existing.name == rule.name)
+    {
       Some(existing) => {
         existing.text.push('\n');
         existing.text.push_str(&text);

--- a/src/modules/resolver.rs
+++ b/src/modules/resolver.rs
@@ -1,0 +1,440 @@
+//! Resolution of module-structured CDDL into basic (RFC 8610) CDDL.
+//!
+//! Resolution is a source-to-source transformation, matching the behavior of
+//! the `cddlc -2tcddl` tool described in Appendix B of the specification: the
+//! directives of the input are processed, the rules they name are pulled in
+//! from the referenced modules (prefixed into a namespace where an `as` clause
+//! asks for one), and the result is a document containing no directives that
+//! any RFC 8610 parser can read.
+
+#[cfg(not(feature = "std"))]
+use alloc::{
+  collections::{BTreeMap, BTreeSet},
+  format,
+  string::{String, ToString},
+  vec::Vec,
+};
+
+#[cfg(feature = "std")]
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::{
+  directive::{parse_directives, Directive, DirectiveKind, NameSelector},
+  scan::{scan, IdentRole},
+  ModuleError, ModuleSource,
+};
+
+/// The names of the standard prelude (Appendix D of RFC 8610). Prelude names
+/// are never namespaced when a module is imported under an `as` clause, and
+/// never count as references into a module.
+const PRELUDE: &[&str] = &[
+  "any",
+  "uint",
+  "nint",
+  "int",
+  "bstr",
+  "bytes",
+  "tstr",
+  "text",
+  "tdate",
+  "time",
+  "number",
+  "biguint",
+  "bignint",
+  "bigint",
+  "integer",
+  "unsigned",
+  "decfrac",
+  "bigfloat",
+  "eb64url",
+  "eb64legacy",
+  "eb16",
+  "encoded-cbor",
+  "uri",
+  "b64url",
+  "b64legacy",
+  "regexp",
+  "mime-message",
+  "cbor-any",
+  "float16",
+  "float32",
+  "float64",
+  "float16-32",
+  "float32-64",
+  "float",
+  "false",
+  "true",
+  "bool",
+  "nil",
+  "null",
+  "undefined",
+];
+
+/// Options controlling module resolution.
+#[derive(Debug, Clone, Default)]
+pub struct ResolveOptions {
+  /// A start (root) rule, emitted as `$.start.$ = <rule>` per §2.7 of the
+  /// specification. Corresponds to the tool's `-s` flag.
+  pub start_rule: Option<String>,
+  /// Directives synthesized from the command line, applied before any
+  /// directives found in the input, as `(namespace, module)` pairs. Corresponds
+  /// to the tool's `-i` flag, where `-icose=rfc9052` is a shortcut for
+  /// `;# import rfc9052 as cose`.
+  pub command_line_imports: Vec<(String, String)>,
+}
+
+/// A rule definition recovered from a module, with its original text intact.
+#[derive(Debug, Clone)]
+struct ModuleRule {
+  name: String,
+  text: String,
+  deps: Vec<String>,
+}
+
+/// Resolve the module directives in `input` against `source`, returning an
+/// equivalent basic CDDL document.
+///
+/// # Errors
+///
+/// Returns a [`ModuleError`] if a directive is malformed, a referenced module
+/// cannot be found or read, a rule named in a `from` clause does not exist, or
+/// the modules reference each other cyclically.
+pub fn resolve_modules(
+  input: &str,
+  source: &dyn ModuleSource,
+  options: &ResolveOptions,
+) -> Result<String, ModuleError> {
+  let mut chain = Vec::new();
+  resolve(input, source, options, &mut chain)
+}
+
+fn resolve(
+  input: &str,
+  source: &dyn ModuleSource,
+  options: &ResolveOptions,
+  chain: &mut Vec<String>,
+) -> Result<String, ModuleError> {
+  let mut directives: Vec<Directive> = options
+    .command_line_imports
+    .iter()
+    .map(|(namespace, module)| Directive {
+      kind: DirectiveKind::Import,
+      names: None,
+      filename: module.clone(),
+      alias: Some(namespace.clone()),
+      line: 0,
+    })
+    .collect();
+
+  directives.extend(parse_directives(input)?);
+
+  let body = strip_directives(input);
+  let local = rules_of(&body);
+
+  let mut emitted: BTreeSet<String> = local.iter().map(|rule| rule.name.clone()).collect();
+  let mut references = referenced_names(&body);
+
+  if let Some(start) = &options.start_rule {
+    references.insert(start.clone());
+  }
+
+  let mut pulled: Vec<String> = Vec::new();
+
+  for directive in &directives {
+    let text = load_module(&directive.filename, directive.line, source, chain)?;
+
+    let defined: BTreeSet<String> = scan(&text)
+      .rules
+      .into_iter()
+      .map(|rule| rule.name)
+      .collect();
+
+    let text = match &directive.alias {
+      Some(alias) => apply_namespace(&text, &defined, alias),
+      None => text,
+    };
+
+    let rules = rules_of(&text);
+    let index: BTreeMap<&str, &ModuleRule> =
+      rules.iter().map(|rule| (rule.name.as_str(), rule)).collect();
+
+    let mut aliases: Vec<String> = Vec::new();
+
+    let selected = match (&directive.kind, &directive.names) {
+      // `include <module>`: every rule of the module, verbatim.
+      (DirectiveKind::Include, None) => rules.iter().map(|rule| rule.name.clone()).collect(),
+
+      // `include <names> from <module>`: exactly the rules named.
+      (DirectiveKind::Include, Some(selectors)) => {
+        let mut names = Vec::new();
+
+        for selector in selectors {
+          match selector {
+            NameSelector::All => {
+              for rule in &rules {
+                push_unique(&mut names, rule.name.clone());
+              }
+            }
+            NameSelector::Name(written) => {
+              let resolved = qualify(written, directive.alias.as_deref());
+
+              if !index.contains_key(resolved.as_str()) {
+                return Err(ModuleError::RuleNotFound {
+                  rule: written.clone(),
+                  module: directive.filename.clone(),
+                  line: directive.line,
+                });
+              }
+
+              push_unique(&mut names, resolved);
+            }
+          }
+        }
+
+        names
+      }
+
+      // `import <module>`: the rules this module references, transitively.
+      (DirectiveKind::Import, None) => {
+        let seeds: Vec<String> = rules
+          .iter()
+          .map(|rule| rule.name.clone())
+          .filter(|name| references.contains(name))
+          .collect();
+
+        closure(&seeds, &index)
+      }
+
+      // `import <names> from <module>`: the rules named, transitively.
+      (DirectiveKind::Import, Some(selectors)) => {
+        let mut seeds = Vec::new();
+
+        for selector in selectors {
+          match selector {
+            NameSelector::All => {
+              for rule in &rules {
+                push_unique(&mut seeds, rule.name.clone());
+              }
+            }
+            NameSelector::Name(written) => {
+              let resolved = qualify(written, directive.alias.as_deref());
+
+              if !index.contains_key(resolved.as_str()) {
+                return Err(ModuleError::RuleNotFound {
+                  rule: written.clone(),
+                  module: directive.filename.clone(),
+                  line: directive.line,
+                });
+              }
+
+              // §2.6: importing a name that was written without the namespace
+              // prefix also defines an unprefixed alias for it.
+              if resolved != *written && !emitted.contains(written) {
+                aliases.push(format!("{} = {}", written, resolved));
+              }
+
+              push_unique(&mut seeds, resolved);
+            }
+          }
+        }
+
+        closure(&seeds, &index)
+      }
+    };
+
+    for alias in aliases {
+      pulled.push(alias);
+    }
+
+    for name in selected {
+      if !emitted.insert(name.clone()) {
+        continue;
+      }
+
+      if let Some(rule) = index.get(name.as_str()) {
+        pulled.push(rule.text.clone());
+      }
+    }
+  }
+
+  let mut output = String::new();
+
+  if let Some(start) = &options.start_rule {
+    output.push_str(&format!("$.start.$ = {}\n", start));
+  }
+
+  let body = body.trim();
+  if !body.is_empty() {
+    output.push_str(body);
+    output.push('\n');
+  }
+
+  for rule in pulled {
+    output.push_str(rule.trim_end());
+    output.push('\n');
+  }
+
+  Ok(output)
+}
+
+/// Load a module and resolve its own directives, so that what a caller sees is
+/// always basic CDDL.
+fn load_module(
+  name: &str,
+  line: usize,
+  source: &dyn ModuleSource,
+  chain: &mut Vec<String>,
+) -> Result<String, ModuleError> {
+  if chain.iter().any(|entry| entry == name) {
+    let mut cycle = chain.clone();
+    cycle.push(name.to_string());
+
+    return Err(ModuleError::CircularReference { chain: cycle });
+  }
+
+  let text = source
+    .load(name)?
+    .ok_or_else(|| ModuleError::ModuleNotFound {
+      name: name.to_string(),
+      line,
+    })?;
+
+  chain.push(name.to_string());
+  let resolved = resolve(&text, source, &ResolveOptions::default(), chain);
+  chain.pop();
+
+  resolved
+}
+
+/// Resolve a name written in a directive against the directive's namespace.
+fn qualify(written: &str, alias: Option<&str>) -> String {
+  match alias {
+    Some(alias) if !written.starts_with(&format!("{}.", alias)) => format!("{}.{}", alias, written),
+    _ => written.to_string(),
+  }
+}
+
+fn push_unique(names: &mut Vec<String>, name: String) {
+  if !names.contains(&name) {
+    names.push(name);
+  }
+}
+
+/// Breadth-first transitive closure over rule dependencies, in discovery order.
+fn closure(seeds: &[String], index: &BTreeMap<&str, &ModuleRule>) -> Vec<String> {
+  let mut ordered: Vec<String> = Vec::new();
+  let mut queue: Vec<String> = seeds.to_vec();
+  let mut head = 0usize;
+
+  while head < queue.len() {
+    let name = queue[head].clone();
+    head += 1;
+
+    if ordered.contains(&name) {
+      continue;
+    }
+
+    ordered.push(name.clone());
+
+    if let Some(rule) = index.get(name.as_str()) {
+      for dep in &rule.deps {
+        if !ordered.contains(dep) {
+          queue.push(dep.clone());
+        }
+      }
+    }
+  }
+
+  ordered
+}
+
+/// Remove directive lines, leaving the rest of the document otherwise intact.
+fn strip_directives(input: &str) -> String {
+  let mut output = String::with_capacity(input.len());
+
+  for line in input.lines() {
+    if line.trim_end_matches('\r').starts_with(";#") {
+      continue;
+    }
+
+    output.push_str(line);
+    output.push('\n');
+  }
+
+  output
+}
+
+/// Split a document into its rules, recording each rule's dependencies on
+/// other rules of the same document.
+fn rules_of(src: &str) -> Vec<ModuleRule> {
+  let scanned = scan(src);
+  let defined: BTreeSet<&str> = scanned
+    .rules
+    .iter()
+    .map(|rule| rule.name.as_str())
+    .collect();
+
+  scanned
+    .rules
+    .iter()
+    .map(|rule| {
+      let mut deps: Vec<String> = Vec::new();
+
+      for ident in &scanned.idents {
+        if ident.role != IdentRole::Reference
+          || ident.start < rule.start
+          || ident.end > rule.end
+          || ident.text == rule.name
+          || PRELUDE.contains(&ident.text.as_str())
+          || !defined.contains(ident.text.as_str())
+        {
+          continue;
+        }
+
+        push_unique(&mut deps, ident.text.clone());
+      }
+
+      ModuleRule {
+        name: rule.name.clone(),
+        text: src[rule.start..rule.end].to_string(),
+        deps,
+      }
+    })
+    .collect()
+}
+
+/// Every name referenced — as opposed to defined — by a document.
+fn referenced_names(src: &str) -> BTreeSet<String> {
+  scan(src)
+    .idents
+    .into_iter()
+    .filter(|ident| ident.role == IdentRole::Reference)
+    .map(|ident| ident.text)
+    .collect()
+}
+
+/// Rewrite a module so that every name it defines, and every reference to one,
+/// carries the given namespace prefix. Prelude names are left alone.
+fn apply_namespace(src: &str, defined: &BTreeSet<String>, namespace: &str) -> String {
+  let scanned = scan(src);
+  let mut output = String::with_capacity(src.len());
+  let mut cursor = 0usize;
+
+  for ident in &scanned.idents {
+    if !matches!(ident.role, IdentRole::RuleHead | IdentRole::Reference)
+      || PRELUDE.contains(&ident.text.as_str())
+      || !defined.contains(&ident.text)
+    {
+      continue;
+    }
+
+    output.push_str(&src[cursor..ident.start]);
+    output.push_str(namespace);
+    output.push('.');
+    output.push_str(&ident.text);
+    cursor = ident.end;
+  }
+
+  output.push_str(&src[cursor..]);
+  output
+}

--- a/src/modules/scan.rs
+++ b/src/modules/scan.rs
@@ -79,9 +79,9 @@ fn is_ident_continue(b: u8) -> bool {
 fn generic_params_end(bytes: &[u8], open: usize) -> Option<usize> {
   let mut i = open + 1;
   while i < bytes.len() && bytes[i] != b'>' {
-    // Parameters are plain identifiers; anything structural means this is not
-    // a parameter list.
-    if matches!(bytes[i], b'(' | b'[' | b'{' | b'<' | b'"' | b'\'' | b';' | b'\n') {
+    // Parameters are plain identifiers separated by commas and whitespace;
+    // anything structural means this is not a parameter list.
+    if matches!(bytes[i], b'(' | b'[' | b'{' | b'<' | b'"' | b'\'' | b';') {
       return None;
     }
     i += 1;
@@ -210,26 +210,31 @@ pub(crate) fn scan(src: &str) -> Scan {
       // assignment operator, i.e. the head of `messages<a, b> = ...`. Anywhere
       // else a `<` group holds generic *arguments*, whose identifiers are real
       // references and are scanned normally.
-      b'<' if depth == 0 && generic_params_end(bytes, i).is_some() => {
-        let close = generic_params_end(bytes, i).unwrap();
-        i += 1;
-        while i < close {
-          if is_ident_start(bytes[i]) {
-            let start = i;
-            while i < close && (is_ident_continue(bytes[i]) || bytes[i] == b'-') {
-              i += 1;
-            }
-            idents.push(IdentToken {
-              start,
-              end: i,
-              text: src[start..i].to_string(),
-              role: IdentRole::GenericParam,
-            });
-          } else {
+      b'<' if depth == 0 => {
+        match generic_params_end(bytes, i) {
+          Some(close) => {
             i += 1;
+            while i < close {
+              if is_ident_start(bytes[i]) {
+                let start = i;
+                while i < close && (is_ident_continue(bytes[i]) || bytes[i] == b'-') {
+                  i += 1;
+                }
+                idents.push(IdentToken {
+                  start,
+                  end: i,
+                  text: src[start..i].to_string(),
+                  role: IdentRole::GenericParam,
+                });
+              } else {
+                i += 1;
+              }
+            }
+            i = close + 1;
           }
+          None => i += 1,
         }
-        i = close + 1;
+
         prev_was_ident_end = false;
       }
 
@@ -365,6 +370,31 @@ mod tests {
       .iter()
       .filter(|i| i.text == "a")
       .any(|i| i.role == IdentRole::GenericParam));
+  }
+
+  #[test]
+  fn generic_parameters_may_span_lines() {
+    let scan = scan("messages<\n  a,\n  b\n> = [a, b]\n");
+    assert_eq!(scan.rules.len(), 1);
+    assert_eq!(scan.rules[0].name, "messages");
+  }
+
+  #[test]
+  fn generic_arguments_are_references() {
+    let scan = scan("a = messages<int>\n");
+    assert_eq!(scan.rules.len(), 1);
+    assert_eq!(scan.rules[0].name, "a");
+    assert!(scan
+      .idents
+      .iter()
+      .any(|i| i.text == "messages" && i.role == IdentRole::Reference));
+  }
+
+  #[test]
+  fn extensions_are_separate_spans() {
+    let scan = scan("foo = int\nbar = tstr\nfoo /= tstr\n");
+    let names: Vec<_> = scan.rules.iter().map(|r| r.name.as_str()).collect();
+    assert_eq!(names, ["foo", "bar", "foo"]);
   }
 
   #[test]

--- a/src/modules/scan.rs
+++ b/src/modules/scan.rs
@@ -1,0 +1,376 @@
+//! A minimal structural scanner over CDDL source text.
+//!
+//! Module resolution is a source-to-source transformation, so it needs three
+//! things from a module's text and nothing more: where each rule begins and
+//! ends, what each rule is named, and which identifiers a rule references. A
+//! full parse would give all three, but it would also discard the original
+//! formatting that the resolved output is expected to preserve, and it would
+//! couple resolution to the AST's lifetimes. This scanner works directly on the
+//! text instead.
+//!
+//! It is deliberately conservative: string literals, comments and control
+//! operator names are recognized only well enough to keep them from being
+//! mistaken for rule references. A false positive is harmless — an identifier
+//! that names no rule in the module is simply ignored during selection.
+
+#[cfg(not(feature = "std"))]
+use alloc::{
+  string::{String, ToString},
+  vec::Vec,
+};
+
+/// What an identifier occurrence means structurally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IdentRole {
+  /// The name being defined by a rule.
+  RuleHead,
+  /// A reference to some other name.
+  Reference,
+  /// The name of a control operator, e.g. the `size` in `.size`.
+  ControlName,
+  /// A generic parameter in a rule head, which is local to that rule.
+  GenericParam,
+}
+
+/// A single identifier occurrence, as a byte range into the scanned source.
+#[derive(Debug, Clone)]
+pub(crate) struct IdentToken {
+  /// Byte offset of the first character.
+  pub start: usize,
+  /// Byte offset one past the last character.
+  pub end: usize,
+  /// The identifier text.
+  pub text: String,
+  /// What this occurrence means.
+  pub role: IdentRole,
+}
+
+/// The extent of a single rule definition.
+#[derive(Debug, Clone)]
+pub(crate) struct RuleSpan {
+  /// The defined name.
+  pub name: String,
+  /// Byte offset where the rule begins (at its head identifier).
+  pub start: usize,
+  /// Byte offset one past the end of the rule, trailing whitespace trimmed.
+  pub end: usize,
+}
+
+/// The result of scanning a CDDL document.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct Scan {
+  /// Every identifier occurrence, in source order.
+  pub idents: Vec<IdentToken>,
+  /// Every rule definition, in source order.
+  pub rules: Vec<RuleSpan>,
+}
+
+fn is_ident_start(b: u8) -> bool {
+  b == b'$' || b == b'_' || b == b'@' || b.is_ascii_alphabetic()
+}
+
+fn is_ident_continue(b: u8) -> bool {
+  is_ident_start(b) || b.is_ascii_digit()
+}
+
+/// If the `<` at `open` begins a generic *parameter* list — that is, if the
+/// group it opens is followed by an assignment operator — return the byte
+/// offset of its closing `>`.
+fn generic_params_end(bytes: &[u8], open: usize) -> Option<usize> {
+  let mut i = open + 1;
+  while i < bytes.len() && bytes[i] != b'>' {
+    // Parameters are plain identifiers; anything structural means this is not
+    // a parameter list.
+    if matches!(bytes[i], b'(' | b'[' | b'{' | b'<' | b'"' | b'\'' | b';' | b'\n') {
+      return None;
+    }
+    i += 1;
+  }
+
+  if i >= bytes.len() {
+    return None;
+  }
+
+  let close = i;
+  let mut j = close + 1;
+  while j < bytes.len() && matches!(bytes[j], b' ' | b'\t' | b'\r' | b'\n') {
+    j += 1;
+  }
+
+  while j < bytes.len() && bytes[j] == b'/' {
+    j += 1;
+  }
+
+  if j < bytes.len() && bytes[j] == b'=' && !(j + 1 < bytes.len() && bytes[j + 1] == b'>') {
+    Some(close)
+  } else {
+    None
+  }
+}
+
+/// Scan `src`, recovering rule extents and identifier occurrences.
+pub(crate) fn scan(src: &str) -> Scan {
+  let bytes = src.as_bytes();
+  let mut idents: Vec<IdentToken> = Vec::new();
+  // Byte offsets of assignment operators found at bracket depth zero.
+  let mut top_level_assigns: Vec<usize> = Vec::new();
+
+  let mut i = 0usize;
+  let mut depth = 0usize;
+  // Byte offset of the previous non-whitespace byte, used to tell a control
+  // operator (`bstr .size 4`, where `.` follows whitespace) from a namespaced
+  // identifier (`cose.label`, where `.` is part of the identifier itself).
+  let mut prev_was_ident_end = false;
+
+  while i < bytes.len() {
+    let b = bytes[i];
+
+    match b {
+      b' ' | b'\t' | b'\r' | b'\n' => {
+        prev_was_ident_end = false;
+        i += 1;
+      }
+
+      // Comment (including a `;#` directive line) runs to end of line.
+      b';' => {
+        prev_was_ident_end = false;
+        while i < bytes.len() && bytes[i] != b'\n' {
+          i += 1;
+        }
+      }
+
+      // Text string.
+      b'"' => {
+        prev_was_ident_end = false;
+        i += 1;
+        while i < bytes.len() {
+          match bytes[i] {
+            b'\\' => i += 2,
+            b'"' => {
+              i += 1;
+              break;
+            }
+            _ => i += 1,
+          }
+        }
+      }
+
+      // Byte string.
+      b'\'' => {
+        prev_was_ident_end = false;
+        i += 1;
+        while i < bytes.len() {
+          match bytes[i] {
+            b'\\' => i += 2,
+            b'\'' => {
+              i += 1;
+              break;
+            }
+            _ => i += 1,
+          }
+        }
+      }
+
+      b'(' | b'[' | b'{' => {
+        prev_was_ident_end = false;
+        depth += 1;
+        i += 1;
+      }
+
+      b')' | b']' | b'}' => {
+        prev_was_ident_end = false;
+        depth = depth.saturating_sub(1);
+        i += 1;
+      }
+
+      // A control operator: a `.` that does not directly follow an identifier
+      // character. The name that follows is an operator name, not a reference.
+      b'.' if !prev_was_ident_end => {
+        i += 1;
+        // `..` and `...` are range operators, not control operators.
+        while i < bytes.len() && bytes[i] == b'.' {
+          i += 1;
+        }
+        if i < bytes.len() && is_ident_start(bytes[i]) {
+          let start = i;
+          while i < bytes.len() && (is_ident_continue(bytes[i]) || bytes[i] == b'-') {
+            i += 1;
+          }
+          idents.push(IdentToken {
+            start,
+            end: i,
+            text: src[start..i].to_string(),
+            role: IdentRole::ControlName,
+          });
+        }
+        prev_was_ident_end = false;
+      }
+
+      // Generic parameters: a `<` group that is immediately followed by an
+      // assignment operator, i.e. the head of `messages<a, b> = ...`. Anywhere
+      // else a `<` group holds generic *arguments*, whose identifiers are real
+      // references and are scanned normally.
+      b'<' if depth == 0 && generic_params_end(bytes, i).is_some() => {
+        let close = generic_params_end(bytes, i).unwrap();
+        i += 1;
+        while i < close {
+          if is_ident_start(bytes[i]) {
+            let start = i;
+            while i < close && (is_ident_continue(bytes[i]) || bytes[i] == b'-') {
+              i += 1;
+            }
+            idents.push(IdentToken {
+              start,
+              end: i,
+              text: src[start..i].to_string(),
+              role: IdentRole::GenericParam,
+            });
+          } else {
+            i += 1;
+          }
+        }
+        i = close + 1;
+        prev_was_ident_end = false;
+      }
+
+      // Assignment operators: `=`, `/=`, `//=`. `=>` is an entry separator and
+      // must not be mistaken for one.
+      b'=' if i + 1 >= bytes.len() || bytes[i + 1] != b'>' => {
+        if depth == 0 {
+          top_level_assigns.push(i);
+        }
+        prev_was_ident_end = false;
+        i += 1;
+      }
+
+      _ if is_ident_start(b) => {
+        let start = i;
+        while i < bytes.len() {
+          let c = bytes[i];
+          if is_ident_continue(c) || c == b'-' {
+            i += 1;
+          } else if c == b'.'
+            && i + 1 < bytes.len()
+            && (is_ident_continue(bytes[i + 1]) || bytes[i + 1] == b'-')
+          {
+            // A namespaced name such as `cose.label`: the dot binds tightly to
+            // the surrounding identifier characters.
+            i += 2;
+          } else {
+            break;
+          }
+        }
+        idents.push(IdentToken {
+          start,
+          end: i,
+          text: src[start..i].to_string(),
+          role: IdentRole::Reference,
+        });
+        prev_was_ident_end = true;
+      }
+
+      _ => {
+        prev_was_ident_end = false;
+        i += 1;
+      }
+    }
+  }
+
+  // The head of a rule is the last plain reference occurring before its
+  // assignment operator; generic parameters and control names are excluded by
+  // construction.
+  let mut head_indices: Vec<usize> = Vec::new();
+  for assign in &top_level_assigns {
+    let head = idents
+      .iter()
+      .enumerate()
+      .rev()
+      .find(|(_, id)| id.end <= *assign && id.role == IdentRole::Reference)
+      .map(|(idx, _)| idx);
+
+    if let Some(idx) = head {
+      if !head_indices.contains(&idx) {
+        head_indices.push(idx);
+      }
+    }
+  }
+
+  for idx in &head_indices {
+    idents[*idx].role = IdentRole::RuleHead;
+  }
+
+  let mut rules: Vec<RuleSpan> = Vec::new();
+  for (n, idx) in head_indices.iter().enumerate() {
+    let start = idents[*idx].start;
+    let end = match head_indices.get(n + 1) {
+      Some(next) => idents[*next].start,
+      None => src.len(),
+    };
+    let end = src[start..end].trim_end().len() + start;
+
+    rules.push(RuleSpan {
+      name: idents[*idx].text.clone(),
+      start,
+      end,
+    });
+  }
+
+  Scan { idents, rules }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn finds_rule_extents_and_names() {
+    let src = "label = int / tstr\nvalues = any\n";
+    let scan = scan(src);
+    let names: Vec<_> = scan.rules.iter().map(|r| r.name.as_str()).collect();
+    assert_eq!(names, ["label", "values"]);
+    assert_eq!(&src[scan.rules[0].start..scan.rules[0].end], "label = int / tstr");
+  }
+
+  #[test]
+  fn namespaced_names_scan_as_one_identifier() {
+    let scan = scan("mydata = {Fritz: cose.empty_or_serialized_map}");
+    assert!(scan.idents.iter().any(|i| i.text == "cose.empty_or_serialized_map"));
+  }
+
+  #[test]
+  fn control_names_are_not_references() {
+    let scan = scan("a = bstr .cbor header_map");
+    let cbor = scan.idents.iter().find(|i| i.text == "cbor").unwrap();
+    assert_eq!(cbor.role, IdentRole::ControlName);
+    assert!(scan
+      .idents
+      .iter()
+      .any(|i| i.text == "header_map" && i.role == IdentRole::Reference));
+  }
+
+  #[test]
+  fn entry_separator_is_not_an_assignment() {
+    let scan = scan("m = {\n  1 => tstr,\n}\nn = int\n");
+    let names: Vec<_> = scan.rules.iter().map(|r| r.name.as_str()).collect();
+    assert_eq!(names, ["m", "n"]);
+  }
+
+  #[test]
+  fn generic_parameters_are_local() {
+    let scan = scan("messages<a, b> = [a, b]\n");
+    assert_eq!(scan.rules.len(), 1);
+    assert_eq!(scan.rules[0].name, "messages");
+    assert!(scan
+      .idents
+      .iter()
+      .filter(|i| i.text == "a")
+      .any(|i| i.role == IdentRole::GenericParam));
+  }
+
+  #[test]
+  fn comments_and_strings_are_skipped() {
+    let scan = scan("a = \"not_a_rule = x\" ; nor = this\nb = int\n");
+    let names: Vec<_> = scan.rules.iter().map(|r| r.name.as_str()).collect();
+    assert_eq!(names, ["a", "b"]);
+  }
+}

--- a/src/modules/scan.rs
+++ b/src/modules/scan.rs
@@ -333,13 +333,19 @@ mod tests {
     let scan = scan(src);
     let names: Vec<_> = scan.rules.iter().map(|r| r.name.as_str()).collect();
     assert_eq!(names, ["label", "values"]);
-    assert_eq!(&src[scan.rules[0].start..scan.rules[0].end], "label = int / tstr");
+    assert_eq!(
+      &src[scan.rules[0].start..scan.rules[0].end],
+      "label = int / tstr"
+    );
   }
 
   #[test]
   fn namespaced_names_scan_as_one_identifier() {
     let scan = scan("mydata = {Fritz: cose.empty_or_serialized_map}");
-    assert!(scan.idents.iter().any(|i| i.text == "cose.empty_or_serialized_map"));
+    assert!(scan
+      .idents
+      .iter()
+      .any(|i| i.text == "cose.empty_or_serialized_map"));
   }
 
   #[test]

--- a/src/modules/source.rs
+++ b/src/modules/source.rs
@@ -136,9 +136,13 @@ mod tests {
 
   #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
   #[test]
-  fn empty_include_path_elements_are_skipped() {
+  fn empty_include_path_elements_carry_no_bundled_collection() {
+    // §2.4 gives an empty element the meaning "the processor's own collection".
+    // This implementation ships no such collection, so the element resolves to
+    // nothing rather than to the root directory.
     let source = FsModuleSource::from_include_path(".:");
     assert_eq!(source.directories().len(), 1);
+    assert_eq!(source.load("rfc9052").unwrap(), None);
   }
 }
 

--- a/src/modules/source.rs
+++ b/src/modules/source.rs
@@ -1,0 +1,144 @@
+//! Locating module sources.
+
+#[cfg(not(feature = "std"))]
+use alloc::{collections::BTreeMap, string::String};
+
+#[cfg(feature = "std")]
+use std::collections::BTreeMap;
+
+use super::ModuleError;
+
+/// A provider of module sources, keyed by the filename written in a directive.
+///
+/// This is the seam that keeps module resolution usable on targets without a
+/// filesystem (notably `wasm32-unknown-unknown`), where the embedder supplies
+/// module text directly.
+pub trait ModuleSource {
+  /// Return the CDDL text of the named module, or `None` if this source does
+  /// not provide it.
+  fn load(&self, name: &str) -> Result<Option<String>, ModuleError>;
+}
+
+/// An in-memory [`ModuleSource`], usable on every target.
+#[derive(Debug, Clone, Default)]
+pub struct MemoryModuleSource {
+  modules: BTreeMap<String, String>,
+}
+
+impl MemoryModuleSource {
+  /// Create an empty source.
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  /// Register the text of a module under `name`.
+  pub fn insert(&mut self, name: impl Into<String>, text: impl Into<String>) -> &mut Self {
+    self.modules.insert(name.into(), text.into());
+    self
+  }
+}
+
+impl ModuleSource for MemoryModuleSource {
+  fn load(&self, name: &str) -> Result<Option<String>, ModuleError> {
+    Ok(self.modules.get(name).cloned())
+  }
+}
+
+/// The environment variable naming the module search path.
+#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
+pub const INCLUDE_PATH_VAR: &str = "CDDL_INCLUDE_PATH";
+
+/// The search path used when [`INCLUDE_PATH_VAR`] is unset: the current
+/// directory, followed by the processor's own collection.
+#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
+pub const DEFAULT_INCLUDE_PATH: &str = ".:";
+
+/// A [`ModuleSource`] backed by a colon-separated search path of directories,
+/// per §2.4 of the specification.
+///
+/// An empty path element denotes the processor's own bundled collection of
+/// modules extracted from published RFCs. This implementation ships no such
+/// collection, so empty elements are accepted and skipped rather than being
+/// resolved against the root directory.
+#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
+#[derive(Debug, Clone, Default)]
+pub struct FsModuleSource {
+  directories: Vec<std::path::PathBuf>,
+}
+
+#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
+impl FsModuleSource {
+  /// Build a source from a colon-separated search path.
+  pub fn from_include_path(path: &str) -> Self {
+    FsModuleSource {
+      directories: path
+        .split(':')
+        .filter(|element| !element.is_empty())
+        .map(std::path::PathBuf::from)
+        .collect(),
+    }
+  }
+
+  /// Build a source from `CDDL_INCLUDE_PATH`, falling back to
+  /// [`DEFAULT_INCLUDE_PATH`].
+  pub fn from_env() -> Self {
+    match std::env::var(INCLUDE_PATH_VAR) {
+      Ok(path) if !path.is_empty() => Self::from_include_path(&path),
+      _ => Self::from_include_path(DEFAULT_INCLUDE_PATH),
+    }
+  }
+
+  /// The directories searched, in order.
+  pub fn directories(&self) -> &[std::path::PathBuf] {
+    &self.directories
+  }
+}
+
+#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
+impl ModuleSource for FsModuleSource {
+  fn load(&self, name: &str) -> Result<Option<String>, ModuleError> {
+    for directory in &self.directories {
+      // A module name matches the `filename` production, which admits no path
+      // separator, so this can only ever name a direct child.
+      for candidate in [directory.join(name), directory.join(format!("{}.cddl", name))] {
+        if !candidate.is_file() {
+          continue;
+        }
+
+        return std::fs::read_to_string(&candidate)
+          .map(Some)
+          .map_err(|e| ModuleError::ModuleUnreadable {
+            name: name.to_string(),
+            message: e.to_string(),
+          });
+      }
+    }
+
+    Ok(None)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn memory_source_round_trips() {
+    let mut source = MemoryModuleSource::new();
+    source.insert("rfc9052", "label = int / tstr\n");
+
+    assert_eq!(
+      source.load("rfc9052").unwrap().as_deref(),
+      Some("label = int / tstr\n")
+    );
+    assert_eq!(source.load("missing").unwrap(), None);
+  }
+
+  #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
+  #[test]
+  fn empty_include_path_elements_are_skipped() {
+    let source = FsModuleSource::from_include_path(".:");
+    assert_eq!(source.directories().len(), 1);
+  }
+}
+

--- a/src/modules/source.rs
+++ b/src/modules/source.rs
@@ -48,13 +48,28 @@ impl ModuleSource for MemoryModuleSource {
 #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 pub const INCLUDE_PATH_VAR: &str = "CDDL_INCLUDE_PATH";
 
+/// The character separating elements of the module search path: `;` on Windows,
+/// where `:` occurs in drive-letter paths, and `:` elsewhere.
+#[cfg(all(feature = "std", not(target_arch = "wasm32"), windows))]
+pub const INCLUDE_PATH_SEPARATOR: char = ';';
+
+/// The character separating elements of the module search path: `;` on Windows,
+/// where `:` occurs in drive-letter paths, and `:` elsewhere.
+#[cfg(all(feature = "std", not(target_arch = "wasm32"), not(windows)))]
+pub const INCLUDE_PATH_SEPARATOR: char = ':';
+
 /// The search path used when [`INCLUDE_PATH_VAR`] is unset: the current
 /// directory, followed by the processor's own collection.
-#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
+#[cfg(all(feature = "std", not(target_arch = "wasm32"), windows))]
+pub const DEFAULT_INCLUDE_PATH: &str = ".;";
+
+/// The search path used when [`INCLUDE_PATH_VAR`] is unset: the current
+/// directory, followed by the processor's own collection.
+#[cfg(all(feature = "std", not(target_arch = "wasm32"), not(windows)))]
 pub const DEFAULT_INCLUDE_PATH: &str = ".:";
 
-/// A [`ModuleSource`] backed by a colon-separated search path of directories,
-/// per §2.4 of the specification.
+/// A [`ModuleSource`] backed by a search path of directories separated by
+/// [`INCLUDE_PATH_SEPARATOR`], per §2.4 of the specification.
 ///
 /// An empty path element denotes the processor's own bundled collection of
 /// modules extracted from published RFCs. This implementation ships no such
@@ -68,11 +83,12 @@ pub struct FsModuleSource {
 
 #[cfg(all(feature = "std", not(target_arch = "wasm32")))]
 impl FsModuleSource {
-  /// Build a source from a colon-separated search path.
+  /// Build a source from a search path whose elements are separated by
+  /// [`INCLUDE_PATH_SEPARATOR`].
   pub fn from_include_path(path: &str) -> Self {
     FsModuleSource {
       directories: path
-        .split(':')
+        .split(INCLUDE_PATH_SEPARATOR)
         .filter(|element| !element.is_empty())
         .map(std::path::PathBuf::from)
         .collect(),
@@ -143,7 +159,7 @@ mod tests {
     // §2.4 gives an empty element the meaning "the processor's own collection".
     // This implementation ships no such collection, so the element resolves to
     // nothing rather than to the root directory.
-    let source = FsModuleSource::from_include_path(".:");
+    let source = FsModuleSource::from_include_path(DEFAULT_INCLUDE_PATH);
     assert_eq!(source.directories().len(), 1);
     assert_eq!(source.load("rfc9052").unwrap(), None);
   }

--- a/src/modules/source.rs
+++ b/src/modules/source.rs
@@ -100,17 +100,20 @@ impl ModuleSource for FsModuleSource {
     for directory in &self.directories {
       // A module name matches the `filename` production, which admits no path
       // separator, so this can only ever name a direct child.
-      for candidate in [directory.join(name), directory.join(format!("{}.cddl", name))] {
+      for candidate in [
+        directory.join(name),
+        directory.join(format!("{}.cddl", name)),
+      ] {
         if !candidate.is_file() {
           continue;
         }
 
-        return std::fs::read_to_string(&candidate)
-          .map(Some)
-          .map_err(|e| ModuleError::ModuleUnreadable {
+        return std::fs::read_to_string(&candidate).map(Some).map_err(|e| {
+          ModuleError::ModuleUnreadable {
             name: name.to_string(),
             message: e.to_string(),
-          });
+          }
+        });
       }
     }
 
@@ -145,4 +148,3 @@ mod tests {
     assert_eq!(source.load("rfc9052").unwrap(), None);
   }
 }
-

--- a/tests/modules.rs
+++ b/tests/modules.rs
@@ -310,6 +310,44 @@ fn a_malformed_directive_is_an_error_not_a_comment() {
 }
 
 #[test]
+fn a_rule_carries_its_noncontiguous_extensions() {
+  let mut source = MemoryModuleSource::new();
+  source.insert(
+    "ext",
+    "foo = int\nbar = baz\nbaz = tstr\nfoo /= tstr\n",
+  );
+
+  let output = resolve_modules(
+    "start = foo\n;# include foo from ext\n",
+    &source,
+    &ResolveOptions::default(),
+  )
+  .unwrap();
+
+  assert!(output.contains("foo = int"), "{}", output);
+  assert!(output.contains("foo /= tstr"), "{}", output);
+  assert!(!output.contains("bar"), "{}", output);
+  assert_parses(&output);
+}
+
+#[test]
+fn a_later_import_sees_references_introduced_by_an_earlier_include() {
+  let mut source = MemoryModuleSource::new();
+  source.insert("module-a", "wrapper = [* external]\n");
+  source.insert("module-b", "external = int\nunused = tstr\n");
+
+  let output = resolve_modules(
+    "root = wrapper\n;# include wrapper from module-a\n;# import module-b\n",
+    &source,
+    &ResolveOptions::default(),
+  )
+  .unwrap();
+
+  assert_eq!(defined_order(&output), ["root", "wrapper", "external"]);
+  assert_parses(&output);
+}
+
+#[test]
 fn a_rule_already_defined_locally_is_not_pulled_in() {
   let output = resolve("label = tstr\nmydata = {* label => values}\n;# include label, values from rfc9052\n");
 

--- a/tests/modules.rs
+++ b/tests/modules.rs
@@ -1,0 +1,320 @@
+#![cfg(all(feature = "modules", feature = "std", not(target_arch = "wasm32")))]
+
+//! Conformance tests for the CDDL module structure, drawn from the examples in
+//! draft-ietf-cbor-cddl-modules-06.
+
+use cddl::modules::{resolve_modules, MemoryModuleSource, ModuleError, ResolveOptions};
+
+/// The CDDL of RFC 9052 used throughout §2.5 and §2.6 of the specification.
+const RFC9052: &str = r#"COSE_Key = {
+  1 => tstr / int,
+  ? 2 => bstr,
+  ? 3 => tstr / int,
+  ? 4 => [+ tstr / int],
+  ? 5 => bstr,
+  * label => values,
+}
+empty_or_serialized_map = bstr .cbor header_map / bstr .size 0
+header_map = {
+  Generic_Headers,
+  * label => values,
+}
+Generic_Headers = (
+  ? 1 => int / tstr,
+  ? 2 => [+ label],
+  ? 3 => tstr / int,
+  ? 4 => bstr,
+  ? (5 => bstr // 6 => bstr),
+  )
+label = int / tstr
+values = any
+"#;
+
+fn cose() -> MemoryModuleSource {
+  let mut source = MemoryModuleSource::new();
+  source.insert("rfc9052", RFC9052);
+  source
+}
+
+fn resolve(input: &str) -> String {
+  resolve_modules(input, &cose(), &ResolveOptions::default()).unwrap()
+}
+
+/// The order in which rules are defined in `output`.
+fn defined_order(output: &str) -> Vec<String> {
+  output
+    .lines()
+    .filter_map(|line| {
+      if line.starts_with(' ') {
+        return None;
+      }
+
+      let assign = line.find('=')?;
+
+      // `=>` is an entry separator, not a rule definition.
+      if line.as_bytes().get(assign + 1) == Some(&b'>') {
+        return None;
+      }
+
+      let head = line[..assign].trim_end_matches('/').trim();
+
+      if head.is_empty() || head.contains(' ') {
+        return None;
+      }
+
+      Some(head.to_string())
+    })
+    .collect()
+}
+
+/// Every resolved document must be readable by a basic CDDL parser.
+fn assert_parses(output: &str) {
+  assert!(
+    cddl::parser::cddl_from_str(output, false).is_ok(),
+    "resolved output is not valid basic CDDL:\n{}",
+    output
+  );
+  assert!(
+    !output.contains(";#"),
+    "resolved output still contains directives:\n{}",
+    output
+  );
+}
+
+#[test]
+fn import_pulls_referenced_rules_transitively() {
+  let output = resolve("start = COSE_Key\n;# import rfc9052\n");
+
+  assert_eq!(
+    defined_order(&output),
+    ["start", "COSE_Key", "label", "values"]
+  );
+  assert!(!output.contains("header_map"));
+  assert_parses(&output);
+}
+
+#[test]
+fn import_as_namespaces_module_rules_but_not_the_prelude() {
+  let output = resolve("start = cose.COSE_Key\n;# import rfc9052 as cose\n");
+
+  assert_eq!(
+    defined_order(&output),
+    ["start", "cose.COSE_Key", "cose.label", "cose.values"]
+  );
+  assert!(output.contains("* cose.label => cose.values"));
+  assert!(output.contains("cose.label = int / tstr"));
+  // Prelude names are never prefixed.
+  assert!(!output.contains("cose.tstr"));
+  assert!(!output.contains("cose.int"));
+  assert!(!output.contains("cose.any"));
+  assert_parses(&output);
+}
+
+#[test]
+fn include_from_takes_exactly_the_rules_named() {
+  let output = resolve("mydata = {* label => values}\n;# include label, values from rfc9052\n");
+
+  assert_eq!(defined_order(&output), ["mydata", "label", "values"]);
+  assert!(!output.contains("COSE_Key"));
+  assert_parses(&output);
+}
+
+#[test]
+fn include_from_honors_an_already_namespaced_selector() {
+  let output = resolve(
+    "mydata = {* cose.label => cose.values}\n;# include cose.label, cose.values from rfc9052 as cose\n",
+  );
+
+  assert_eq!(defined_order(&output), ["mydata", "cose.label", "cose.values"]);
+  assert_parses(&output);
+}
+
+#[test]
+fn import_from_draws_in_the_transitive_closure_in_discovery_order() {
+  let output = resolve(
+    "mydata = {Fritz: cose.empty_or_serialized_map}\n;# import cose.empty_or_serialized_map from rfc9052 as cose\n",
+  );
+
+  assert_eq!(
+    defined_order(&output),
+    [
+      "mydata",
+      "cose.empty_or_serialized_map",
+      "cose.header_map",
+      "cose.Generic_Headers",
+      "cose.label",
+      "cose.values",
+    ]
+  );
+  assert!(!output.contains("COSE_Key"));
+  assert_parses(&output);
+}
+
+#[test]
+fn import_from_without_the_prefix_also_defines_an_alias() {
+  let output = resolve(
+    "mydata = {Fritz: cose.empty_or_serialized_map}\n;# import empty_or_serialized_map from rfc9052 as cose\n",
+  );
+
+  assert!(output.contains("empty_or_serialized_map = cose.empty_or_serialized_map"));
+  assert_eq!(
+    defined_order(&output),
+    [
+      "mydata",
+      "empty_or_serialized_map",
+      "cose.empty_or_serialized_map",
+      "cose.header_map",
+      "cose.Generic_Headers",
+      "cose.label",
+      "cose.values",
+    ]
+  );
+  assert_parses(&output);
+}
+
+#[test]
+fn include_without_a_from_clause_takes_every_rule() {
+  let output = resolve("mydata = {* label => values}\n;# include rfc9052\n");
+  let defined = defined_order(&output);
+
+  for name in [
+    "COSE_Key",
+    "empty_or_serialized_map",
+    "header_map",
+    "Generic_Headers",
+    "label",
+    "values",
+  ] {
+    assert!(defined.iter().any(|d| d == name), "missing {}", name);
+  }
+  assert_parses(&output);
+}
+
+#[test]
+fn wildcard_selector_takes_every_rule() {
+  let output = resolve("mydata = {* label => values}\n;# include * from rfc9052\n");
+
+  assert!(defined_order(&output).iter().any(|d| d == "COSE_Key"));
+  assert_parses(&output);
+}
+
+#[test]
+fn command_line_import_and_start_rule() {
+  let options = ResolveOptions {
+    start_rule: Some("cose.COSE_Key".to_string()),
+    command_line_imports: vec![("cose".to_string(), "rfc9052".to_string())],
+  };
+
+  let output = resolve_modules("", &cose(), &options).unwrap();
+
+  assert!(output.starts_with("$.start.$ = cose.COSE_Key\n"));
+  assert_eq!(
+    defined_order(&output),
+    [
+      "$.start.$",
+      "cose.COSE_Key",
+      "cose.label",
+      "cose.values"
+    ]
+  );
+}
+
+#[test]
+fn directives_are_resolved_transitively_through_modules() {
+  let mut source = MemoryModuleSource::new();
+  source.insert("rfc9052", RFC9052);
+  source.insert("middle", "wrapper = [* label]\n;# include label from rfc9052\n");
+
+  let output = resolve_modules(
+    "top = wrapper\n;# import middle\n",
+    &source,
+    &ResolveOptions::default(),
+  )
+  .unwrap();
+
+  assert_eq!(defined_order(&output), ["top", "wrapper", "label"]);
+  assert_parses(&output);
+}
+
+#[test]
+fn a_document_without_directives_is_unchanged() {
+  let input = "a = int\nb = [* a]\n";
+  let output = resolve(input);
+
+  assert_eq!(output, input);
+}
+
+#[test]
+fn ordinary_comments_survive_resolution() {
+  let output = resolve("; a plain comment\na = int\n");
+
+  assert!(output.contains("; a plain comment"));
+}
+
+#[test]
+fn circular_module_references_are_detected() {
+  let mut source = MemoryModuleSource::new();
+  source.insert("one", "a = b\n;# include two\n");
+  source.insert("two", "b = c\n;# include one\n");
+
+  let error = resolve_modules("start = a\n;# include one\n", &source, &ResolveOptions::default())
+    .unwrap_err();
+
+  assert!(matches!(error, ModuleError::CircularReference { .. }));
+}
+
+#[test]
+fn a_missing_module_is_reported_with_its_line() {
+  let error = resolve_modules(
+    "start = int\n;# import nowhere\n",
+    &cose(),
+    &ResolveOptions::default(),
+  )
+  .unwrap_err();
+
+  assert_eq!(
+    error,
+    ModuleError::ModuleNotFound {
+      name: "nowhere".to_string(),
+      line: 2,
+    }
+  );
+}
+
+#[test]
+fn a_missing_rule_is_reported_with_its_module() {
+  let error = resolve_modules(
+    "start = int\n;# include nonesuch from rfc9052\n",
+    &cose(),
+    &ResolveOptions::default(),
+  )
+  .unwrap_err();
+
+  assert!(matches!(
+    error,
+    ModuleError::RuleNotFound { ref rule, ref module, line: 2 }
+      if rule == "nonesuch" && module == "rfc9052"
+  ));
+}
+
+#[test]
+fn a_malformed_directive_is_an_error_not_a_comment() {
+  let error = resolve_modules(
+    "start = int\n;# improt rfc9052\n",
+    &cose(),
+    &ResolveOptions::default(),
+  )
+  .unwrap_err();
+
+  assert!(matches!(error, ModuleError::Directive { line: 2, .. }));
+}
+
+#[test]
+fn a_rule_already_defined_locally_is_not_pulled_in() {
+  let output = resolve("label = tstr\nmydata = {* label => values}\n;# include label, values from rfc9052\n");
+
+  let defined = defined_order(&output);
+  assert_eq!(defined.iter().filter(|d| *d == "label").count(), 1);
+  assert!(output.contains("label = tstr"));
+  assert_parses(&output);
+}

--- a/tests/modules.rs
+++ b/tests/modules.rs
@@ -125,7 +125,10 @@ fn include_from_honors_an_already_namespaced_selector() {
     "mydata = {* cose.label => cose.values}\n;# include cose.label, cose.values from rfc9052 as cose\n",
   );
 
-  assert_eq!(defined_order(&output), ["mydata", "cose.label", "cose.values"]);
+  assert_eq!(
+    defined_order(&output),
+    ["mydata", "cose.label", "cose.values"]
+  );
   assert_parses(&output);
 }
 
@@ -210,12 +213,7 @@ fn command_line_import_and_start_rule() {
   assert!(output.starts_with("$.start.$ = cose.COSE_Key\n"));
   assert_eq!(
     defined_order(&output),
-    [
-      "$.start.$",
-      "cose.COSE_Key",
-      "cose.label",
-      "cose.values"
-    ]
+    ["$.start.$", "cose.COSE_Key", "cose.label", "cose.values"]
   );
 }
 
@@ -223,7 +221,10 @@ fn command_line_import_and_start_rule() {
 fn directives_are_resolved_transitively_through_modules() {
   let mut source = MemoryModuleSource::new();
   source.insert("rfc9052", RFC9052);
-  source.insert("middle", "wrapper = [* label]\n;# include label from rfc9052\n");
+  source.insert(
+    "middle",
+    "wrapper = [* label]\n;# include label from rfc9052\n",
+  );
 
   let output = resolve_modules(
     "top = wrapper\n;# import middle\n",
@@ -257,8 +258,12 @@ fn circular_module_references_are_detected() {
   source.insert("one", "a = b\n;# include two\n");
   source.insert("two", "b = c\n;# include one\n");
 
-  let error = resolve_modules("start = a\n;# include one\n", &source, &ResolveOptions::default())
-    .unwrap_err();
+  let error = resolve_modules(
+    "start = a\n;# include one\n",
+    &source,
+    &ResolveOptions::default(),
+  )
+  .unwrap_err();
 
   assert!(matches!(error, ModuleError::CircularReference { .. }));
 }
@@ -312,10 +317,7 @@ fn a_malformed_directive_is_an_error_not_a_comment() {
 #[test]
 fn a_rule_carries_its_noncontiguous_extensions() {
   let mut source = MemoryModuleSource::new();
-  source.insert(
-    "ext",
-    "foo = int\nbar = baz\nbaz = tstr\nfoo /= tstr\n",
-  );
+  source.insert("ext", "foo = int\nbar = baz\nbaz = tstr\nfoo /= tstr\n");
 
   let output = resolve_modules(
     "start = foo\n;# include foo from ext\n",
@@ -349,7 +351,8 @@ fn a_later_import_sees_references_introduced_by_an_earlier_include() {
 
 #[test]
 fn a_rule_already_defined_locally_is_not_pulled_in() {
-  let output = resolve("label = tstr\nmydata = {* label => values}\n;# include label, values from rfc9052\n");
+  let output =
+    resolve("label = tstr\nmydata = {* label => values}\n;# include label, values from rfc9052\n");
 
   let defined = defined_order(&output);
   assert_eq!(defined.iter().filter(|d| *d == "label").count(), 1);

--- a/tests/modules.rs
+++ b/tests/modules.rs
@@ -269,6 +269,24 @@ fn circular_module_references_are_detected() {
 }
 
 #[test]
+fn a_module_that_is_not_basic_cddl_is_reported_against_the_module() {
+  let mut source = MemoryModuleSource::new();
+  source.insert("broken", "label = \n");
+
+  let error = resolve_modules(
+    "start = broken.label\n;# import broken\n",
+    &source,
+    &ResolveOptions::default(),
+  )
+  .unwrap_err();
+
+  match error {
+    ModuleError::ModuleParse { name, .. } => assert_eq!(name, "broken"),
+    other => panic!("expected a ModuleParse error, got {:?}", other),
+  }
+}
+
+#[test]
 fn a_missing_module_is_reported_with_its_line() {
   let error = resolve_modules(
     "start = int\n;# import nowhere\n",


### PR DESCRIPTION
Implements the CDDL module structure of [draft-ietf-cbor-cddl-modules-06](https://datatracker.ietf.org/doc/draft-ietf-cbor-cddl-modules/06/) behind a new **default-off `modules` feature**.

## Approach

Directives are carried in comments beginning with `;#`, so a module-structured document stays valid basic CDDL. Resolution is a **source-to-source transformation** into basic RFC 8610 CDDL, matching `cddlc -2tcddl` (Appendix B of the draft).

Two findings from reading the existing code shaped this:

* `cddl.pest:240` already admits `.` inside `id`, so namespaced names such as `cose.label` parse today — **no grammar change was needed**, and `cddl.pest` / `pest_bridge.rs` are untouched.
* `cddl_from_str<'a>(&'a str) -> CDDL<'a>` borrows its input, so a fused "parse with modules" entry point would have to be self-referential. The two-step `resolve_modules(...) -> String` then parse shape avoids that entirely.

Consequently this is almost all new code: the only shared files touched are `Cargo.toml`, `src/lib.rs` (one `pub mod`), `src/bin/cli.rs`, and `README.md`.

## What's implemented

| Draft section | Feature |
| --- | --- |
| §2.3, App. A | `;#` directive parsing against the Appendix A ABNF |
| §2.5 | `import` (referenced rules, transitively) and `include` (all rules) |
| §2.6 | `from` name selection, `*` wildcard, and the alias rule emitted for `import <name> from <mod> as <ns>` |
| §2.2, §2.5 | `as` namespacing, which never prefixes CDDL prelude names |
| §2.4 | Module lookup by filename along the colon-separated `CDDL_INCLUDE_PATH` (default `.:`) |
| §2.7 | CLI `resolve-modules` subcommand with the `-i` and `-s` shortcuts |

Module sources go through a `ModuleSource` trait, so the filesystem implementation stays behind `cfg(not(target_arch = "wasm32"))` and embedders on wasm can supply modules in memory via `MemoryModuleSource`.

## Verification

* `cargo test -p cddl --features modules` — all green, including 19 integration tests in `tests/modules.rs` derived from the draft's own examples (every worked example in §2.5–§2.7 is asserted, including exact emitted rule ordering).
* `cargo test --all` (default features, CI-exact) — green; no existing test changed.
* `cargo fmt --all -- --check`, `cargo clippy --all --features modules` — clean (the one clippy warning is pre-existing in `src/validator/cbor.rs`).
* `cargo check --lib --target wasm32-unknown-unknown --features modules` — clean.
* `cargo check -p cddl --lib --no-default-features --features modules,_build-parser --target thumbv7em-none-eabihf` — clean, so the `no_std` + `alloc` path holds.
* CLI smoke test reproduces the §2.7 output byte for byte.

## Reviewer notes

1. ~~**The tests are dark in CI.**~~ Resolved: `ci.yml` now carries a dedicated `cargo test --all --features modules` step, so the module tests run in CI.
2. **Scanner, not parser.** `src/modules/scan.rs` is a small structural scanner over CDDL text that recovers rule extents and identifier roles. It deliberately does not parse: resolution has to preserve the original formatting of imported rules, and a false-positive identifier is harmless because only names that actually resolve to module rules are ever selected.
3. **Two deliberate deviations from Appendix A**, both documented at the call site: `id` accepts `.` and `-` (the draft's own §2.6 examples use `cose.label`, which the ABNF's `id` production does not admit), and the filenames `.` and `..` are rejected as hardening even though the `filename` production admits them.
4. **Empty `CDDL_INCLUDE_PATH` elements** are accepted and skipped rather than resolving to `/`. §2.4 gives them the meaning "the processor's own collection"; this crate ships no bundled RFC collection.
5. Being an unratified draft, the feature is off by default and its output is explicitly not covered by semver.

A review pass caught two real defects before this was opened, both fixed in c280b4a: `/=` and `//=` extensions were dropped when not adjacent to the rule they extend, and the reference set was fixed at the original body so a later `import` could not see names an earlier `include` had introduced. Both now have regression tests.


Tracked by #711, which is in scope for 1.0 (#712 §2).


