### PR TITLE
fix: add cfg attribute to CDDL::validate_json and CDDL::validate_cbor

### DIFF
--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -271,6 +271,7 @@ impl<'a> ValidationState<'a> {
 }
 
 impl CDDL<'_> {
+  #[cfg(feature = "json")]
   /// Validate the given document against the CDDL definition
   fn validate_json(
     &self,
@@ -293,6 +294,7 @@ impl CDDL<'_> {
     jv.validate().map_err(|e| e.into())
   }
 
+  #[cfg(feature = "cbor")]
   fn validate_cbor(
     &self,
     document: &[u8],


### PR DESCRIPTION
This PR fixes library build failure unless `json` and `cbor` features are enabled