### PR TITLE
docs: describe the current CDDL playground capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,17 @@ docker run -i --rm -v $PWD:/data -w /data ghcr.io/anweiss/cddl-cli:0.10.7 valida
 
 ## Website
 
-You can also find a simple RFC 8610 conformance tool at [https://cddl.anweiss.tech](https://cddl.anweiss.tech). This same codebase has been compiled for use in the browser via WebAssembly.
+A browser-based CDDL playground is available at [https://cddl.anweiss.tech](https://cddl.anweiss.tech), built on this same codebase compiled to WebAssembly. Beyond RFC 8610 conformance checking, it provides:
+
+* **Editing** — syntax highlighting, autocompletion over the rules defined in the current document plus the RFC 8610 Appendix D prelude and the supported control operators, formatting, find/replace and comment toggling.
+* **Diagnostics** — a Problems panel listing parser errors, and an optional check for references to undefined rules.
+* **Instance validation** — validate a JSON or CBOR instance against the schema, using a chosen root rule. CBOR can be pasted as hex or base64.
+* **Sample generation** — generate a sample JSON instance from the schema; samples are validated back against the schema before being shown.
+* **Outline** — a filterable list of the rules in the document, distinguishing types, groups and sockets/plugs.
+* **Files and sharing** — open and save `.cddl`, `.json` and `.cbor` files, including by drag-and-drop, and share the current schema and instance via a URL.
+* **Examples** — a built-in set covering basic types, arrays, choices, generics, sockets/plugs, constrained strings, tagged CBOR, occurrence indicators, JWT and COSE keys.
+
+Keyboard shortcuts are listed in-app under **Shortcuts**.
 
 ## Visual Studio Code extension
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ A browser-based CDDL playground is available at [https://cddl.anweiss.tech](http
 * **Editing** — syntax highlighting, autocompletion over the rules defined in the current document plus the RFC 8610 Appendix D prelude and the supported control operators, formatting, find/replace and comment toggling.
 * **Diagnostics** — a Problems panel listing parser errors, and an optional check for references to undefined rules.
 * **Instance validation** — validate a JSON or CBOR instance against the schema, using a chosen root rule. CBOR can be pasted as hex or base64.
-* **Sample generation** — generate a sample JSON instance from the schema; samples are validated back against the schema before being shown.
+* **Sample generation** — generate a sample JSON instance from the schema; when the WebAssembly validator is available, samples are validated back against the schema and any that do not conform are flagged.
 * **Outline** — a filterable list of the rules in the document, distinguishing types, groups and sockets/plugs.
 * **Files and sharing** — open and save `.cddl`, `.json` and `.cbor` files, including by drag-and-drop, and share the current schema and instance via a URL.
 * **Examples** — a built-in set covering basic types, arrays, choices, generics, sockets/plugs, constrained strings, tagged CBOR, occurrence indicators, JWT and COSE keys.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,8 +140,9 @@
 //! * **Instance validation** — validate a JSON or CBOR instance against the
 //!   schema, using a chosen root rule. CBOR can be pasted as hex or base64.
 //! * **Sample generation** — generate a sample JSON instance from the
-//!   schema; samples are validated back against the schema before being
-//!   shown.
+//!   schema; when the WebAssembly validator is available, samples are
+//!   validated back against the schema and any that do not conform are
+//!   flagged.
 //! * **Outline** — a filterable list of the rules in the document,
 //!   distinguishing types, groups and sockets/plugs.
 //! * **Files and sharing** — open and save `.cddl`, `.json` and `.cbor`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,9 +126,32 @@
 //!
 //! ## Website
 //!
-//! You can also find a simple RFC 8610 conformance tool at
-//! [https://cddl.anweiss.tech](https://cddl.anweiss.tech). This same codebase
-//! has been compiled for use in the browser via WebAssembly.
+//! A browser-based CDDL playground is available at
+//! [https://cddl.anweiss.tech](https://cddl.anweiss.tech), built on this
+//! same codebase compiled to WebAssembly. Beyond RFC 8610 conformance
+//! checking, it provides:
+//!
+//! * **Editing** — syntax highlighting, autocompletion over the rules
+//!   defined in the current document plus the RFC 8610 Appendix D prelude and
+//!   the supported control operators, formatting, find/replace and comment
+//!   toggling.
+//! * **Diagnostics** — a Problems panel listing parser errors, and an
+//!   optional check for references to undefined rules.
+//! * **Instance validation** — validate a JSON or CBOR instance against the
+//!   schema, using a chosen root rule. CBOR can be pasted as hex or base64.
+//! * **Sample generation** — generate a sample JSON instance from the
+//!   schema; samples are validated back against the schema before being
+//!   shown.
+//! * **Outline** — a filterable list of the rules in the document,
+//!   distinguishing types, groups and sockets/plugs.
+//! * **Files and sharing** — open and save `.cddl`, `.json` and `.cbor`
+//!   files, including by drag-and-drop, and share the current schema and
+//!   instance via a URL.
+//! * **Examples** — a built-in set covering basic types, arrays, choices,
+//!   generics, sockets/plugs, constrained strings, tagged CBOR, occurrence
+//!   indicators, JWT and COSE keys.
+//!
+//! Keyboard shortcuts are listed in-app under **Shortcuts**.
 //!
 //! ## Visual Studio Code extension
 //!


### PR DESCRIPTION
The **Website** section still described [cddl.anweiss.tech](https://cddl.anweiss.tech) as "a simple RFC 8610 conformance tool". That predates #700, #704 and #705, which added instance validation, sample generation, outline, file I/O, sharing and autocomplete, so the docs undersell the playground considerably.

Replaced with a short capability list covering editing, diagnostics, instance validation, sample generation, outline, files/sharing and the bundled examples.

Every item was verified against `www/` rather than inferred — `www/index.html` for the UI surface and `www/src/{cddl-completion,instance-validation,sample-gen,outline,file-io,share,shortcuts}.js` for behavior. Two details worth calling out because they are easy to get wrong: CBOR instances accept **hex or base64**, and generated samples are **validated back against the schema** before being displayed.

Applied to the two sources of truth:

- `README.md` — also what `Cargo.toml`'s `readme` key ships to crates.io
- `src/lib.rs` — the crate-level docs, which mirror the README by hand

`cddl-languageserver/README.md` carries the same paragraph but is deliberately **not** touched: that whole directory is a `wasm-pack build --out-dir cddl-languageserver` artifact and is gitignored, so it is regenerated from `README.md` at publish time.

Verified with `cargo doc --no-deps --lib`. Docs only — no code changes.